### PR TITLE
[fix] Issue #32 - subtle dependency breaks no_std/embedded builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ edition = "2021"
 
 [workspace.dependencies]
 zerocopy = { version = "0.8.27", features = ["derive"] }
-zeroize = { version = "1.7", features = ["derive"] }
+zeroize = { version = "1.7", default-features = false, features = ["derive"] }
 subtle = { version = "2.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ edition = "2021"
 [workspace.dependencies]
 zerocopy = { version = "0.8.27", features = ["derive"] }
 zeroize = { version = "1.7", features = ["derive"] }
-subtle = "2.5"
+subtle = { version = "2.5", default-features = false }


### PR DESCRIPTION
The subtle crate is designed to work in no_std environments when default features are disabled. The current configuration prevents OpenPRoT from being used in the embedded ecosystem where constant-time cryptographic operations are particularly important.