### PR TITLE
Initial mctp baremetal implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,27 @@ dependencies = [
  "embedded-hal 0.2.7",
  "volatile-register",
 ]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "embedded-crc-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1c75747a43b086df1a87fb2a889590bc0725e0abf54bba6d0c4bf7bd9e762c"
 
 [[package]]
 name = "embedded-hal"
@@ -62,6 +89,57 @@ checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
 dependencies = [
  "embedded-hal 1.0.0",
  "nb 1.1.0",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mctp"
+version = "0.2.0"
+source = "git+https://github.com/9elements/mctp-rs.git?branch=embassy-feature#c632a6737ccbfbbe1d8382e40d2c2b9b90634f20"
+
+[[package]]
+name = "mctp-baremetal"
+version = "0.1.0"
+dependencies = [
+ "mctp",
+ "mctp-estack",
+]
+
+[[package]]
+name = "mctp-estack"
+version = "0.1.0"
+source = "git+https://github.com/9elements/mctp-rs.git?branch=embassy-feature#c632a6737ccbfbbe1d8382e40d2c2b9b90634f20"
+dependencies = [
+ "crc",
+ "heapless",
+ "log",
+ "mctp",
+ "smbus-pec",
+ "uuid",
 ]
 
 [[package]]
@@ -200,6 +278,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "smbus-pec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0763a680cd5d72b28f7bfc8a054c117d8841380a6ad4f72f05bd2a34217d3e"
+dependencies = [
+ "embedded-crc-macros",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +308,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 
 [[package]]
 name = "vcell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "platform/impls/hubris",
     "services/telemetry",
     "services/storage",
+    "platform/impls/baremetal/mctp",
 ]
 resolver = "2"
 

--- a/platform/impls/baremetal/mctp/Cargo.toml
+++ b/platform/impls/baremetal/mctp/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mctp-baremetal"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mctp-estack = { git = "https://github.com/9elements/mctp-rs.git", branch = "embassy-feature", default-features = false, features = ["log"] }
+mctp = { git = "https://github.com/9elements/mctp-rs.git", branch = "embassy-feature", default-features = false }

--- a/platform/impls/baremetal/mctp/src/lib.rs
+++ b/platform/impls/baremetal/mctp/src/lib.rs
@@ -206,9 +206,17 @@ impl Router {
                 .ok_or(Error::BadArgument)?;
             Ok(())
         } else {
-            self.requests[requests_index_from_cookie(cookie).ok_or(Error::BadArgument)?]
-                .take()
-                .ok_or(Error::BadArgument)?;
+            let req = self.requests
+                [requests_index_from_cookie(cookie).ok_or(Error::BadArgument)?]
+            .take()
+            .ok_or(Error::BadArgument)?;
+            if let ReqHandle {
+                eid,
+                last_tag: Some(tag),
+            } = req
+            {
+                self.stack.cancel_flow(eid, tag.tag());
+            }
             Ok(())
         }
     }

--- a/platform/impls/baremetal/mctp/src/lib.rs
+++ b/platform/impls/baremetal/mctp/src/lib.rs
@@ -1,0 +1,303 @@
+#![no_std]
+use mctp::{Eid, Error, MsgIC, MsgType, Result, Tag};
+use mctp_estack::{Stack, fragment};
+
+pub use mctp_estack::AppCookie;
+
+pub const MAX_LISTENER_HANDLES: usize = 64;
+pub const MAX_REQUEST_HANDLES: usize = 64;
+
+#[derive(Debug)]
+struct ReqHandle {
+    /// Destination EID
+    eid: Eid,
+    /// Tag from last send
+    ///
+    /// Has to be cleared upon receiving a response.
+    // A no-expire option might be added as a future improvement.
+    last_tag: Option<Tag>,
+}
+impl ReqHandle {
+    fn new(eid: Eid) -> ReqHandle {
+        ReqHandle {
+            eid,
+            last_tag: None,
+        }
+    }
+}
+
+/// A platform agnostic MCTP stack with routing
+#[derive(Debug)]
+pub struct Router {
+    stack: Stack,
+    /// listener handles
+    ///
+    /// The index is used to construct the AppCookie.
+    // TODO: A map with MsgType as key might be better.
+    listeners: [Option<MsgType>; MAX_LISTENER_HANDLES],
+    /// request handles
+    ///
+    /// The index is used to construct the AppCookie.
+    requests: [Option<ReqHandle>; MAX_REQUEST_HANDLES],
+}
+
+impl Router {
+    pub fn new<O>(own_eid: Eid, now_millis: u64, outbound: O) -> Self
+    where
+        O: FnMut(&[u8]),
+    {
+        // TODO: Outbound handler and lookup (a Trait might be a better fit)
+        let stack = Stack::new(own_eid, now_millis);
+        Router {
+            stack,
+            listeners: [None; MAX_LISTENER_HANDLES],
+            requests: [const { None }; MAX_REQUEST_HANDLES],
+        }
+    }
+
+    /// update the stack, returning after how many milliseconds update has to be called again
+    pub fn update(&mut self, now_millis: u64) -> Result<u32> {
+        // TODO: Handle timeouts
+        self.stack.update(now_millis).map(|x| x.0 as u32)
+    }
+
+    /// Provide an incoming packet to the router.
+    ///
+    /// This expects a single MCTP packet, without transport binding header.
+    pub fn inbound(&mut self, pkt: &[u8]) -> Result<()> {
+        let own_eid = self.stack.eid();
+        let Some(mut msg) = self.stack.receive(pkt)? else {
+            return Ok(());
+        };
+
+        if msg.dest != own_eid {
+            // Drop messages if eid does not match (for now)
+            return Ok(());
+        }
+
+        match msg.tag {
+            Tag::Unowned(_) => {
+                // check for matching requests
+                if let Some(cookie) = msg.cookie() {
+                    if requests_index_from_cookie(cookie)
+                        .is_some_and(|i| self.requests[i].is_some())
+                    {
+                        msg.retain();
+                        return Ok(());
+                    }
+                }
+                // In this case an unowned message that isn't associated to a request was received.
+                // This might happen, if if this endpoint was inteded to route the packet to a different
+                // bus it is connected to (bridge configuration).
+                // Support for this is missing right now.
+            }
+            Tag::Owned(_) => {
+                // check for matching listeners and retain with cookie
+                for i in 0..self.listeners.len() {
+                    if self.listeners[i] == Some(msg.typ) {
+                        msg.set_cookie(Some(listener_cookie_from_index(i)));
+                        msg.retain();
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Return Ok(()) even if a message has been discarded
+        Ok(())
+    }
+
+    /// Allocate a new request "_Handle_"
+    pub fn req(&mut self, eid: Eid) -> Result<AppCookie> {
+        for (index, handle) in self.requests.iter_mut().enumerate() {
+            if handle.is_none() {
+                let _ = handle.insert(ReqHandle::new(eid));
+                return Ok(req_cookie_from_index(index));
+            }
+        }
+        Err(mctp::Error::NoSpace)
+    }
+
+    /// Allocate a new listener for [`typ`](MsgType)
+    pub fn listener(&mut self, typ: MsgType) -> Result<AppCookie> {
+        if self.listeners.iter().any(|x| x == &Some(typ)) {
+            return Err(mctp::Error::AddrInUse);
+        }
+        for (index, handle) in self.listeners.iter_mut().enumerate() {
+            if handle.is_none() {
+                let _ = handle.insert(typ);
+                return Ok(listener_cookie_from_index(index));
+            }
+        }
+        Err(mctp::Error::NoSpace)
+    }
+
+    /// Get the currently configured _Eid_ for this endpoint
+    pub fn get_eid(&self) -> Eid {
+        self.stack.eid()
+    }
+
+    /// Set the _Eid_ for this endpoint
+    pub fn set_eid(&mut self, eid: Eid) -> Result<()> {
+        self.stack.set_eid(eid.0)
+    }
+
+    pub fn send(
+        &mut self,
+        eid: Eid,
+        typ: MsgType,
+        tag: Option<Tag>,
+        ic: MsgIC,
+        cookie: AppCookie,
+        bufs: &[&[u8]],
+    ) -> Result<Tag> {
+        const MTU: usize = 64;
+        // TODO: mtu (and port) lookup
+        let mut frag = self
+            .stack
+            .start_send(eid, typ, tag, true, ic, None, Some(cookie))?;
+
+        let mut local_buffer = [0; mctp_estack::config::MAX_PAYLOAD];
+
+        let payload = if bufs.len() == 1 {
+            bufs[0]
+        } else {
+            let total_len = bufs.iter().fold(0, |acc, x| acc + x.len());
+            if total_len > mctp_estack::config::MAX_PAYLOAD {
+                return Err(Error::NoSpace);
+            }
+            let mut start = 0;
+            for p in bufs {
+                local_buffer[start..p.len()].copy_from_slice(p);
+                start += p.len();
+            }
+            &local_buffer[..total_len]
+        };
+        // TODO: this seems unnecessary,
+        // the fragmenter should iterate over the bufs requiring only a single packet buffer.
+
+        loop {
+            let mut pkt_buf = [0; MTU];
+            match frag.fragment(payload, &mut pkt_buf) {
+                fragment::SendOutput::Packet(items) => {
+                    todo!("send data over the provided outgoing port")
+                }
+                fragment::SendOutput::Complete { tag, cookie: _ } => return Ok(tag),
+                fragment::SendOutput::Error { err, cookie: _ } => return Err(err),
+            }
+        }
+    }
+
+    /// Receive a message associated with a [`AppCookie`]
+    ///
+    /// Returns `None` when no message is available for the listener/request.
+    pub fn recv(&mut self, cookie: AppCookie) -> Option<mctp_estack::MctpMessage<'_>> {
+        self.stack.get_deferred_bycookie(&[cookie])
+    }
+
+    /// Unbind a listener/request
+    ///
+    /// This has to be called to free the request/listener slot.
+    /// Returns [BadArgument](Error::BadArgument) for cookies that are malformed or non existent.
+    pub fn unbind(&mut self, cookie: AppCookie) -> Result<()> {
+        if cookie_is_listener(&cookie) {
+            self.listeners[listeners_index_from_cookie(cookie).ok_or(Error::BadArgument)?]
+                .take()
+                .ok_or(Error::BadArgument)?;
+            Ok(())
+        } else {
+            self.requests[requests_index_from_cookie(cookie).ok_or(Error::BadArgument)?]
+                .take()
+                .ok_or(Error::BadArgument)?;
+            Ok(())
+        }
+    }
+}
+
+/// Function to create a router unique AppCookie for listeners
+///
+/// Currently the listeners are just the index ranging from 0 to LISTENER_HANDLES-1.
+/// Requests are enumerated from LISTENER_HANDLES to LISTENER_HANDLES+REQUEST_HANDLES-1
+fn listener_cookie_from_index(i: usize) -> AppCookie {
+    debug_assert!(
+        i < MAX_LISTENER_HANDLES,
+        "tried to create out of range listener AppCookie!"
+    );
+    AppCookie(i)
+}
+
+/// Function to create a router unique AppCookie for requests
+///
+/// Currently the listeners are just the index ranging from 0 to LISTENER_HANDLES-1.
+/// Requests are enumerated from LISTENER_HANDLES to LISTENER_HANDLES+REQUEST_HANDLES-1
+fn req_cookie_from_index(i: usize) -> AppCookie {
+    debug_assert!(
+        i < MAX_REQUEST_HANDLES,
+        "tried to create out of range request AppCookie!"
+    );
+    AppCookie(i + MAX_LISTENER_HANDLES)
+}
+
+/// Get the listeners array index from a AppCookie
+///
+/// Returns `None` for invalid cookies.
+fn listeners_index_from_cookie(cookie: AppCookie) -> Option<usize> {
+    if cookie.0 < MAX_LISTENER_HANDLES {
+        Some(cookie.0)
+    } else {
+        None
+    }
+}
+
+/// Get the requesters array index from a AppCookie
+///
+/// Returns `None` for invalid cookies.
+fn requests_index_from_cookie(cookie: AppCookie) -> Option<usize> {
+    if cookie.0 >= MAX_LISTENER_HANDLES && cookie.0 < (MAX_LISTENER_HANDLES + MAX_REQUEST_HANDLES) {
+        Some(cookie.0 - MAX_LISTENER_HANDLES)
+    } else {
+        None
+    }
+}
+
+/// Check if a cookie is a corresponding to a listener
+///
+/// Checks based on the contained id.
+/// Returns false for request cookies.
+fn cookie_is_listener(cookie: &AppCookie) -> bool {
+    cookie.0 < MAX_LISTENER_HANDLES
+}
+
+#[cfg(test)]
+mod test {
+    use mctp::Eid;
+
+    use crate::Router;
+
+    /// Test the creation of request and listener handles (`AppCookies`)
+    #[test]
+    fn test_handle_creation() {
+        let mut router = Router::new(Eid(42), 0, |_| {});
+
+        // create a new listener and expect the cookie value to be 0 (raw index of the underlying table)
+        let listener = router.listener(mctp::MsgType(0));
+        assert!(listener.is_ok());
+        assert!(listener.as_ref().is_ok_and(|x| x.0 == 0));
+
+        // create a new request
+        // we expect the value to be MAX_LISTENER_HANDLES (request table index 0 + offset)
+        let req = router.req(Eid(112));
+        assert!(req.is_ok());
+        assert!(
+            req.as_ref()
+                .is_ok_and(|x| x.0 == crate::MAX_LISTENER_HANDLES)
+        );
+
+        router
+            .unbind(listener.unwrap())
+            .expect("failed to unbind listener handle");
+        router
+            .unbind(req.unwrap())
+            .expect("failed to unbind request handle");
+    }
+}

--- a/platform/impls/baremetal/mctp/src/lib.rs
+++ b/platform/impls/baremetal/mctp/src/lib.rs
@@ -60,9 +60,9 @@ impl<S: Sender> Router<S> {
     }
 
     /// update the stack, returning after how many milliseconds update has to be called again
-    pub fn update(&mut self, now_millis: u64) -> Result<u32> {
+    pub fn update(&mut self, now_millis: u64) -> Result<u64> {
         // TODO: Handle timeouts
-        self.stack.update(now_millis).map(|x| x.0 as u32)
+        self.stack.update(now_millis).map(|x| x.0)
     }
 
     /// Provide an incoming packet to the router.


### PR DESCRIPTION
Implementation of a baremetal mctp router that uses the available types from [mctp-estack]().

The router currently only supports a single transport binding (so no real routing/bridge functionality).
The `mctp-rs` blocking traits for requests and listeners are not implemented right now since that is difficult without any runtime.