### PR TITLE
ci: update cargo-deny to 0.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       run: cargo install cargo-audit --locked
     
     - name: Install cargo-deny
-      run: cargo install cargo-deny --version 0.18.3 --locked
+      run: cargo install cargo-deny --version 0.19.0 --locked
     
     - name: Run security audit
       run: cargo audit


### PR DESCRIPTION
Older versions of cargo-deny (0.18.3) do not support the CVSS 4.0 format, which is now present in the Rust advisory database. This caused `cargo-deny check` to fail when encountering such advisories.

Updating to 0.19.0 resolves this issue by adding support for CVSS 4.0.