### PR TITLE
docs: introduce formal RFC and development process

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,30 @@
+---
+name: OpenPRoT RFC Issue Template
+about: Template for OpenPRoT contributors to file an RFC proposing significant changes to the project.
+title: "[RFC] {RFC title here}"
+labels: RFC
+assignees: ''
+
+---
+
+# [edit] Title for contribution proposal
+[edit] Abstract
+
+## Scope
+[edit] What parts of the project will be affected.
+* [edit] Overview of anticipated changes to specifications or other documentation (e.g., repo structures, APIs, etc.)
+
+## Rationale
+[edit] The motivation and justification for the change, including why it is important to include in the project.
+
+## Implementation Tradeoffs
+[edit] Details of various implementations being considered and the reasons for selecting the proposed approach.
+
+## Implementation Timeline
+[edit] A realistic estimate for completion and the intended release or milestone.
+
+## Test Plan
+[edit] Required for any security-critical or architectural changes to ensure quality and maintainability.
+
+## Maintenance
+[edit] The individual or team responsible as the point of contact for this feature now and in the future.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to OpenPRoT
+
+Thank you for your interest in contributing to the OpenPRoT project!
+
+Detailed guidelines for contributing, including our development setup, coding style, and formal RFC process, can be found in our documentation:
+
+*   **[Development Process](docs/src/development-process.md)**: Details on the formal RFC process for large changes and our standard requirements for pull requests.
+*   **[Contributing Guidelines](docs/src/contributing.md)**: Setup instructions, license agreements, and code of conduct.
+
+## Quick Start
+
+1.  **Fork** the repository.
+2.  **Clone** your fork.
+3.  **Set up** the environment (we use [Bazel](https://bazel.build/) and [Pigweed](https://pigweed.dev/)).
+4.  **Create** a branch for your changes.
+5.  **Submit** a Pull Request.
+
+For large changes, please follow the RFC process described in the [Development Process](docs/src/development-process.md) document.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 * [Architecture](./architecture.md)
 * [Coding Style](./coding-style.md)
 * [Contributing](./contributing.md)
+* [Development Process](./development-process.md)
 * [Design](./design/README.md)
   * [Digest Driver for Hubris](./design/driver-hubris-hash.md)
   * [Rust Traits to IDL Guide](./design/rust-trait-to-idl-conversion.md)

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,5 +1,11 @@
 # Contributing to OpenPRoT
 
+Thank you for your interest in contributing to the OpenPRoT project!
+
+## Contribution Process
+
+Before you begin, please review our [Development Process](development-process.md) for details on our **RFC process** for large changes and our standard requirements for pull requests.
+
 ## Contributor License Agreement
 
 - Use of OpenPRoT requires no CLA.
@@ -11,30 +17,23 @@ The code of conduct can be found [here](https://github.com/OpenPRoT/.github/blob
 
 ## Development Setup
 
-1. Clone the repository
-2. Install dependencies: `cargo xtask check`
-3. Run tests: `cargo xtask test`
-4. Format code: `cargo xtask fmt`
+1. Clone the repository.
+2. Use the Pigweed workflow launcher `pw` or `bazel` for common tasks:
+   - `./pw presubmit` - Run presubmit checks: formatting, license checks, C/C++ header checks, and `clippy`.
+   - `./pw format` - Run the code formatters.
+   - `bazel test //...` - Run all tests.
+   - `bazel build //docs` - Build documentation.
 
 ## Code Style
 
 - Follow the [coding style](coding-style.md) guide.
-- Run `cargo xtask clippy` to check for lints
-- Ensure all tests pass with `cargo xtask test`
+- Run `./pw presubmit` to check for lints and ensure all tests pass.
 
 ## Documentation
 
-- Update documentation in the `docs/` directory
-- Build docs with `cargo xtask docs`
-- Documentation is built with mdbook
-
-## Pull Requests
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run the full test suite
-5. Submit a pull request
+- Update documentation in the `docs/` directory.
+- Build docs with `bazel build //docs`.
+- Documentation is built with mdbook.
 
 ## Issues
 

--- a/docs/src/development-process.md
+++ b/docs/src/development-process.md
@@ -1,0 +1,86 @@
+# Development Process
+
+This document describes the formal process for contributing changes to the OpenPRoT Project.
+
+## Types of Changes
+
+There are two types of changes contributors may make:
+
+1.  **Small Change**: Standard bug fixes, minor improvements, or documentation updates.
+    *   [Optional] File a lightweight GitHub issue.
+    *   Submit a pull request (PR) with the change.
+    *   Wait for project maintainers to approve and merge.
+2.  **Large Change**: Substantial changes that require a Request for Comment (RFC).
+    *   Draft an RFC (a GitHub issue titled "[RFC] …") describing the proposed change.
+    *   Seek commentary from project contributors.
+    *   Seek approval from the OpenPRoT Technical Steering Committee (TSC).
+    *   Update the RFC based on feedback.
+    *   Submit one or more pull requests to implement the approved RFC.
+
+## Process Flow
+
+```mermaid
+graph TD
+    Start((Proposal)) --> Type{Type?}
+    Type -- Small --> SmallImpl[Implement]
+    SmallImpl --> SmallIssue[Optional: File Issue]
+    SmallIssue --> SmallPR[Submit PR]
+    SmallPR --> SmallApprove[Approval]
+    SmallApprove --> SmallMerge[Merge]
+    Type -- Large --> LargeRFC[Draft RFC]
+    LargeRFC --> LargeDiscuss[Discussion]
+    LargeDiscuss --> LargeTSC[Approval - TSC]
+    LargeTSC --> LargeUpdate{Changes?}
+    LargeUpdate -- Yes --> LargeRFCUpdate[Update RFC]
+    LargeRFCUpdate --> LargeDiscuss
+    LargeUpdate -- No --> LargeImpl[Implement]
+    LargeImpl --> LargePR[Submit PR]
+    LargePR --> LargeApprove[Approval]
+    LargeApprove --> LargeMerge[Merge]
+    LargeMerge -. Loop for multiple PRs .-> LargeImpl
+```
+
+### What constitutes a "Large" change?
+
+A large change is loosely defined as any change that substantially impacts:
+
+*   **Architecture**: Adding a new component, module, or drastically changing an existing one.
+*   **Boot process**: Changes to the firmware initialization or secure boot sequence.
+*   **API**: Command sets, register layout changes (as defined in firmware drivers), or I/O interface changes.
+*   **Security Posture**: Changes to the threat model, attestation mechanisms, or cryptographic implementations.
+*   **Maintenance**: Significant tool changes or environment updates.
+
+If a contributor is unclear whether a change is "small" or "large," they should start by filing a GitHub issue for guidance.
+
+### Structure of an RFC
+
+To streamline the review of large changes, all RFCs must be submitted as a GitHub Issue with a title prefixed by "[RFC]". The body must detail:
+
+*   **Scope**: What parts of the project will be affected.
+*   **Rationale**: The motivation and justification for the change.
+*   **Implementation Tradeoffs**: Details of various implementations being considered.
+*   **Implementation Timeline**: A realistic estimate for completion.
+*   **Test Plan**: Required for any security-critical or architectural changes to ensure quality and maintainability.
+*   **Maintenance**: The individual or team responsible for the feature's future maintenance.
+
+### RFC Approval Authority
+
+Final approval authority for all RFCs rests with the **OpenPRoT TSC**. Once the TSC approves an RFC, corresponding PRs can be submitted for review. Implementation may begin on a fork for experimentation, but PRs should not be submitted to the upstream repository until approval is granted.
+
+## Implementation
+
+### Additional Requirements for Contribution
+
+To ensure quality and maintainability, all contributions must adhere to these rules:
+
+*   **Documentation**: Updates must describe new functionality and usage.
+*   **Cryptographic Hardening**: Changes to cryptographic modules must include a thorough test plan.
+*   **Tool Compatibility**: All validation plans and features must be compatible with existing supported tools and versions.
+
+### Submission of Pull Requests
+
+All contributions must follow the standard GitHub **fork-and-PR methodology**. Large features should be submitted via multiple, smaller PRs (ideally fewer than 500 lines of code) to reduce the burden of review.
+
+## References
+
+This process is adapted from the [Caliptra Contributing Process](https://github.com/chipsalliance/Caliptra/blob/main/doc/CaliptraContributingProcess.md).

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -2,32 +2,30 @@
 
 ## Prerequisites
 
-- Rust 1.70 or later
-- Cargo
+- [Bazel](https://bazel.build/). We recommend installing [bazelisk](https://github.com/bazelbuild/bazelisk) to automatically manage bazel versions.
+
+No additional tools are required - all dependencies are managed by bazel.
 
 ## Installation
 
 Clone the repository:
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/OpenPRoT/openprot
 cd openprot
 ```
 
-Build the project:
+## Available Tasks
 
-```bash
-cargo xtask build
-```
+You can run common development tasks using the Pigweed workflow launcher `pw` or `bazel`:
 
-Run tests:
-
-```bash
-cargo xtask test
-```
+- `./pw presubmit` - Run presubmit checks: formatting, license checks, C/C++ header checks, and `clippy`.
+- `./pw format` - Run the code formatters.
+- `bazel test //...` - Run all tests.
+- `bazel build //docs` - Build documentation.
 
 ## Next Steps
 
-- Read the [Usage](./usage.md) guide
-- Check out the [Architecture](./architecture.md) documentation
-- Learn about [Contributing](./contributing.md)
+- Read the [Usage](./usage.md) guide.
+- Check out the [Architecture](./architecture.md) documentation.
+- Learn about [Contributing](./contributing.md).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -73,8 +73,8 @@ To get started with OpenPRoT, you can build and test the project using the
 following commands:
 
 ```bash
-cargo xtask build
-cargo xtask test
+./pw presubmit
+bazel test //...
 ```
 
 For more detailed instructions, please refer to the


### PR DESCRIPTION
### Summary
This PR establishes a formal development and RFC process for OpenPRoT, ensuring a standardized path for both small and large contributions.

### Changes Included
1. **Formal RFC and Development Process**:
   - Adds  detailing the RFC workflow for large changes.
   - Updates  and the root  to point to the new process.
   - Includes a Mermaid flow diagram of the contribution path.
   - Adapts criteria for firmware-only project needs (removing hardware-specific concepts like CDC/RDC).
2. **RFC Issue Template**:
   - Introduces a standardized GitHub issue template in  for Request for Comment (RFC) proposals.

### Attribution
The process and templates are adapted from the [Caliptra Contributing Process](https://github.com/chipsalliance/Caliptra/blob/main/doc/CaliptraContributingProcess.md).
