### PR TITLE
earlgrey: Implement GPIO and Pinmux drivers

### DIFF
--- a/target/earlgrey/BUILD.bazel
+++ b/target/earlgrey/BUILD.bazel
@@ -89,6 +89,34 @@ rust_library(
 )
 
 rust_library(
+    name = "gpio",
+    srcs = ["gpio.rs"],
+    crate_name = "earlgrey_gpio",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pinmux",
+        "//hal/blocking",
+        "//target/earlgrey/registers",
+        "@ureg",
+    ],
+)
+
+rust_library(
+    name = "pinmux",
+    srcs = ["pinmux.rs"],
+    crate_name = "earlgrey_pinmux",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//target/earlgrey/registers",
+        "@ureg",
+    ],
+)
+
+rust_library(
     name = "console",
     srcs = ["console.rs"],
     crate_name = "console_backend",

--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -1,0 +1,33 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+
+rust_library(
+    name = "gpio",
+    srcs = ["gpio.rs"],
+    crate_name = "earlgrey_gpio",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pinmux",
+        "//hal/blocking",
+        "//target/earlgrey/registers",
+        "@ureg",
+    ],
+)
+
+rust_library(
+    name = "pinmux",
+    srcs = ["pinmux.rs"],
+    crate_name = "earlgrey_pinmux",
+    edition = "2024",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//target/earlgrey/registers",
+        "@ureg",
+    ],
+)

--- a/target/earlgrey/drivers/gpio.rs
+++ b/target/earlgrey/drivers/gpio.rs
@@ -1,0 +1,318 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+
+use earlgrey_pinmux::{EarlGreyPinmux, Pad, PadConfig, Pull};
+use core::fmt::Debug;
+use openprot_hal_blocking::gpio_port::{
+    EdgeSensitivity, GpioError, GpioErrorKind, GpioErrorType, GpioInterrupt, GpioPort,
+    InterruptOperation, PinMask,
+};
+use registers::gpio;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EarlGreyGpioError {
+    HardwareFailure,
+    InvalidConfiguration,
+}
+
+// TODO: figure out what we're doing with precise errors.
+impl GpioError for EarlGreyGpioError {
+    fn kind(&self) -> GpioErrorKind {
+        match self {
+            EarlGreyGpioError::HardwareFailure => GpioErrorKind::HardwareFailure,
+            EarlGreyGpioError::InvalidConfiguration => GpioErrorKind::UnsupportedConfiguration,
+        }
+    }
+}
+
+pub struct EarlGreyGpio {
+    registers: gpio::RegisterBlock<ureg::RealMmioMut<'static>>,
+    pinmux: EarlGreyPinmux,
+}
+
+impl EarlGreyGpio {
+    /// Create a new instance of the EarlGrey GPIO driver using real MMIO.
+    /// 
+    /// # Safety
+    /// 
+    /// The caller must ensure that they have exclusive access to the GPIO and Pinmux peripherals.
+    pub unsafe fn new() -> Self {
+        Self {
+            registers: unsafe { gpio::RegisterBlock::new(gpio::Gpio::PTR) },
+            pinmux: unsafe { EarlGreyPinmux::new() },
+        }
+    }
+
+    /// Read current state of output pins.
+    /// 
+    /// This is a target-specific extension not yet in the core HAL.
+    pub fn read_output(&self) -> Result<GpioMask, EarlGreyGpioError> {
+        Ok(GpioMask(self.registers.direct_out().read()))
+    }
+
+    /// Read current output enable configuration.
+    pub fn read_oe(&self) -> Result<GpioMask, EarlGreyGpioError> {
+        Ok(GpioMask(self.registers.direct_oe().read()))
+    }
+}
+
+impl GpioErrorType for EarlGreyGpio {
+    type Error = EarlGreyGpioError;
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct GpioMask(pub u32);
+
+impl PinMask for GpioMask {
+    fn empty() -> Self {
+        Self(0)
+    }
+
+    fn all() -> Self {
+        Self(0xFFFF_FFFF)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    fn contains(&self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    fn union(&self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    fn intersection(&self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    fn toggle(&self) -> Self {
+        Self(!self.0)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum GpioPin {
+    Pin0 = 0, Pin1 = 1, Pin2 = 2, Pin3 = 3, Pin4 = 4, Pin5 = 5, Pin6 = 6, Pin7 = 7,
+    Pin8 = 8, Pin9 = 9, Pin10 = 10, Pin11 = 11, Pin12 = 12, Pin13 = 13, Pin14 = 14, Pin15 = 15,
+    Pin16 = 16, Pin17 = 17, Pin18 = 18, Pin19 = 19, Pin20 = 20, Pin21 = 21, Pin22 = 22, Pin23 = 23,
+    Pin24 = 24, Pin25 = 25, Pin26 = 26, Pin27 = 27, Pin28 = 28, Pin29 = 29, Pin30 = 30, Pin31 = 31,
+}
+
+impl From<GpioPin> for GpioMask {
+    fn from(pin: GpioPin) -> Self {
+        Self(1 << (pin as u32))
+    }
+}
+
+pub struct EarlGreyPinConfig {
+    /// Whether the pins should be configured as inputs.
+    pub is_input: bool,
+    /// Whether the pins should be configured as outputs.
+    pub is_output: bool,
+    /// Whether to enable the 16-cycle input filter.
+    pub input_filter: bool,
+    /// Optional pad to connect these pins to. 
+    /// If multiple pins are specified in the mask, this should be None.
+    pub pad: Option<Pad>,
+    /// Pull-up/down configuration for the pad.
+    pub pull: Pull,
+}
+
+impl Default for EarlGreyPinConfig {
+    fn default() -> Self {
+        Self {
+            is_input: true,
+            is_output: false,
+            input_filter: false,
+            pad: None,
+            pull: Pull::None,
+        }
+    }
+}
+
+impl GpioPort for EarlGreyGpio {
+    type Config = EarlGreyPinConfig;
+    type Mask = GpioMask;
+
+    fn configure(&mut self, pins: Self::Mask, config: Self::Config) -> Result<(), Self::Error> {
+        // If a pad is provided, ensure only one pin is being configured
+        if config.pad.is_some() && (pins.0.count_ones() != 1) {
+            return Err(EarlGreyGpioError::InvalidConfiguration);
+        }
+
+        // Configure Output Enable
+        let lower_mask = pins.0 & 0xFFFF;
+        let upper_mask = (pins.0 >> 16) & 0xFFFF;
+
+        if lower_mask != 0 {
+            self.registers.masked_oe_lower().write(|w| {
+                w.mask(lower_mask)
+                    .data(if config.is_output { lower_mask } else { 0 })
+            });
+        }
+
+        if upper_mask != 0 {
+            self.registers.masked_oe_upper().write(|w| {
+                w.mask(upper_mask)
+                    .data(if config.is_output { upper_mask } else { 0 })
+            });
+        }
+
+        // Configure Input Filter
+        self.registers.ctrl_en_input_filter().modify(|w| {
+            if config.input_filter {
+                w | pins.0
+            } else {
+                w & !pins.0
+            }
+        });
+
+        // Handle Pinmux and Pad attributes
+        if let Some(pad) = config.pad {
+            let pin_idx = pins.0.trailing_zeros() as usize;
+            
+            // DIO pads are dedicated and don't require routing, 
+            // only attribute configuration.
+            if !pad.is_dio() {
+                if config.is_input {
+                    self.pinmux.connect_input(pin_idx, pad);
+                }
+                if config.is_output {
+                    self.pinmux.connect_output(pad, pin_idx);
+                }
+            }
+
+            self.pinmux.configure_pad(pad, &PadConfig {
+                pull: config.pull,
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+
+    fn set_reset(
+        &mut self,
+        set_mask: Self::Mask,
+        reset_mask: Self::Mask,
+    ) -> Result<(), Self::Error> {
+        // Process lower 16 bits
+        let set_lower = set_mask.0 & 0xFFFF;
+        let reset_lower = reset_mask.0 & 0xFFFF;
+        let lower_mask = set_lower | reset_lower;
+
+        if lower_mask != 0 {
+            self.registers.masked_out_lower().write(|w| {
+                w.mask(lower_mask).data(set_lower)
+            });
+        }
+
+        // Process upper 16 bits
+        let set_upper = (set_mask.0 >> 16) & 0xFFFF;
+        let reset_upper = (reset_mask.0 >> 16) & 0xFFFF;
+        let upper_mask = set_upper | reset_upper;
+
+        if upper_mask != 0 {
+            self.registers.masked_out_upper().write(|w| {
+                w.mask(upper_mask).data(set_upper)
+            });
+        }
+
+        Ok(())
+    }
+
+    fn read_input(&self) -> Result<Self::Mask, Self::Error> {
+        Ok(GpioMask(self.registers.data_in().read()))
+    }
+
+    fn toggle(&mut self, pins: Self::Mask) -> Result<(), Self::Error> {
+        let current = self.read_output()?;
+        let set_mask = GpioMask(pins.0 & !current.0);
+        let reset_mask = GpioMask(pins.0 & current.0);
+        self.set_reset(set_mask, reset_mask)
+    }
+}
+
+impl GpioInterrupt for EarlGreyGpio {
+    type Mask = GpioMask;
+
+    fn irq_configure(
+        &mut self,
+        mask: Self::Mask,
+        sensitivity: EdgeSensitivity,
+    ) -> Result<(), Self::Error> {
+        // Clear all sensitivity settings for these pins first
+        self.registers.intr_ctrl_en_rising().modify(|w| w & !mask.0);
+        self.registers.intr_ctrl_en_falling().modify(|w| w & !mask.0);
+        self.registers.intr_ctrl_en_lvlhigh().modify(|w| w & !mask.0);
+        self.registers.intr_ctrl_en_lvllow().modify(|w| w & !mask.0);
+
+        // Apply new sensitivity
+        match sensitivity {
+            EdgeSensitivity::RisingEdge => {
+                self.registers.intr_ctrl_en_rising().modify(|w| w | mask.0);
+            }
+            EdgeSensitivity::FallingEdge => {
+                self.registers.intr_ctrl_en_falling().modify(|w| w | mask.0);
+            }
+            EdgeSensitivity::BothEdges => {
+                self.registers.intr_ctrl_en_rising().modify(|w| w | mask.0);
+                self.registers.intr_ctrl_en_falling().modify(|w| w | mask.0);
+            }
+            EdgeSensitivity::HighLevel => {
+                self.registers.intr_ctrl_en_lvlhigh().modify(|w| w | mask.0);
+            }
+            EdgeSensitivity::LowLevel => {
+                self.registers.intr_ctrl_en_lvllow().modify(|w| w | mask.0);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn irq_control(
+        &mut self,
+        mask: Self::Mask,
+        operation: InterruptOperation,
+    ) -> Result<bool, Self::Error> {
+        match operation {
+            InterruptOperation::Enable => {
+                // Clear state first to avoid spurious interrupts (ported from pie-rot)
+                self.registers.intr_state().write(|_| mask.0);
+                self.registers.intr_enable().modify(|w| w | mask.0);
+                Ok(true)
+            }
+            InterruptOperation::Disable => {
+                self.registers.intr_enable().modify(|w| w & !mask.0);
+                Ok(true)
+            }
+            InterruptOperation::Clear => {
+                // In EarlGrey, writing 1 to intr_state clears the interrupt
+                self.registers.intr_state().write(|_| mask.0);
+                Ok(true)
+            }
+            InterruptOperation::IsPending => {
+                let state = self.registers.intr_state().read();
+                Ok((state & mask.0) != 0)
+            }
+        }
+    }
+
+    fn register_interrupt_handler<F>(
+        &mut self,
+        _mask: Self::Mask,
+        _handler: F,
+    ) -> Result<(), Self::Error>
+    where
+        F: FnMut(Self::Mask) + Send + 'static,
+    {
+        // In the OpenPRoT microkernel architecture, interrupts are handled
+        // via syscalls (wait on object) rather than registered callbacks.
+        Err(EarlGreyGpioError::InvalidConfiguration)
+    }
+}

--- a/target/earlgrey/drivers/pinmux.rs
+++ b/target/earlgrey/drivers/pinmux.rs
@@ -1,0 +1,129 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+
+use registers::pinmux;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Pad {
+    // MIO Pads (0-46)
+    IOA0 = 0, IOA1 = 1, IOA2 = 2, IOA3 = 3, IOA4 = 4, IOA5 = 5, IOA6 = 6, IOA7 = 7, IOA8 = 8,
+    IOB0 = 9, IOB1 = 10, IOB2 = 11, IOB3 = 12, IOB4 = 13, IOB5 = 14, IOB6 = 15, IOB7 = 16, IOB8 = 17,
+    IOB9 = 18, IOB10 = 19, IOB11 = 20, IOB12 = 21,
+    IOC0 = 22, IOC1 = 23, IOC2 = 24, IOC3 = 25, IOC4 = 26, IOC5 = 27, IOC6 = 28, IOC7 = 29, IOC8 = 30,
+    IOC9 = 31, IOC10 = 32, IOC11 = 33, IOC12 = 34,
+    IOR0 = 35, IOR1 = 36, IOR2 = 37, IOR3 = 38, IOR4 = 39, IOR5 = 40, IOR6 = 41, IOR7 = 42,
+    IOR10 = 43, IOR11 = 44, IOR12 = 45, IOR13 = 46,
+    // DIO Pads (47-62)
+    DIO0 = 47, DIO1 = 48, DIO2 = 49, DIO3 = 50, DIO4 = 51, DIO5 = 52, DIO6 = 53, DIO7 = 54,
+    DIO8 = 55, DIO9 = 56, DIO10 = 57, DIO11 = 58, DIO12 = 59, DIO13 = 60, DIO14 = 61, DIO15 = 62,
+}
+
+impl Pad {
+    pub fn is_dio(&self) -> bool {
+        (*self as u32) >= 47
+    }
+
+    pub fn dio_index(self) -> Option<usize> {
+        let index = self as usize;
+        if index >= 47 {
+            Some(index - 47)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Pull {
+    None,
+    Up,
+    Down,
+}
+
+pub struct PadConfig {
+    pub pull: Pull,
+    pub open_drain: bool,
+    pub invert: bool,
+}
+
+impl Default for PadConfig {
+    fn default() -> Self {
+        Self {
+            pull: Pull::None,
+            open_drain: false,
+            invert: false,
+        }
+    }
+}
+
+pub struct EarlGreyPinmux {
+    registers: pinmux::RegisterBlock<ureg::RealMmioMut<'static>>,
+}
+
+impl EarlGreyPinmux {
+    /// Create a new instance of the EarlGrey Pinmux driver.
+    /// 
+    /// # Safety
+    /// 
+    /// The caller must ensure that they have exclusive access to the Pinmux peripheral.
+    pub unsafe fn new() -> Self {
+        Self {
+            registers: unsafe { pinmux::RegisterBlock::new(pinmux::PinmuxAon::PTR) },
+        }
+    }
+
+    /// Connects a peripheral input to an MIO pad.
+    pub fn connect_input(&mut self, periph_input_idx: usize, pad: Pad) {
+        // MIO pads start at index 2 in periph_insel (0=Low, 1=High)
+        let periph_source = 2 + (pad as u32);
+        self.registers.mio_periph_insel()
+            .at(periph_input_idx)
+            .write(|w| w.in_(periph_source));
+    }
+
+    /// Connects an MIO pad to a peripheral output.
+    pub fn connect_output(&mut self, pad: Pad, periph_output_idx: usize) {
+        // Peripheral outputs start at index 3 in outsel (0=Low, 1=High, 2=HighZ)
+        let pad_source = 3 + (periph_output_idx as u32);
+        self.registers.mio_outsel()
+            .at(pad as usize)
+            .write(|w| w.out(pad_source));
+    }
+
+    pub fn configure_pad(&mut self, pad: Pad, config: &PadConfig) {
+        if let Some(dio_idx) = pad.dio_index() {
+            self.registers.dio_pad_attr()
+                .at(dio_idx)
+                .modify(|w| {
+                    w.pull_en(config.pull != Pull::None)
+                        .pull_select(|w| {
+                            if config.pull == Pull::Up {
+                                w.pull_up()
+                            } else {
+                                w.pull_down()
+                            }
+                        })
+                        .od_en(config.open_drain)
+                        .invert(config.invert)
+                });
+        } else {
+            self.registers.mio_pad_attr()
+                .at(pad as usize)
+                .modify(|w| {
+                    w.pull_en(config.pull != Pull::None)
+                        .pull_select(|w| {
+                            if config.pull == Pull::Up {
+                                w.pull_up()
+                            } else {
+                                w.pull_down()
+                            }
+                        })
+                        .od_en(config.open_drain)
+                        .invert(config.invert)
+                });
+        }
+    }
+}

--- a/target/earlgrey/tests/drivers/gpio/BUILD.bazel
+++ b/target/earlgrey/tests/drivers/gpio/BUILD.bazel
@@ -1,0 +1,93 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:rust_app.bzl", "rust_app")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+
+rust_app(
+    name = "test_gpio",
+    srcs = [
+        "test_gpio.rs",
+    ],
+    codegen_crate_name = "test_gpio_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking",
+        "//target/earlgrey/drivers:gpio",
+        "//target/earlgrey/drivers:pinmux",
+        "//target/earlgrey/registers",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+system_image(
+    name = "gpio",
+    apps = [
+        ":test_gpio",
+    ],
+    kernel = ":target",
+    platform = "//target/earlgrey",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/earlgrey:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/earlgrey:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+opentitan_test(
+    name = "gpio_verilator_test",
+    timeout = "eternal",
+    interface = "verilator",
+    tags = [
+        "nightly_test",
+        "verilator",
+    ],
+    target = ":gpio",
+)

--- a/target/earlgrey/tests/drivers/gpio/system.json5
+++ b/target/earlgrey/tests/drivers/gpio/system.json5
@@ -1,0 +1,49 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "test_gpio",
+      flash_size_bytes: 16384,
+      processes: [
+        {
+          name: "test_gpio",
+          ram_size_bytes: 4096,
+          objects: [],
+          memory_mappings: [
+            {
+              name: "gpio",
+              type: "device",
+              start_address: 0x40040000,
+              size_bytes: 0x40,
+            },
+            {
+              name: "pinmux",
+              type: "device",
+              start_address: 0x40460000,
+              size_bytes: 0x1000,
+            }
+          ],
+          threads: [
+            {
+              name: "main_thread",
+              kernel_stack_size_bytes: 2048,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/target/earlgrey/tests/drivers/gpio/target.rs
+++ b/target/earlgrey/tests/drivers/gpio/target.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use target_common::{TargetInterface, declare_target};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey GPIO Smoke Test";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/earlgrey/tests/drivers/gpio/test_gpio.rs
+++ b/target/earlgrey/tests/drivers/gpio/test_gpio.rs
@@ -1,0 +1,92 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+
+use earlgrey_gpio::{EarlGreyGpio, EarlGreyPinConfig, GpioMask, GpioPin};
+use earlgrey_pinmux::{Pad, Pull};
+use openprot_hal_blocking::gpio_port::{GpioPort, PinMask};
+use pw_status::Result;
+use userspace::{entry, syscall};
+
+fn test_gpio_basic() -> Result<()> {
+    let mut gpio = unsafe { EarlGreyGpio::new() };
+
+    // Test 1: Configure Pin 0 as output
+    pw_log::info!("Configuring Pin 0 as output");
+    gpio.configure(
+        GpioPin::Pin0.into(),
+        EarlGreyPinConfig {
+            is_input: false,
+            is_output: true,
+            input_filter: false,
+            pad: None, // Don't care about physical pad in Verilator for this basic test
+            pull: Pull::None,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    // Test 2: Set Pin 0 high
+    pw_log::info!("Setting Pin 0 high");
+    gpio.set_reset(GpioPin::Pin0.into(), GpioMask::empty())
+        .map_err(|_| pw_status::Error::Internal)?;
+
+    // In Verilator, data_in usually reflects data_out if OE is set (loopback behavior depends on testbench)
+    // For now, let's just check if we can read back our own output state using our target-specific method
+    let output = gpio.read_output().map_err(|_| pw_status::Error::Internal)?;
+    if !output.contains(GpioPin::Pin0.into()) {
+        pw_log::error!("Pin 0 output readback failed (expected High)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    // Test 3: Toggle Pin 0
+    pw_log::info!("Toggling Pin 0");
+    gpio.toggle(GpioPin::Pin0.into())
+        .map_err(|_| pw_status::Error::Internal)?;
+
+    let output = gpio.read_output().map_err(|_| pw_status::Error::Internal)?;
+    if output.contains(GpioPin::Pin0.into()) {
+        pw_log::error!("Pin 0 toggle failed (expected Low)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    // Test 4: Configure a Dedicated I/O (DIO) pin
+    // Note: Toggling DIOs via the GPIO block isn't possible in standard EarlGrey,
+    // but we can verify the configuration logic (attributes/pull-ups) works.
+    pw_log::info!("Configuring DIO 0 (Dedicated IO) with Pull-up");
+    gpio.configure(
+        GpioPin::Pin0.into(),
+        EarlGreyPinConfig {
+            is_input: true,
+            is_output: false,
+            input_filter: false,
+            pad: Some(Pad::DIO0),
+            pull: Pull::Up,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    Ok(())
+}
+
+#[entry]
+fn entry() -> ! {
+    pw_log::info!("🔄 RUNNING GPIO SMOKE TEST");
+    let ret = test_gpio_basic();
+
+    if ret.is_err() {
+        pw_log::error!("❌ FAIL");
+    } else {
+        pw_log::info!("✅ PASS");
+    }
+
+    let _ = syscall::debug_shutdown(ret);
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    pw_log::error!("FAIL: panic in gpio test");
+    loop {}
+}


### PR DESCRIPTION
- Implemented EarlGrey GPIO driver with HAL trait support
- Implemented EarlGrey Pinmux driver for pad routing
- Optimized for hardware masked registers and atomic updates
- Added Verilator smoke test for functional verification