### PR TITLE
fix path in "Build and Deploy to GitHub Pages" workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -37,7 +37,7 @@ jobs:
       id: build-docs
       run: |
         bazel build //docs
-        echo "path=$(bazel cquery --output=files //docs 2>/dev/null)" >> "$GITHUB_OUTPUT"
+        echo "path=$(bazel cquery --output=files --platform_suffix= --@@pigweed+//pw_kernel:enable_tests=false //docs 2>/dev/null)" >> "$GITHUB_OUTPUT"
 
     - name: Setup Pages
       uses: actions/configure-pages@v6


### PR DESCRIPTION
workflow was incorrectly calculating file path using test build parameters, causing workflow to fail