### PR TITLE
feat(hal): Add comprehensive ECDSA traits with curve markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cortex-m"
@@ -27,6 +60,94 @@ dependencies = [
  "bitfield",
  "embedded-hal 0.2.7",
  "volatile-register",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -65,6 +186,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-storage"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +286,8 @@ name = "openprot-hal-blocking"
 version = "0.1.0"
 dependencies = [
  "embedded-hal 1.0.0",
+ "rand_core",
+ "sha2",
  "subtle",
  "zerocopy",
  "zeroize",
@@ -141,6 +334,19 @@ dependencies = [
 [[package]]
 name = "openprot-platform-traits"
 version = "0.1.0"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "embedded-hal 1.0.0",
+ "embedded-io",
+ "embedded-storage",
+ "p256",
+ "rand",
+ "rand_core",
+ "sha2",
+ "signature",
+ "zeroize",
+]
 
 [[package]]
 name = "openprot-services-storage"
@@ -149,6 +355,55 @@ version = "0.1.0"
 [[package]]
 name = "openprot-services-telemetry"
 version = "0.1.0"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -166,6 +421,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -187,6 +482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +509,37 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "subtle"
@@ -219,6 +559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +575,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -254,6 +606,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "winapi-util"

--- a/hal/blocking/Cargo.toml
+++ b/hal/blocking/Cargo.toml
@@ -12,3 +12,4 @@ embedded-hal = "1.0"
 zerocopy = { workspace = true }
 zeroize = { workspace = true }
 subtle = { workspace = true }
+rand_core = "0.6"

--- a/hal/blocking/src/ecdsa.rs
+++ b/hal/blocking/src/ecdsa.rs
@@ -1,0 +1,875 @@
+// Licensed under the Apache-2.0 license
+
+//! # ECDSA Digital Signature Operations
+//!
+//! This module provides a comprehensive, type-safe abstraction for Elliptic Curve Digital 
+//! Signature Algorithm (ECDSA) operations. The design follows security best practices and 
+//! provides a generic interface that can work with any elliptic curve.
+//!
+//! ## Features
+//!
+//! - **Type Safety**: Generic over curve types to prevent cross-curve contamination
+//! - **Security First**: Mandatory cryptographic RNG, proper key validation, secure memory clearing
+//! - **No-std Compatible**: Works in embedded environments without standard library
+//! - **Comprehensive Error Handling**: Detailed error types for proper debugging and security
+//! - **Zero-copy Serialization**: Efficient serialization using `zerocopy` traits
+//!
+//! ## Architecture
+//!
+//! The module follows a trait-based design with the following key components:
+//!
+//! ```text
+//! Curve (Abstract EC Parameters) 
+//! ├── DigestType: DigestAlgorithm
+//! └── Scalar: IntoBytes + FromBytes
+//!
+//! Key Management
+//! ├── PrivateKey<C>: Zeroize + Serialization + Validation
+//! └── PublicKey<C>: Serialization + Coordinate Access + Validation
+//!
+//! Signatures
+//! └── Signature<C>: Serialization + Component Access + Validation
+//!
+//! Operations
+//! ├── EcdsaKeyGen<C>: Key pair generation
+//! ├── EcdsaSign<C>: Digital signing with RNG
+//! └── EcdsaVerify<C>: Signature verification
+//!
+//! Error Handling
+//! ├── Error: Debug → ErrorKind mapping
+//! ├── ErrorType: Associated error types
+//! └── ErrorKind: Common error classifications
+//! ```
+//!
+//! ## Usage Example
+//!
+//! ```rust,no_run
+//! # use openprot_hal_blocking::ecdsa::*;
+//! # use rand_core::{RngCore, CryptoRng};
+//! # 
+//! # // Mock types for example
+//! # struct MockCurve;
+//! # impl Curve for MockCurve {
+//! #     type DigestType = ();
+//! #     type Scalar = [u8; 32];
+//! # }
+//! # struct MockKeyGen;
+//! # impl ErrorType for MockKeyGen { type Error = core::convert::Infallible; }
+//! # impl EcdsaKeyGen<MockCurve> for MockKeyGen {
+//! #     type PrivateKey = MockPrivateKey;
+//! #     type PublicKey = MockPublicKey;
+//! #     fn generate_keypair<R>(&mut self, rng: &mut R) -> Result<(Self::PrivateKey, Self::PublicKey), Self::Error> 
+//! #     where R: RngCore + CryptoRng { unimplemented!() }
+//! # }
+//! #
+//! // Key generation
+//! let mut key_generator = MockKeyGen;
+//! let mut rng = /* your crypto RNG */;
+//! let (private_key, public_key) = key_generator.generate_keypair(&mut rng)?;
+//!
+//! // Validate keys before use
+//! private_key.validate()?;
+//! public_key.validate()?;
+//!
+//! // Sign a message
+//! let mut signer = /* your signer implementation */;
+//! let message_digest = /* hash of your message */;
+//! let signature = signer.sign(&private_key, &message_digest, &mut rng)?;
+//!
+//! // Verify signature
+//! let mut verifier = /* your verifier implementation */;
+//! let is_valid = verifier.verify(&public_key, &message_digest, &signature)?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ## Security Considerations
+//!
+//! - **Always validate inputs**: Use the `validate()` methods on keys and signatures
+//! - **Use cryptographic RNG**: Only `CryptoRng + RngCore` is accepted for signing
+//! - **Clear sensitive data**: Private keys implement `Zeroize` for secure memory clearing
+//! - **Constant-time operations**: Implementers should use constant-time algorithms where possible
+//! - **Side-channel protection**: Be aware of timing attacks in verification operations
+
+use crate::digest::DigestAlgorithm;
+use core::fmt::Debug;
+use zerocopy::{FromBytes, IntoBytes};
+use zeroize::Zeroize;
+
+/// Trait for converting implementation-specific ECDSA errors into generic error kinds.
+///
+/// This trait allows HAL implementations to define their own detailed error types
+/// while still providing a common interface for generic code to handle errors.
+///
+/// # Example
+///
+/// ```rust
+/// # use openprot_hal_blocking::ecdsa::{Error, ErrorKind};
+/// #[derive(Debug)]
+/// enum MyEcdsaError {
+///     HardwareFault,
+///     InvalidParameters,
+///     Timeout,
+/// }
+///
+/// impl Error for MyEcdsaError {
+///     fn kind(&self) -> ErrorKind {
+///         match self {
+///             MyEcdsaError::HardwareFault => ErrorKind::Other,
+///             MyEcdsaError::InvalidParameters => ErrorKind::InvalidKeyFormat,
+///             MyEcdsaError::Timeout => ErrorKind::Busy,
+///         }
+///     }
+/// }
+/// ```
+pub trait Error: core::fmt::Debug {
+    /// Convert error to a generic error kind
+    ///
+    /// By using this method, errors freely defined by HAL implementations
+    /// can be converted to a set of generic errors upon which generic
+    /// code can act.
+    fn kind(&self) -> ErrorKind;
+}
+
+impl Error for core::convert::Infallible {
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}
+
+/// Trait for associating a type with an ECDSA error type.
+///
+/// This trait is used throughout the ECDSA module to associate operations
+/// with their specific error types while maintaining type safety.
+///
+/// # Example
+///
+/// ```rust
+/// # use openprot_hal_blocking::ecdsa::{ErrorType, Error, ErrorKind};
+/// # #[derive(Debug)]
+/// # enum MyError { Failed }
+/// # impl Error for MyError {
+/// #     fn kind(&self) -> ErrorKind { ErrorKind::Other }
+/// # }
+/// struct MyEcdsaDevice;
+///
+/// impl ErrorType for MyEcdsaDevice {
+///     type Error = MyError;
+/// }
+/// ```
+pub trait ErrorType {
+    /// Error type.
+    type Error: Error;
+}
+
+/// Error kind for ECDSA operations.
+///
+/// This represents a common set of ECDSA operation errors that can occur across
+/// different implementations. The enum is `#[non_exhaustive]` to allow for future
+/// additions without breaking API compatibility.
+///
+/// Implementations are free to define more specific or additional error types. 
+/// However, by providing a mapping to these common errors through the [`Error::kind`]
+/// method, generic code can still react to them appropriately.
+///
+/// # Security Note
+///
+/// Error types should not leak sensitive information. For example, avoid
+/// distinguishing between "key not found" and "wrong key" errors, as this
+/// could provide timing attack vectors.
+///
+/// # Examples
+///
+/// ```rust
+/// # use openprot_hal_blocking::ecdsa::ErrorKind;
+/// match error_kind {
+///     ErrorKind::InvalidSignature => {
+///         // Handle signature verification failure
+///         log::warn!("Signature verification failed");
+///     }
+///     ErrorKind::WeakKey => {
+///         // Handle weak key detection
+///         log::error!("Weak key detected - regenerate keypair");
+///     }
+///     ErrorKind::Busy => {
+///         // Handle resource busy - retry later
+///         tokio::time::sleep(Duration::from_millis(10)).await;
+///     }
+///     _ => {
+///         // Handle other errors
+///         log::error!("ECDSA operation failed: {:?}", error_kind);
+///     }
+/// }
+/// ```
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// The operation is busy and cannot be completed
+    ///
+    /// This indicates that the hardware or implementation is currently
+    /// busy with another operation. The caller should retry later.
+    Busy,
+    
+    /// The signature is invalid
+    ///
+    /// Returned when signature verification fails. This could indicate:
+    /// - The signature was corrupted during transmission
+    /// - The signature was created with a different key
+    /// - The message was modified after signing
+    /// - The signature components (r, s) are invalid
+    InvalidSignature,
+    
+    /// Key generation failed
+    ///
+    /// Indicates that the key generation process could not complete successfully.
+    /// This might be due to insufficient entropy, hardware failures, or other
+    /// random number generation issues.
+    KeyGenError,
+    
+    /// Signing operation failed
+    ///
+    /// The signing process encountered an error. This is distinct from key
+    /// generation errors and typically indicates issues during the actual
+    /// signing computation.
+    SigningError,
+    
+    /// Invalid key format or encoding
+    ///
+    /// The provided key data could not be parsed or is in an unsupported format.
+    /// This includes issues with:
+    /// - Incorrect key length
+    /// - Invalid encoding (DER, PEM, etc.)
+    /// - Malformed key structure
+    InvalidKeyFormat,
+    
+    /// Point is not on the curve
+    ///
+    /// The provided coordinates do not represent a valid point on the specified
+    /// elliptic curve. This is a critical security check that prevents attacks
+    /// using invalid curve points.
+    InvalidPoint,
+    
+    /// Unsupported curve or algorithm
+    ///
+    /// The requested elliptic curve or algorithm parameters are not supported
+    /// by this implementation. Common reasons include:
+    /// - Curve not implemented in hardware
+    /// - Disabled curve due to security concerns
+    /// - Incompatible curve parameters
+    UnsupportedCurve,
+    
+    /// Weak key detected (e.g., zero key, key equal to curve order)
+    ///
+    /// The key fails cryptographic strength requirements. This includes:
+    /// - Zero private keys
+    /// - Private keys equal to the curve order
+    /// - Public keys at the identity point
+    /// - Other mathematically weak keys
+    WeakKey,
+    
+    /// Other unspecified error
+    ///
+    /// A catch-all for errors that don't fit into the specific categories above.
+    /// Implementations should prefer specific error types when possible.
+    Other,
+}
+
+/// Trait for ECC private keys associated with a specific curve.
+///
+/// Private keys must implement secure memory clearing through the [`Zeroize`] trait
+/// to ensure cryptographic material is properly destroyed when no longer needed.
+///
+/// # Security Requirements
+///
+/// Implementations must:
+/// - Validate keys are within the valid scalar range (1 < key < curve_order)
+/// - Implement constant-time operations where possible
+/// - Clear sensitive data from memory using [`Zeroize`]
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{PrivateKey, Curve, ErrorKind};
+/// use zeroize::Zeroize;
+///
+/// struct MyPrivateKey([u8; 32]);
+///
+/// impl<C: Curve> PrivateKey<C> for MyPrivateKey {
+///     fn validate(&self) -> Result<(), ErrorKind> {
+///         // Check if key is zero or equal to curve order
+///         if self.0.iter().all(|&b| b == 0) {
+///             return Err(ErrorKind::WeakKey);
+///         }
+///         Ok(())
+///     }
+/// }
+/// ```
+pub trait PrivateKey<C: Curve>: IntoBytes + FromBytes + Zeroize {
+    /// Validate that this private key is valid for the curve.
+    ///
+    /// This method should verify that the private key is within the valid
+    /// range for the curve (typically 1 < key < curve_order).
+    ///
+    /// # Returns
+    /// - `Ok(())`: The private key is valid
+    /// - `Err(ErrorKind::WeakKey)`: The key is zero, equal to curve order, or otherwise weak
+    /// - `Err(ErrorKind::InvalidKeyFormat)`: The key format is invalid
+    fn validate(&self) -> Result<(), ErrorKind>;
+}
+
+/// A trait representing an abstract elliptic curve with associated types for cryptographic operations.
+///
+/// This trait defines the fundamental components required for elliptic curve cryptography,
+/// including the digest algorithm for hashing operations and the scalar field element type
+/// for curve arithmetic.
+///
+/// # Associated Types
+///
+/// - [`DigestType`]: The hash function used for message digests in signing operations
+/// - [`Scalar`]: The field element type representing curve coordinates and private keys
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{Curve, DigestAlgorithm};
+/// use openprot_hal_blocking::digest::Sha256;
+///
+/// struct P256;
+///
+/// impl Curve for P256 {
+///     type DigestType = Sha256;
+///     type Scalar = [u8; 32];
+/// }
+/// ```
+///
+/// [`DigestType`]: Curve::DigestType
+/// [`Scalar`]: Curve::Scalar
+pub trait Curve {
+    /// The digest algorithm used by this elliptic curve for cryptographic operations.
+    type DigestType: DigestAlgorithm;
+    /// The scalar field element type used in elliptic curve operations.
+    type Scalar: IntoBytes + FromBytes;
+}
+
+/// Trait for ECDSA signatures associated with a specific curve.
+///
+/// This trait provides access to signature components and validation methods
+/// for ECDSA signatures over elliptic curves.
+///
+/// # Security Considerations
+///
+/// - Signature components (r, s) must be in the range [1, curve_order)
+/// - Zero values for r or s make the signature invalid
+/// - Implementations should validate signatures before use
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{Signature, Curve, ErrorKind};
+///
+/// struct MySignature {
+///     r: [u8; 32],
+///     s: [u8; 32],
+/// }
+///
+/// impl<C: Curve> Signature<C> for MySignature {
+///     fn r(&self) -> &C::Scalar {
+///         // Return reference to r component
+///         unimplemented!()
+///     }
+///
+///     fn s(&self) -> &C::Scalar {
+///         // Return reference to s component  
+///         unimplemented!()
+///     }
+///
+///     fn from_components(r: C::Scalar, s: C::Scalar) -> Result<Self, ErrorKind> {
+///         // Validate components and create signature
+///         unimplemented!()
+///     }
+///
+///     fn new_unchecked(r: C::Scalar, s: C::Scalar) -> Self {
+///         // Create signature without validation (use with caution)
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait Signature<C: Curve>: IntoBytes + FromBytes {
+    /// Get the r component of the signature.
+    fn r(&self) -> &C::Scalar;
+    /// Get the s component of the signature.
+    fn s(&self) -> &C::Scalar;
+
+    /// Create a new signature from r and s components with validation.
+    ///
+    /// This method validates that both r and s are within the valid range
+    /// for the curve (typically 1 ≤ r,s < curve_order).
+    ///
+    /// # Parameters
+    /// - `r`: The r component of the signature
+    /// - `s`: The s component of the signature
+    ///
+    /// # Returns
+    /// - `Ok(Self)`: Valid signature
+    /// - `Err(ErrorKind::InvalidSignature)`: If r or s are invalid (zero or ≥ curve order)
+    fn from_components(r: C::Scalar, s: C::Scalar) -> Result<Self, ErrorKind>
+    where
+        Self: Sized;
+
+    /// Validate that this signature has valid r and s components.
+    ///
+    /// # Returns
+    /// - `Ok(())`: The signature components are valid
+    /// - `Err(ErrorKind::InvalidSignature)`: Invalid r or s component
+    fn validate(&self) -> Result<(), ErrorKind>;
+
+    /// Create a new signature from r and s components without validation.
+    ///
+    /// # Safety
+    /// This method should only be used when the caller can guarantee that
+    /// r and s are valid for the curve. Use `from_components` for safe
+    /// construction with validation.
+    fn new_unchecked(r: C::Scalar, s: C::Scalar) -> Self;
+}
+
+/// A trait representing a public key associated with a specific elliptic curve.
+/// Trait for ECC public keys associated with a specific curve.
+///
+/// Public keys represent points on elliptic curves and are used for signature verification.
+/// This trait provides coordinate access and validation methods to ensure keys represent
+/// valid curve points.
+///
+/// # Security Considerations
+///
+/// - Points must lie on the specified elliptic curve
+/// - The identity element (point at infinity) is typically invalid for cryptographic use
+/// - Always validate public keys before using them for verification
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{PublicKey, Curve, ErrorKind};
+///
+/// struct MyPublicKey {
+///     x: [u8; 32],
+///     y: [u8; 32],
+/// }
+///
+/// impl<C: Curve> PublicKey<C> for MyPublicKey {
+///     fn x(&self) -> &C::Scalar {
+///         // Return reference to x coordinate
+///         unimplemented!()
+///     }
+///
+///     fn y(&self) -> &C::Scalar {
+///         // Return reference to y coordinate
+///         unimplemented!()
+///     }
+///
+///     fn from_coordinates(x: C::Scalar, y: C::Scalar) -> Result<Self, ErrorKind> {
+///         // Validate point is on curve and create public key
+///         unimplemented!()
+///     }
+///
+///     fn validate(&self) -> Result<(), ErrorKind> {
+///         // Check if point lies on the curve
+///         unimplemented!()
+///     }
+///
+///     fn new_unchecked(x: C::Scalar, y: C::Scalar) -> Self {
+///         // Create key without validation (use with caution)
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait PublicKey<C: Curve>: IntoBytes + FromBytes {
+    /// Get the x coordinate of the public key.
+    fn x(&self) -> &C::Scalar;
+    /// Get the y coordinate of the public key.
+    fn y(&self) -> &C::Scalar;
+
+    /// Create a new public key from x and y coordinates with validation.
+    ///
+    /// This method validates that the point (x, y) lies on the specified curve.
+    ///
+    /// # Parameters
+    /// - `x`: The x coordinate of the point
+    /// - `y`: The y coordinate of the point  
+    ///
+    /// # Returns
+    /// - `Ok(Self)`: Valid public key if the point is on the curve
+    /// - `Err(ErrorKind::InvalidPoint)`: If the point is not on the curve
+    /// - `Err(ErrorKind::WeakKey)`: If the point is the identity element
+    fn from_coordinates(x: C::Scalar, y: C::Scalar) -> Result<Self, ErrorKind>
+    where
+        Self: Sized;
+
+    /// Validate that this public key represents a valid point on the curve.
+    ///
+    /// This method should be called before using a public key for verification
+    /// to ensure it represents a valid curve point and is not a weak key.
+    ///
+    /// # Returns
+    /// - `Ok(())`: The public key is valid
+    /// - `Err(ErrorKind::InvalidPoint)`: The point is not on the curve
+    /// - `Err(ErrorKind::WeakKey)`: The point is the identity element or otherwise weak
+    fn validate(&self) -> Result<(), ErrorKind>;
+
+    /// Create a new public key from x and y coordinates without validation.
+    ///
+    /// # Safety
+    /// This method should only be used when the caller can guarantee that
+    /// the coordinates represent a valid point on the curve. Use `from_coordinates`
+    /// for safe construction with validation.
+    fn new_unchecked(x: C::Scalar, y: C::Scalar) -> Self;
+}
+
+/// Trait for ECDSA key generation over a specific elliptic curve.
+///
+/// This trait enables generation of cryptographically secure ECDSA key pairs
+/// using a cryptographic random number generator.
+///
+/// # Security Requirements
+///
+/// - Must use a cryptographically secure random number generator
+/// - Generated keys must be uniformly distributed over the valid scalar range
+/// - Private keys must be properly zeroized after use
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{EcdsaKeyGen, Curve, ErrorKind};
+/// use rand_core::{RngCore, CryptoRng};
+///
+/// struct MyKeyGenerator;
+///
+/// impl<C: Curve> EcdsaKeyGen<C> for MyKeyGenerator {
+///     type PrivateKey = MyPrivateKey;
+///     type PublicKey = MyPublicKey;
+///
+///     fn generate_keypair<R>(&mut self, rng: &mut R) 
+///         -> Result<(Self::PrivateKey, Self::PublicKey), Self::Error>
+///     where
+///         R: RngCore + CryptoRng,
+///     {
+///         // Generate cryptographically secure key pair
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait EcdsaKeyGen<C: Curve>: ErrorType {
+    /// The type representing the private key for the curve.
+    type PrivateKey: PrivateKey<C>;
+    /// The type representing the public key for the curve.
+    type PublicKey: PublicKey<C>;
+
+    /// Generates an ECDSA key pair.
+    ///
+    /// # Parameters
+    /// - `rng`: A cryptographically secure random number generator.
+    ///
+    /// # Returns
+    /// A tuple containing the generated private key and public key.
+    fn generate_keypair<R>(
+        &mut self,
+        rng: &mut R,
+    ) -> Result<(Self::PrivateKey, Self::PublicKey), Self::Error>
+    where
+        R: rand_core::RngCore + rand_core::CryptoRng;
+}
+
+/// Trait for ECDSA signing using a digest algorithm.
+///
+/// This trait provides ECDSA signature generation from message digests.
+/// The digest should be produced by a cryptographically secure hash function
+/// that matches the curve's security level.
+///
+/// # Security Considerations
+///
+/// - Use cryptographically secure random number generators for nonce generation
+/// - Ensure digest length matches the curve's security level
+/// - Private keys must be validated before use
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{EcdsaSign, Curve, PrivateKey};
+/// use rand_core::{RngCore, CryptoRng};
+///
+/// struct MySigner;
+///
+/// impl<C: Curve> EcdsaSign<C> for MySigner {
+///     type PrivateKey = MyPrivateKey;
+///     type Signature = MySignature;
+///
+///     fn sign<R>(&mut self, key: &Self::PrivateKey, digest: &[u8], rng: &mut R)
+///         -> Result<Self::Signature, Self::Error>
+///     where
+///         R: RngCore + CryptoRng,
+///     {
+///         // Generate ECDSA signature
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait EcdsaSign<C: Curve>: ErrorType {
+    /// The type representing the private key for the curve.
+    type PrivateKey: PrivateKey<C>;
+    /// The type representing the signature for the curve.
+    type Signature: Signature<C>;
+
+    /// Signs a digest produced by a compatible hash function.
+    ///
+    /// # Parameters
+    /// - `private_key`: The private key used for signing.
+    /// - `digest`: The digest output from a hash function.
+    /// - `rng`: A cryptographically secure random number generator.
+    fn sign<R>(
+        &mut self,
+        private_key: &Self::PrivateKey,
+        digest: <<C as Curve>::DigestType as DigestAlgorithm>::Digest,
+        rng: &mut R,
+    ) -> Result<Self::Signature, Self::Error>
+    where
+        R: rand_core::RngCore + rand_core::CryptoRng;
+}
+
+/// Trait for ECDSA signature verification using a digest algorithm.
+///
+/// This trait provides ECDSA signature verification against message digests
+/// using public keys. Verification should be performed in constant time
+/// where possible to prevent timing attacks.
+///
+/// # Security Considerations
+///
+/// - Always validate public keys before verification
+/// - Validate signature components are within valid ranges
+/// - Use constant-time comparison operations when possible
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::{EcdsaVerify, Curve, PublicKey};
+///
+/// struct MyVerifier;
+///
+/// impl<C: Curve> EcdsaVerify<C> for MyVerifier {
+///     type PublicKey = MyPublicKey;
+///     type Signature = MySignature;
+///
+///     fn verify(&mut self, key: &Self::PublicKey, digest: &[u8], signature: &Self::Signature)
+///         -> Result<(), Self::Error>
+///     {
+///         // Verify ECDSA signature
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait EcdsaVerify<C: Curve>: ErrorType {
+    /// The type representing the public key for the curve.
+    type PublicKey: PublicKey<C>;
+    /// The type representing the signature for the curve.
+    type Signature: Signature<C>;
+
+    /// Verifies a signature against a digest.
+    ///
+    /// # Parameters
+    /// - `public_key`: The public key used for verification.
+    /// - `digest`: The digest output from a hash function.
+    /// - `signature`: The signature to verify.
+    fn verify(
+        &mut self,
+        public_key: &Self::PublicKey,
+        digest: <<C as Curve>::DigestType as DigestAlgorithm>::Digest,
+        signature: &Self::Signature,
+    ) -> Result<(), Self::Error>;
+}
+
+/// secp256k1 elliptic curve marker type.
+///
+/// This zero-sized type represents the secp256k1 elliptic curve, widely used in
+/// Bitcoin and other cryptocurrencies. It provides ~128-bit security level.
+///
+/// ## Parameters
+/// - **Field Size**: 256 bits
+/// - **Security Level**: ~128 bits
+/// - **Standard**: SEC 2
+/// - **Common Uses**: Bitcoin, Ethereum, cryptocurrency applications
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::Secp256k1;
+///
+/// // Type-safe key generation for secp256k1
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(Secp256k1)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct Secp256k1;
+
+impl Curve for Secp256k1 {
+    type DigestType = crate::digest::Sha2_256;
+    type Scalar = [u8; 32];
+}
+
+/// NIST P-256 elliptic curve marker type.
+///
+/// This zero-sized type represents the NIST P-256 elliptic curve (secp256r1).
+/// This is the most widely used elliptic curve for ECDSA, providing ~128-bit security.
+///
+/// ## Parameters
+/// - **Field Size**: 256 bits
+/// - **Security Level**: ~128 bits
+/// - **Standard**: FIPS 186-4, RFC 5480
+/// - **Common Uses**: TLS certificates, JWT signing, general-purpose cryptography
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::P256;
+///
+/// // Type-safe key generation for P-256
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(P256)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct P256;
+
+impl Curve for P256 {
+    type DigestType = crate::digest::Sha2_256;
+    type Scalar = [u8; 32];
+}
+
+/// NIST P-384 elliptic curve marker type.
+///
+/// This zero-sized type represents the NIST P-384 elliptic curve (secp384r1).
+/// Provides higher security level than P-256 with ~192-bit security.
+///
+/// ## Parameters
+/// - **Field Size**: 384 bits
+/// - **Security Level**: ~192 bits
+/// - **Standard**: FIPS 186-4, RFC 5480
+/// - **Common Uses**: High-security applications, government systems
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::P384;
+///
+/// // Type-safe key generation for P-384
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(P384)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct P384;
+
+impl Curve for P384 {
+    type DigestType = crate::digest::Sha2_384;
+    type Scalar = [u8; 48];
+}
+
+/// NIST P-521 elliptic curve marker type.
+///
+/// This zero-sized type represents the NIST P-521 elliptic curve (secp521r1).
+/// Provides maximum security among NIST curves with ~256-bit security.
+///
+/// ## Parameters
+/// - **Field Size**: 521 bits
+/// - **Security Level**: ~256 bits
+/// - **Standard**: FIPS 186-4, RFC 5480
+/// - **Common Uses**: Maximum security applications, long-term archival
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::P521;
+///
+/// // Type-safe key generation for P-521
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(P521)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct P521;
+
+impl Curve for P521 {
+    type DigestType = crate::digest::Sha2_512;
+    type Scalar = [u8; 66];
+}
+
+/// Brainpool P256r1 elliptic curve marker type.
+///
+/// This zero-sized type represents the Brainpool P256r1 elliptic curve.
+/// Brainpool curves are alternative curves to NIST curves with potentially better properties.
+///
+/// ## Parameters
+/// - **Field Size**: 256 bits
+/// - **Security Level**: ~128 bits
+/// - **Standard**: RFC 5639
+/// - **Common Uses**: Alternative to NIST curves, European standards
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::BrainpoolP256r1;
+///
+/// // Type-safe key generation for Brainpool P256r1
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(BrainpoolP256r1)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct BrainpoolP256r1;
+
+impl Curve for BrainpoolP256r1 {
+    type DigestType = crate::digest::Sha2_256;
+    type Scalar = [u8; 32];
+}
+
+/// Brainpool P384r1 elliptic curve marker type.
+///
+/// This zero-sized type represents the Brainpool P384r1 elliptic curve.
+/// Provides higher security level than P256r1 with 192-bit security.
+///
+/// ## Parameters
+/// - **Field Size**: 384 bits
+/// - **Security Level**: ~192 bits
+/// - **Standard**: RFC 5639
+/// - **Common Uses**: High-security applications, European standards
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::BrainpoolP384r1;
+///
+/// // Type-safe key generation for Brainpool P384r1
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(BrainpoolP384r1)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct BrainpoolP384r1;
+
+impl Curve for BrainpoolP384r1 {
+    type DigestType = crate::digest::Sha2_384;
+    type Scalar = [u8; 48];
+}
+
+/// Brainpool P512r1 elliptic curve marker type.
+///
+/// This zero-sized type represents the Brainpool P512r1 elliptic curve.
+/// Provides maximum security among Brainpool curves with ~256-bit security.
+///
+/// ## Parameters
+/// - **Field Size**: 512 bits
+/// - **Security Level**: ~256 bits
+/// - **Standard**: RFC 5639
+/// - **Common Uses**: Maximum security applications, European standards
+///
+/// ## Example
+/// ```rust,ignore
+/// use openprot_hal_blocking::ecdsa::BrainpoolP512r1;
+///
+/// // Type-safe key generation for Brainpool P512r1
+/// let key_gen = MyKeyGenerator;
+/// let (private_key, public_key) = key_gen.generate_keypair(BrainpoolP512r1)?;
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct BrainpoolP512r1;
+
+impl Curve for BrainpoolP512r1 {
+    type DigestType = crate::digest::Sha2_512;
+    type Scalar = [u8; 64];
+}
+

--- a/hal/blocking/src/lib.rs
+++ b/hal/blocking/src/lib.rs
@@ -16,8 +16,12 @@
 
 /// Cryptographic digest operations (hashing)
 pub mod digest;
+/// ECDSA digital signature operations
+pub mod ecdsa;
 /// Gpio port module
 pub mod gpio_port;
+/// I2C target device operations
+pub mod i2c_target;
 /// Message Authentication Code (MAC) traits and implementations
 pub mod mac;
 /// Reset and clocking traits for OpenPRoT HAL


### PR DESCRIPTION
- Add complete ECDSA trait suite (key generation, signing, verification)
- Include security-first design with mandatory validation and zeroization
- Add curve markers for P256, P384, P521, secp256k1, and Brainpool curves
- Implement type-safe generic interface preventing cross-curve contamination
- Add comprehensive error handling with detailed ErrorKind enum
- Include extensive documentation with security considerations and examples.