### PR TITLE
WIP: pigweed on veer

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,6 +79,13 @@ archive_override(
     url = "https://storage.googleapis.com/artifacts.opentitan.org/dev_bundle/devbundle-test-20251105.tar.xz",
 )
 
+bazel_dep(name = "caliptra_devbundle")
+archive_override(
+    module_name = "caliptra_devbundle",
+    integrity = "sha256-k5EobAyBQqApv/s4QsMVEaJKRptnS6Ic//eJr8F4yOw=",
+    url = "https://storage.googleapis.com/artifacts.opentitan.org/dev_bundle/experimental/cptra-dev-20260330.zip",
+)
+
 nonhermetic_repo = use_repo_rule("//target/earlgrey/tooling/signing:nonhermetic.bzl", "nonhermetic_repo")
 
 nonhermetic_repo(name = "nonhermetic")

--- a/target/veer/BUILD.bazel
+++ b/target/veer/BUILD.bazel
@@ -1,0 +1,126 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@pigweed//pw_build:merge_flags.bzl", "flags_from_dict")
+load("@pigweed//pw_kernel:flags.bzl", "KERNEL_DEVICE_COMMON_FLAGS")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//target/veer:defs.bzl", "TARGET_COMPATIBLE_WITH")
+
+platform(
+    name = "veer",
+    constraint_values = [
+        ":target_veer",
+        "@pigweed//pw_kernel/arch/riscv:timer_clint",
+        "@pigweed//pw_build/constraints/riscv/extensions:I",
+        "@pigweed//pw_build/constraints/riscv/extensions:M",
+        "@pigweed//pw_build/constraints/riscv/extensions:C",
+        "@pigweed//pw_build/constraints/riscv/extensions:A.not",
+        "@pigweed//pw_build/constraints/rust:no_std",
+        "@platforms//cpu:riscv32",
+        "@platforms//os:none",
+    ],
+    flags = flags_from_dict(
+        KERNEL_DEVICE_COMMON_FLAGS | {
+            "@pigweed//pw_kernel/arch/riscv:veer_pic": True,
+            "@pigweed//pw_kernel/config:kernel_config": ":config",
+            "@pigweed//pw_kernel/subsys/console:console_backend": ":console",
+            "@pigweed//pw_log/rust:pw_log_backend": "@pigweed//pw_kernel:log_backend_basic",
+        },
+    ),
+    visibility = [":__subpackages__"],
+)
+
+string_flag(
+    name = "target_type",
+    build_setting_default = "silicon",
+    values = [
+        "silicon",
+        "fpga",
+        "emulator",
+    ],
+)
+
+config_setting(
+    name = "silicon",
+    flag_values = {":target_type": "silicon"},
+)
+
+config_setting(
+    name = "fpga",
+    flag_values = {":target_type": "fpga"},
+)
+
+config_setting(
+    name = "emulator",
+    flag_values = {":target_type": "emulator"},
+)
+
+constraint_value(
+    name = "target_veer",
+    constraint_setting = "@pigweed//pw_kernel/target:target",
+    visibility = [":__subpackages__"],
+)
+
+rust_library(
+    name = "entry",
+    srcs = [
+        "entry.rs",
+    ],
+    crate_features = select({
+        ":fpga": ["fpga"],
+        ":silicon": ["silicon"],
+        ":emulator": ["emulator"],
+        "//conditions:default": [],
+    }),
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = [":__subpackages__"],
+    deps = [
+        ":config",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/lib/memory_config",
+        "@rust_crates//:riscv-rt",
+    ],
+)
+
+rust_library(
+    name = "console",
+    srcs = ["console.rs"],
+    crate_name = "console_backend",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:embedded-io",
+    ],
+)
+
+rust_library(
+    name = "config",
+    srcs = ["config.rs"],
+    crate_features = select({
+        ":fpga": ["fpga"],
+        ":silicon": ["silicon"],
+        ":emulator": ["emulator"],
+        "//conditions:default": [],
+    }),
+    crate_name = "kernel_config",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = [":__subpackages__"],
+    deps = [
+        "@pigweed//pw_kernel/config:kernel_config_interface",
+        "@pigweed//pw_kernel/lib/memory_config",
+    ],
+)
+
+filegroup(
+    name = "linker_script_template",
+    srcs = ["target.ld.jinja"],
+    visibility = [":__subpackages__"],
+)

--- a/target/veer/config.rs
+++ b/target/veer/config.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+
+use core::ops::Range;
+use memory_config::MemoryRegion;
+
+pub use kernel_config::{
+    ClintTimerConfigInterface, ExceptionMode, KernelConfigInterface, RiscVKernelConfigInterface,
+    VeerPicConfigInterface,
+};
+
+//const RAM_BASE: usize = 0x4000_0000;
+//const RAM_SIZE: usize = 384*1024;
+//
+//const UART0_BASE: usize = 0x1000_1000;
+//const UART0_SIZE: usize = 0x100;
+//
+//const TIMER_BASE: usize = 0x4010_0000;
+//const TIMER_SIZE: usize = 0x200;
+//
+//const PLIC_SIZE: usize = 0x0000_5400;
+const PIC_BASE: usize = 0x6000_0000;
+
+pub struct KernelConfig;
+
+impl KernelConfigInterface for KernelConfig {
+    #[cfg(feature = "silicon")]
+    const SYSTEM_CLOCK_HZ: u64 = 100_000_000;
+    #[cfg(feature = "fpga")]
+    const SYSTEM_CLOCK_HZ: u64 = 10_000_000; //FIXME
+    #[cfg(feature = "emulator")]
+    const SYSTEM_CLOCK_HZ: u64 = 1_000_000;
+}
+
+impl RiscVKernelConfigInterface for KernelConfig {
+    type Timer = TimerConfig;
+
+    const MTIME_HZ: u64 = KernelConfig::SYSTEM_CLOCK_HZ;
+    const PMP_ENTRIES: usize = 16;
+    const PMP_USERSPACE_ENTRIES: Range<usize> = Range {
+        start: 0usize,
+        end: 16usize,
+    };
+    const PMP_GRANULARITY: usize = 0;
+    const KERNEL_MEMORY_REGIONS: &'static [MemoryRegion] = &[];
+
+    fn get_exception_mode() -> ExceptionMode {
+        ExceptionMode::Vectored(unsafe { MTVEC_TABLE.as_ptr() as usize })
+    }
+}
+
+pub struct VeerPicConfig;
+
+impl VeerPicConfigInterface for VeerPicConfig {
+    const PIC_BASE_ADDRESS: usize = PIC_BASE;
+    const MAX_IRQS: u32 = 256;
+}
+
+pub struct TimerConfig;
+
+const TIMER_BASE: usize = 0x2100_0000;
+
+impl ClintTimerConfigInterface for TimerConfig {
+    const MTIME_REGISTER: usize = TIMER_BASE + 0xe4;
+    const MTIMECMP_REGISTER: usize = TIMER_BASE + 0xec;
+}
+
+unsafe extern "C" {
+    #[link_name = "_mtvec_table"]
+    static MTVEC_TABLE: [u32; 32];
+}

--- a/target/veer/console.rs
+++ b/target/veer/console.rs
@@ -1,0 +1,28 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+
+use kernel::sync::spinlock::SpinLock;
+use pw_status::Result;
+
+struct Uart;
+
+impl Uart {
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        let tx = core::ptr::with_exposed_provenance_mut::<u8>(0x1000_1041);
+        for &byte in buf.iter() {
+            unsafe {
+                tx.write_volatile(byte);
+            }
+        }
+        Ok(())
+    }
+}
+
+static UART: SpinLock<arch_riscv::Arch, Uart> = SpinLock::new(Uart);
+
+#[unsafe(no_mangle)]
+pub fn console_backend_write_all(buf: &[u8]) -> Result<()> {
+    let mut uart = UART.lock(arch_riscv::Arch);
+    uart.write_all(buf)
+}

--- a/target/veer/defs.bzl
+++ b/target/veer/defs.bzl
@@ -1,0 +1,11 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""Common definitions used by all veer targets.
+"""
+
+TARGET_COMPATIBLE_WITH = select({
+    "//target/veer:target_veer": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})

--- a/target/veer/entry.rs
+++ b/target/veer/entry.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![no_main]
+use core::arch::global_asm;
+
+use arch_riscv::Arch;
+use kernel::{self as _};
+
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn pw_assert_HandleFailure() -> ! {
+    use kernel::Arch as _;
+    Arch::panic()
+}
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    kernel::static_init_state!(static mut INIT_STATE: InitKernelState<Arch>);
+
+    // SAFETY: `main` is only executed once, so we never generate more than one
+    // `&mut` reference to `INIT_STATE`.
+    #[allow(static_mut_refs)]
+    kernel::main(Arch, unsafe { &mut INIT_STATE });
+}
+
+pub fn exit(code: u32) -> ! {
+    #[cfg(feature = "emulator")]
+    unsafe {
+        // SAFETY: writing to this address will cause the emulator to exit.
+        let exitcode = core::ptr::with_exposed_provenance_mut::<u32>(0x1000_2000);
+        exitcode.write_volatile(code);
+    }
+    loop {}
+}
+
+global_asm!(
+    "
+    .option push
+    .option norvc
+    .option norelax
+    .balign 256
+    .global _mtvec_table
+_mtvec_table:
+    j _start_trap /* 0: exception and user software interrupt */
+    j _start_trap /* 1: supervisor software interrupt */
+    j _start_trap /* 2: reserved */
+    j _start_trap /* 3: machine software interrupt */
+    j _start_trap /* 4: user timer interrupt */
+    j _start_trap /* 5: supervisor timer interrupt */
+    j _start_trap /* 6: reserved */
+    j _start_trap /* 7: machine timer interrupt */
+    j _start_trap /* 8: user external interrupt */
+    j _start_trap /* 9: supervisor external interrupt */
+    j _start_trap /* 10: reserved */
+    j _start_trap /* 11: machine external interrupt */
+    j _start_trap /* 12: reserved */
+    j _start_trap /* 13: reserved */
+    j _start_trap /* 14: reserved */
+    j _start_trap /* 15: reserved */
+    j _start_trap /* 16-30: On Ibex, reserved for 'fast' interrupts */
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap
+    j _start_trap /* 31: reset vector */
+    .size _mtvec_table, .-_mtvec_table
+    .option pop
+    "
+);

--- a/target/veer/ipc/user/BUILD.bazel
+++ b/target/veer/ipc/user/BUILD.bazel
@@ -1,0 +1,83 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@pigweed//pw_kernel/tooling/panic_detector:rust_binary_no_panics_test.bzl", "rust_binary_no_panics_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/veer:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/veer/tooling:caliptra_runner.bzl", "caliptra_runner", "caliptra_test")
+
+APPS = [
+    "@pigweed//pw_kernel/tests/ipc/user:ipc",
+]
+
+system_image(
+    name = "ipc",
+    apps = APPS,
+    kernel = ":target",
+    platform = "//target/veer",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/veer:linker_script_template",
+)
+
+rust_binary_no_panics_test(
+    name = "no_panics_test",
+    binary = ":ipc",
+    tags = ["kernel"],
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/veer:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+
+caliptra_runner(
+    name = "ipc_runner_emulator",
+    interface = "emulator",
+    tags = ["manual"],
+    target = ":ipc",
+)
+
+caliptra_test(
+    name = "ipc_runner_emulator_test",
+    timeout = "long",
+    interface = "emulator",
+    target = ":ipc",
+)

--- a/target/veer/ipc/user/system.json5
+++ b/target/veer/ipc/user/system.json5
@@ -1,0 +1,60 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0x40000000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x40040000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "initiator",
+      flash_size_bytes: 16384,
+      ram_size_bytes: 4096,
+      process: {
+        name: "initiator process",
+        objects: [
+          {
+            name: "IPC",
+            type: "channel_initiator",
+            handler_app: "handler",
+            handler_object_name: "IPC",
+          },
+        ],
+        threads: [
+          {
+            name: "initiator thread",
+            stack_size_bytes: 1024,
+          },
+        ],
+      },
+    },
+    {
+      name: "handler",
+      flash_size_bytes: 16384,
+      ram_size_bytes: 4096,
+      process: {
+        name: "handler process",
+        objects: [
+          {
+            name: "IPC",
+            type: "channel_handler",
+          },
+        ],
+        threads: [
+          {
+            name: "handler thread",
+            stack_size_bytes: 1024,
+          },
+        ],
+      },
+    },
+  ],
+}

--- a/target/veer/ipc/user/target.rs
+++ b/target/veer/ipc/user/target.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![no_main]
+
+use console_backend as _;
+use entry::exit;
+use target_common::{declare_target, TargetInterface};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Caliptra MCU Userspace IPC";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => pw_log::info!("PASS"),
+            _ => pw_log::info!("FAIL: {}", code as u32),
+        };
+        exit(code);
+    }
+}
+
+declare_target!(Target);

--- a/target/veer/syscall_latency/BUILD.bazel
+++ b/target/veer/syscall_latency/BUILD.bazel
@@ -1,0 +1,101 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+
+load("@pigweed//pw_kernel/tooling:app_package.bzl", "app_package")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/veer:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/veer/tooling:caliptra_runner.bzl", "caliptra_runner")
+
+rust_binary(
+    name = "syscall_latency",
+    srcs = [
+        "main.rs",
+    ],
+    crate_features = select({
+        "//target/veer:fpga": ["fpga"],
+        "//target/veer:silicon": ["silicon"],
+        "//target/veer:emulator": ["emulator"],
+        "//conditions:default": [],
+    }),
+    crate_name = "syscall_latency",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":app_syscall_latency",
+        "//target/veer:config",
+        "@pigweed//pw_base64/rust:pw_base64",
+        "@pigweed//pw_kernel/syscall:syscall_user",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+app_package(
+    name = "app_syscall_latency",
+    app_name = "syscall_latency",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+)
+
+system_image(
+    name = "measure_syscall_latency",
+    apps = [
+        ":syscall_latency",
+    ],
+    kernel = ":target",
+    platform = "//target/veer",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/veer:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/veer:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/lib/memory_config",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+caliptra_runner(
+    name = "measure_syscall_latency_emulator",
+    interface = "emulator",
+    target = ":measure_syscall_latency",
+)

--- a/target/veer/syscall_latency/main.rs
+++ b/target/veer/syscall_latency/main.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+#![no_std]
+
+use kernel_config::{KernelConfig, KernelConfigInterface};
+use pw_status::Result;
+//use registers::rv_timer::RvTimer;
+use userspace::{entry, syscall};
+
+#[cfg(feature = "silicon")]
+const IO_CLOCK_HZ: u64 = 24_000_000;
+#[cfg(feature = "fpga")]
+const IO_CLOCK_HZ: u64 = 6_000_000;
+#[cfg(feature = "emulator")]
+const IO_CLOCK_HZ: u64 = 1_000_000;
+
+#[inline(always)]
+fn mtime_value() -> u64 {
+    let mtime = core::ptr::with_exposed_provenance::<u64>(0x21000000 + 0xe4);
+    unsafe { mtime.read_volatile() }
+}
+
+fn measure_nop_syscall(n: usize) -> Result<()> {
+    let mut total = 0u64;
+    for _ in 0..n {
+        let t0 = mtime_value();
+        syscall::debug_nop()?;
+        let t1 = mtime_value();
+        total += t1 - t0;
+    }
+    pw_log::info!(
+        "Performed {} syscalls in {} rv_timer ticks.",
+        n as usize,
+        total as u64,
+    );
+    let average = total / (n as u64);
+    pw_log::info!("Average latency: {} rv_timer ticks", average as u64);
+
+    let cpu_clocks = average * KernelConfig::SYSTEM_CLOCK_HZ / IO_CLOCK_HZ;
+    pw_log::info!("Average latency: {} cpu clocks", cpu_clocks as u64);
+    Ok(())
+}
+
+#[entry]
+fn entry() -> ! {
+    let result = measure_nop_syscall(100);
+    syscall::debug_shutdown(result).unwrap();
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    pw_log::error!("PANIC: syscall latency");
+    loop {}
+}

--- a/target/veer/syscall_latency/system.json5
+++ b/target/veer/syscall_latency/system.json5
@@ -1,0 +1,40 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0x40000000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x40040000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "syscall_latency",
+      flash_size_bytes: 32768,
+      ram_size_bytes: 4096,
+      process: {
+        name: "syscall latency",
+        memory_mappings: [
+          {
+            name: "MCI",
+            type: "device",
+            start_address: 0x21000000,
+            size_bytes: 0x100,
+          },
+        ],
+        threads: [
+          {
+            name: "syscall_latency",
+            stack_size_bytes: 4096,
+          },
+        ],
+      },
+    },
+  ],
+}

--- a/target/veer/syscall_latency/target.rs
+++ b/target/veer/syscall_latency/target.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![no_main]
+
+use entry::exit;
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, kernel as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey Syscall Latency Test";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => {
+                pw_log::info!("PASS");
+                exit(0);
+            }
+            _ => {
+                pw_log::info!("FAIL: {}", code as u32);
+                exit(code);
+            }
+        };
+    }
+}
+
+declare_target!(Target);

--- a/target/veer/target.ld.jinja
+++ b/target/veer/target.ld.jinja
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache-2.0 license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This relatively simplified linker script will work with many RISC-V cores
+ * that have on-board memory-mapped RAM and FLASH. For more
+ * complex projects and devices, it's possible this linker script will not be
+ * sufficient as-is.
+ *
+ * This linker script is likely not suitable for a project with a bootloader.
+ */
+
+MEMORY
+{
+  /* Internal SRAM */
+  RAM(rw) : ORIGIN = 0x40000000, LENGTH = 0x60000
+
+  /* Each memory region above has an associated .*.unused_space section that
+   * overlays the unused space at the end of the memory segment. These segments
+   * are used by pw_bloat.bloaty_config to create the utilization data source
+   * for bloaty size reports.
+   *
+   * These sections MUST be located immediately after the last section that is
+   * placed in the respective memory region or lld will issue a warning like:
+   *
+   *   warning: ignoring memory region assignment for non-allocatable section
+   *      '.FLASH.unused_space'
+   *
+   * If this warning occurs, it's also likely that LLD will have created quite
+   * large padded regions in the ELF file due to bad cursor operations. This
+   * can cause ELF files to balloon from hundreds of kilobytes to hundreds of
+   * megabytes.
+   *
+   * Attempting to add sections to the memory region AFTER the unused_space
+   * section will cause the region to overflow.
+   */
+}
+
+SECTIONS
+{
+  /* Main executable code. */
+  .code : ALIGN(4)
+  {
+    _code_start = .;
+    /* Put reset handler first in .text section so it ends up as the entry */
+    /* point of the program. */
+    KEEP(*(.init));
+    KEEP(*(.init.rust));
+    . = ALIGN(4);
+
+    /* Application code. */
+    *(.text)
+    *(.text*)
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* The trap handler needs to be in the code section. */
+    *(.trap)
+
+    /* OpenTitan requires the code start/end to be 4-byte aligned. */
+    . = ALIGN(4);
+    _code_end = .;
+
+    /* Constants.*/
+    *(.rodata)
+    *(.rodata*)
+
+    /* .preinit_array, .init_array, .fini_array are used by libc.
+     * Each section is a list of function pointers that are called pre-main and
+     * post-exit for object initialization and tear-down.
+     * Since the region isn't explicitly referenced, specify KEEP to prevent
+     * link-time garbage collection. SORT is used for sections that have strict
+     * init/de-init ordering requirements. */
+    . = ALIGN(4);
+    PROVIDE_HIDDEN(__preinit_array_start = .);
+    KEEP(*(.preinit_array*))
+    PROVIDE_HIDDEN(__preinit_array_end = .);
+
+    PROVIDE_HIDDEN(__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array*))
+    PROVIDE_HIDDEN(__init_array_end = .);
+
+    PROVIDE_HIDDEN(__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array*))
+    PROVIDE_HIDDEN(__fini_array_end = .);
+  } >RAM
+
+  /* Explicitly initialized global and static data. (.data)*/
+  .static_init_ram : ALIGN(4)
+  {
+    *(.data)
+    *(.data*)
+    . = ALIGN(4);
+  } >RAM
+
+  .RAM.kernel_end (NOLOAD) : ALIGN(4)
+  {
+    /*
+     * The end of the kernel text and data sections.
+     * This symbol is used to compute the end of the kernel read-only data
+     * segment in the ePMP configuration.
+     */
+    _kernel_end = .;
+  } >RAM
+
+  /* Represents unused space in the FLASH segment. This MUST be the last section
+   * assigned to the FLASH region.
+   */
+  .RAM.unused_space (NOLOAD) : ALIGN(4)
+  {
+  } >RAM
+
+  /* The .zero_init_ram, .heap, and .stack sections below require (NOLOAD)
+   * annotations for LLVM lld, but not GNU ld, because LLVM's lld intentionally
+   * interprets the linker file differently from ld:
+   *
+   * https://discourse.llvm.org/t/lld-vs-ld-section-type-progbits-vs-nobits/5999/3
+   *
+   * Zero initialized global/static data (.bss) is initialized in
+   * pw_boot_Entry() via memset(), so the section doesn't need to be loaded from
+   * flash. The .heap and .stack sections don't require any initialization,
+   * as they only represent allocated memory regions, so they also do not need
+   * to be loaded.
+   */
+  .zero_init_ram (NOLOAD) : ALIGN(4)
+  {
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+  } >RAM
+
+  .heap (NOLOAD) : ALIGN(4)
+  {
+    pw_boot_heap_low_addr = .;
+    . = . + 0;
+    . = ALIGN(4);
+    pw_boot_heap_high_addr = .;
+  } >RAM
+
+  /* Link-time check for stack overlaps.
+   *
+   */
+  .stack (NOLOAD) :
+  {
+    /* Set the address that the main stack pointer should be initialized to. */
+    pw_boot_stack_low_addr = .;
+    HIDDEN(_stack_size = ORIGIN(RAM) + LENGTH(RAM) - .);
+    /* Align the stack to a lower address to ensure it isn't out of range. */
+    HIDDEN(_stack_high = (. + _stack_size) & ~0x7);
+    ASSERT(_stack_high - . >= 1K,
+           "Error: Not enough RAM for desired minimum stack size.");
+    . = _stack_high;
+    pw_boot_stack_high_addr = .;
+  } >RAM
+
+  /* Represents unused space in the RAM segment. This MUST be the last section
+   * assigned to the RAM region.
+   */
+  .RAM.unused_space (NOLOAD) : ALIGN(4)
+  {
+    . = ABSOLUTE(ORIGIN(RAM) + LENGTH(RAM));
+  } >RAM
+
+  /* Strip unnecessary stuff */
+  /DISCARD/ : { *(.comment .note .eh_frame .eh_frame_hdr) }
+}
+
+/* Symbols used by core_init.c: */
+/* Start of .static_init_ram in RAM. */
+_pw_static_init_flash_start = LOADADDR(.static_init_ram);
+
+/* Region of .static_init_ram in RAM. */
+_pw_static_init_ram_start = ADDR(.static_init_ram);
+_pw_static_init_ram_end = _pw_static_init_ram_start + SIZEOF(.static_init_ram);
+
+/* Region of .zero_init_ram. */
+_pw_zero_init_ram_start = ADDR(.zero_init_ram);
+_pw_zero_init_ram_end = _pw_zero_init_ram_start + SIZEOF(.zero_init_ram);
+
+/* Symbols needed for the Rust riscv-rt crate. */
+_sbss = _pw_zero_init_ram_start;
+_ebss = _pw_zero_init_ram_end;
+_sdata = _pw_static_init_ram_start;
+_edata = _pw_static_init_ram_end;
+_sidata = LOADADDR(.static_init_ram);
+REGION_ALIAS("REGION_TEXT", RAM);
+REGION_ALIAS("REGION_RODATA", RAM);
+REGION_ALIAS("REGION_DATA", RAM);
+REGION_ALIAS("REGION_BSS", RAM);
+REGION_ALIAS("REGION_HEAP", RAM);
+REGION_ALIAS("REGION_STACK", RAM);
+
+_stext = ORIGIN(REGION_TEXT);
+_heap_size = 1K; /* Set heap size to 1KB */
+_max_hart_id = 1; /* Two harts present */
+_hart_stack_size = 1K; /* Set stack size per hart to 1KB */
+_stack_start = _stack_high;
+
+_ram_start = ORIGIN(RAM);
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
+
+PROVIDE(InstructionMisaligned = ExceptionHandler);
+PROVIDE(InstructionFault = ExceptionHandler);
+PROVIDE(IllegalInstruction = ExceptionHandler);
+PROVIDE(Breakpoint = ExceptionHandler);
+PROVIDE(LoadMisaligned = ExceptionHandler);
+PROVIDE(LoadFault = ExceptionHandler);
+PROVIDE(StoreMisaligned = ExceptionHandler);
+PROVIDE(StoreFault = ExceptionHandler);;
+PROVIDE(UserEnvCall = ExceptionHandler);
+PROVIDE(SupervisorEnvCall = ExceptionHandler);
+PROVIDE(MachineEnvCall = ExceptionHandler);
+PROVIDE(InstructionPageFault = ExceptionHandler);
+PROVIDE(LoadPageFault = ExceptionHandler);
+PROVIDE(StorePageFault = ExceptionHandler);
+
+PROVIDE(SupervisorSoft = DefaultHandler);
+PROVIDE(MachineSoft = DefaultHandler);
+PROVIDE(SupervisorTimer = DefaultHandler);
+PROVIDE(MachineTimer = DefaultHandler);
+PROVIDE(SupervisorExternal = DefaultHandler);
+PROVIDE(MachineExternal = DefaultHandler);
+
+PROVIDE(DefaultHandler = DefaultInterruptHandler);
+PROVIDE(ExceptionHandler = DefaultExceptionHandler);
+
+PROVIDE(__pre_init = default_pre_init);
+PROVIDE(_setup_interrupts = default_setup_interrupts);
+PROVIDE(_mp_hook = default_mp_hook);
+PROVIDE(_start_trap = default_start_trap);
+
+
+/* These symbols are used by pw_bloat.bloaty_config to create the memoryregions
+ * data source for bloaty in this format (where the optional _N defaults to 0):
+ * pw_bloat_config_memory_region_NAME_{start,end}{_N,} */
+pw_bloat_config_memory_region_FLASH_start = ORIGIN(RAM);
+pw_bloat_config_memory_region_FLASH_end = ORIGIN(RAM) + LENGTH(RAM);
+pw_bloat_config_memory_region_RAM_start = ORIGIN(RAM);
+pw_bloat_config_memory_region_RAM_end = ORIGIN(RAM) + LENGTH(RAM);
+
+/*
+ * Pigweed linker sections.
+ */
+{% include "pigweed_linker_sections.ld.jinja" %}

--- a/target/veer/threads/kernel/BUILD.bazel
+++ b/target/veer/threads/kernel/BUILD.bazel
@@ -1,0 +1,73 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@pigweed//pw_kernel/tooling/panic_detector:rust_binary_no_panics_test.bzl", "rust_binary_no_panics_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/veer:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/veer/tooling:caliptra_runner.bzl", "caliptra_runner", "caliptra_test")
+
+system_image(
+    name = "threads",
+    kernel = ":target",
+    platform = "//target/veer",
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/veer:linker_script_template",
+)
+
+rust_binary_no_panics_test(
+    name = "no_panics_test",
+    binary = ":threads",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/veer:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/tests/threads/kernel:threads",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+caliptra_runner(
+    name = "threads_runner_emulator",
+    interface = "emulator",
+    tags = ["manual"],
+    target = ":threads",
+)
+
+caliptra_test(
+    name = "threads_runner_emulator_test",
+    interface = "emulator",
+    tags = ["manual"],
+    target = ":threads",
+)

--- a/target/veer/threads/kernel/system.json5
+++ b/target/veer/threads/kernel/system.json5
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+}

--- a/target/veer/threads/kernel/target.rs
+++ b/target/veer/threads/kernel/target.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![no_main]
+
+use arch_riscv::Arch;
+use entry::exit;
+use target_common::{declare_target, TargetInterface};
+use {codegen as _, console_backend as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Caliptra-MCU Kernelspace Threads";
+
+    fn main() -> ! {
+        static mut APP_STATE: threads::AppState<Arch> = threads::AppState::new(Arch);
+        // SAFETY: `main` is only executed once, so we never generate more
+        // than one `&mut` reference to `APP_STATE`.
+        #[allow(static_mut_refs)]
+        match threads::main(Arch, unsafe { &mut APP_STATE }) {
+            Ok(()) => {
+                pw_log::info!("PASS");
+                exit(0);
+            }
+            Err(e) => {
+                pw_log::info!("FAIL: {}", e as u32);
+                exit(e as u32);
+            }
+        };
+    }
+}
+
+declare_target!(Target);

--- a/target/veer/tooling/BUILD.bazel
+++ b/target/veer/tooling/BUILD.bazel
@@ -1,0 +1,49 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_build:pw_py_importable_runfile.bzl", "pw_py_importable_runfile")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+pw_py_importable_runfile(
+    name = "emulator-cptra-rom-runfiles",
+    src = "@caliptra_devbundle//:emulator/cptra-rom.bin",
+    executable = False,
+    import_location = "caliptra.emulator_cptra_rom",
+)
+
+pw_py_importable_runfile(
+    name = "emulator-cptra-firmware-runfiles",
+    src = "@caliptra_devbundle//:emulator/cptra-firmware.bin",
+    executable = False,
+    import_location = "caliptra.emulator_cptra_firmware",
+)
+
+pw_py_importable_runfile(
+    name = "emulator-mcu-rom-runfiles",
+    src = "@caliptra_devbundle//:emulator/mcu-rom.bin",
+    executable = False,
+    import_location = "caliptra.emulator_mcu_rom",
+)
+
+pw_py_importable_runfile(
+    name = "emulator-exe-runfiles",
+    src = "@caliptra_devbundle//:tools/emulator",
+    executable = True,
+    import_location = "caliptra.emulator_exe",
+)
+
+py_binary(
+    name = "caliptra_runner",
+    srcs = [
+        "caliptra_runner.py",
+    ],
+    main = "caliptra_runner.py",
+    deps = [
+        "emulator-cptra-firmware-runfiles",
+        "emulator-cptra-rom-runfiles",
+        "emulator-exe-runfiles",
+        "emulator-mcu-rom-runfiles",
+        "@pigweed//pw_tokenizer/py:detokenize",
+        "@rules_python//python/runfiles",
+    ],
+)

--- a/target/veer/tooling/caliptra_runner.bzl
+++ b/target/veer/tooling/caliptra_runner.bzl
@@ -1,0 +1,128 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+"""A rule for running a pigweed system_image in a calptra-mcu development environment"""
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "SystemImageInfo")
+
+def _target_type_transition_impl(_, attr):
+    if attr.interface == "fpga":
+        return {"//target/veer:target_type": "fpga"}
+    if attr.interface == "emulator":
+        return {"//target/veer:target_type": "emulator"}
+
+    return {"//target/veer:target_type": "silicon"}
+
+_target_type_transition = transition(
+    implementation = _target_type_transition_impl,
+    inputs = [],
+    outputs = ["//target/veer:target_type"],
+)
+
+def _caliptra_runner_impl(ctx):
+    system_image_info = ctx.attr.target[0][SystemImageInfo]
+    bin_file = system_image_info.bin
+    elf_file = system_image_info.elf
+    runner = ctx.executable._caliptra_runner
+
+    manifest = ctx.actions.declare_file("{}.manifest".format(ctx.attr.name))
+    ctx.actions.run(
+        inputs = [
+            bin_file,
+            ctx.file.caliptra_rom,
+            ctx.file.caliptra_firmware,
+        ],
+        outputs = [manifest],
+        executable = ctx.executable._signer,
+        env = {"RUST_BACKTRACE": "1"},
+        arguments = [
+            "auth-manifest",
+            "create",
+            "--mcu_image={},0x4000000,0,2,2".format(bin_file.path),
+            "--caliptra_rom={}".format(ctx.file.caliptra_rom.path),
+            "--caliptra_firmware={}".format(ctx.file.caliptra_firmware.path),
+            "--vendor_pk_hash={}".format(ctx.attr.vendor_pk_hash),
+            "--output={}".format(manifest.path),
+        ],
+    )
+
+    run_script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+
+    # TODO: currently, the caliptra rom, firmware and mcu-rom are hardcoded in the runner python script.
+    # Perhaps these shoulc be arguments to the script instead.
+    ctx.actions.write(
+        output = run_script,
+        is_executable = True,
+        content = """#!/bin/bash
+{runner} --interface {interface} --elf {elf} --bin {bin} --manifest {manifest} --vendor-pk-hash {vendor_pk_hash} {optional_args}
+""".format(
+            runner = runner.short_path,
+            interface = ctx.attr.interface,
+            elf = elf_file.short_path,
+            bin = bin_file.short_path,
+            manifest = manifest.short_path,
+            vendor_pk_hash = ctx.attr.vendor_pk_hash,
+            optional_args = "",
+        ),
+    )
+
+    runner_files_depset = ctx.attr._caliptra_runner[DefaultInfo].default_runfiles.files
+
+    return [DefaultInfo(
+        runfiles = ctx.runfiles(
+            files = [manifest, bin_file, runner],
+            transitive_files = runner_files_depset,
+        ),
+        executable = run_script,
+    )]
+
+_BASE_ATTRS = {
+    "interface": attr.string(
+        doc = "The interface to use.",
+        mandatory = True,
+    ),
+    "target": attr.label(
+        doc = "The system_image target to run.",
+        mandatory = True,
+        providers = [SystemImageInfo],
+        cfg = _target_type_transition,
+    ),
+    "_caliptra_runner": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = "//target/veer/tooling:caliptra_runner",
+    ),
+    "_signer": attr.label(
+        executable = True,
+        allow_single_file = True,
+        cfg = "exec",
+        default = "@caliptra_devbundle//:tools/signer",
+        doc = "caliptra signer",
+    ),
+    "caliptra_rom": attr.label(
+        allow_single_file = True,
+        default = "@caliptra_devbundle//:emulator/cptra-rom.bin",
+        doc = "caliptra ROM",
+    ),
+    "caliptra_firmware": attr.label(
+        allow_single_file = True,
+        default = "@caliptra_devbundle//:emulator/cptra-firmware.bin",
+        doc = "caliptra firmware",
+    ),
+    "vendor_pk_hash": attr.string(
+        default = "b17ca877666657ccd100e6926c7206b60c995cb68992c6c9baefce728af05441dee1ff415adfc187e1e4edb4d3b2d909",
+        doc = "SHA384 of vendor public key",
+    ),
+}
+
+caliptra_runner = rule(
+    implementation = _caliptra_runner_impl,
+    executable = True,
+    attrs = _BASE_ATTRS,
+)
+
+caliptra_test = rule(
+    implementation = _caliptra_runner_impl,
+    test = True,
+    attrs = _BASE_ATTRS,
+)

--- a/target/veer/tooling/caliptra_runner.py
+++ b/target/veer/tooling/caliptra_runner.py
@@ -1,0 +1,204 @@
+# Copyright 2025 The Pigweed Authors
+# Licensed under the Apache-2.0 license
+"""Utility to invoke the caliptra emulator and pipe the output through the detokenizer."""
+
+import argparse
+import logging
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import pathlib
+
+from pathlib import Path
+from pw_tokenizer import detokenize
+
+_LOG = logging.getLogger(__name__)
+_LOG.setLevel(logging.INFO)
+
+try:
+
+    import caliptra.emulator_cptra_rom  # type: ignore
+    import caliptra.emulator_cptra_firmware  # type: ignore
+    import caliptra.emulator_mcu_rom  # type: ignore
+    import caliptra.emulator_exe  # type: ignore
+    from python.runfiles import runfiles  # type: ignore
+
+    r = runfiles.Create()
+    _CPTRA_ROM = r.Rlocation(*caliptra.emulator_cptra_rom.RLOCATION)
+    _CPTRA_FIRMWARE = r.Rlocation(*caliptra.emulator_cptra_firmware.RLOCATION)
+    _MCU_ROM = r.Rlocation(*caliptra.emulator_mcu_rom.RLOCATION)
+    _EMULATOR = r.Rlocation(*caliptra.emulator_exe.RLOCATION)
+except ImportError as e:
+    _LOG.fatal("runfiles could not open resources: %r", e)
+
+
+def _parse_args():
+    """Parse and return command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--interface",
+        type=str,
+        help="interface type",
+    )
+    parser.add_argument(
+        "--elf",
+        type=pathlib.Path,
+        help="elf file ",
+    )
+    parser.add_argument(
+        "--bin",
+        type=pathlib.Path,
+        help="bin file",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=pathlib.Path,
+        help="authorization manifest",
+    )
+    parser.add_argument(
+        "--vendor-pk-hash",
+        type=str,
+        help="SHA384 of public keys",
+    )
+
+    return parser.parse_args()
+
+
+def _detokenizer(image: Path, tokenized_file: Path, finished: threading.Event):
+    try:
+        detokenizer = detokenize.Detokenizer(image)
+        line_buffer = ""
+        with open(tokenized_file, "r", buffering=1) as f:
+            while not finished.is_set():
+                try:
+                    chunk = f.readline()
+                    if chunk:
+                        # qemu may not write a complete line, so buffer
+                        # the chunks until there is a complete line to
+                        # pass to the detokenizer.
+                        line_buffer += chunk
+
+                        # Use a while loop, as there could also potentially
+                        # be multiple lines printed in-between iterations.
+                        while "\n" in line_buffer:
+                            newline_pos = line_buffer.find("\n") + 1
+                            complete_line = line_buffer[:newline_pos]
+                            if not complete_line.endswith("\r\n"):
+                                complete_line = complete_line.replace("\n", "\r\n")
+                            detokenizer.detokenize_text_to_file(
+                                complete_line, sys.stdout.buffer
+                            )
+                            sys.stdout.flush()
+
+                            line_buffer = line_buffer[newline_pos:]
+                except BlockingIOError:
+                    # If writing to stdout too fast, it's sometimes possible
+                    # to get BlockingIOError due to the stdout buffer being
+                    # full, so sleep and try again.
+                    time.sleep(0.1)
+
+            # detokenize any remaining data in the buffer.
+            if line_buffer:
+                detokenizer.detokenize_text_to_file(complete_line, sys.stdout.buffer)
+                sys.stdout.flush()
+    except OSError as e:
+        print(f"Exception opening file {e}", file=sys.stderr)
+
+
+def load_and_run(
+    image: Path, interface: str, manifest: str, vendor_pk_hash: str,
+) -> list[str]:
+    """Prepare arguments to load an image into a board and spawn a console."""
+    if interface == "emulator":
+        return [
+            _EMULATOR,
+            f"--rom={_MCU_ROM}",
+            f"--firmware={image}",
+            f"--caliptra-rom={_CPTRA_ROM}",
+            f"--caliptra-firmware={_CPTRA_FIRMWARE}",
+            f"--soc-manifest={manifest}",
+            f"--vendor-pk-hash={vendor_pk_hash}",
+            "--i3c-port=65534",
+            "--rom-offset=0x80000000",
+            "--rom-size=0x8000",
+            "--dccm-offset=0x50000000",
+            "--dccm-size=0x4000",
+            "--sram-offset=0x40000000",
+            "--sram-size=0x80000",
+            "--pic-offset=0x60000000",
+            "--i3c-offset=0x20004000",
+            "--i3c-size=0x1000",
+            "--mci-offset=0x21000000",
+            "--mci-size=0xe00000",
+            "--mbox-offset=0x30020000",
+            "--mbox-size=0x28",
+            "--soc-offset=0x30030000",
+            "--soc-size=0x5e0",
+            "--otp-offset=0x70000000",
+            "--otp-size=0x140",
+            "--lc-offset=0x70000400",
+            "--lc-size=0x8c",
+
+        ]
+    else:
+        raise Exception("unknown mechanism", mechanism)
+
+
+def simple_console(cmd: list[str]):
+    """Invoke for a simple (non-tokenized) console."""
+    _LOG.info("Invoking mcu emulator: %s", cmd)
+    process = subprocess.run(cmd, check=False)
+    return process.returncode
+
+
+def tokenized_console(cmd: list[str]):
+    """Invoke for a tokenized console."""
+    _LOG.info("Invoking mcu emulator: %s", cmd)
+    with tempfile.NamedTemporaryFile() as f:
+        with subprocess.Popen(
+            args=cmd,
+            stdout=f,
+        ) as proc:
+            # Capturing the sub process stdout or stderr and then writing to
+            # stdout can cause deadlocks (see
+            # https://docs.python.org/3/library/subprocess.html#subprocess.Popen.stderr)
+            # due to a write buffer (child process) filling up the pipe
+            # buffer before the parent process can consume it.
+            # To work around this, write to a temp file, and have the
+            # detokenizer poll and detokenize the temp file.
+            finished_event = threading.Event()
+            stdout_thread = threading.Thread(
+                target=_detokenizer,
+                args=(Path(args.elf), Path(f.name), finished_event),
+                daemon=True,
+            )
+            stdout_thread.start()
+            out, err = proc.communicate()
+            finished_event.set()
+            if out:
+                print(out)
+            if err:
+                print(err)
+            return_code = proc.returncode
+    stdout_thread.join()
+    return return_code
+
+
+def _main(args) -> int:
+    cmd = load_and_run(
+        args.bin, args.interface, args.manifest, args.vendor_pk_hash,
+    )
+    # TODO(cfrantz): add support for the tokenized console.
+    return_code = simple_console(cmd)
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    _main(_parse_args())

--- a/target/veer/unittest_runner/BUILD.bazel
+++ b/target/veer/unittest_runner/BUILD.bazel
@@ -1,0 +1,59 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/veer:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/veer/tooling:caliptra_runner.bzl", "caliptra_test")
+
+system_image(
+    name = "unittest_runner",
+    kernel = ":target",
+    platform = "//target/veer",
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/veer:linker_script_template",
+)
+
+caliptra_test(
+    name = "emulator_test",
+    interface = "emulator",
+    target = ":unittest_runner",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/veer:entry",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/kernel/tests:integration_tests",
+        "@pigweed//pw_kernel/lib/unittest:unittest_core",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)

--- a/target/veer/unittest_runner/system.json5
+++ b/target/veer/unittest_runner/system.json5
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0x40000000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x40040000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+}

--- a/target/veer/unittest_runner/target.rs
+++ b/target/veer/unittest_runner/target.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+
+use entry::exit;
+use target_common::{declare_target, TargetInterface};
+use unittest_core::TestsResult;
+use {codegen as _, console_backend as _, integration_tests as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Caliptra MCU Unittest Runner";
+
+    fn main() -> ! {
+        // riscv does not run ctors, so we do it manually. Note that this is
+        // required in order to register tests, which is a prerequisite to
+        // calling `run_all_tests` below.
+        unsafe { target_common::run_ctors() };
+
+        match unittest_core::run_all_tests!() {
+            TestsResult::AllPassed => {
+                pw_log::info!("PASS");
+                exit(0);
+            }
+            TestsResult::SomeFailed => {
+                pw_log::info!("FAIL: 1");
+                exit(1);
+            }
+        }
+    }
+}
+
+declare_target!(Target);


### PR DESCRIPTION
This is a early port of the pigweed kernel and some of its test programs to the VeeR core present in caliptra-mcu.

1. I'm creating a "devbundle" from the caliptra repos to avoid having to make bazel interact with a (IMHO) very customized cargo+xtask configuration in calipta-mcu.  Some time should be spent seeing if bazel can work with the caliptra repos.  The binaries in the devbundle were built from [my fork](https://github.com/cfrantz/caliptra-mcu-sw/tree/standalone) where I added the dev-bundle xtask.  I am not a caliptra expert and make no claims that I'm doing things "the right way" in my fork.
2. The IPC test program isn't working.  I haven't yet investigated why.
