### PR TITLE
veer: migrate system.json5 to new pw_kernel config schema

### DIFF
--- a/target/veer/ipc/user/system.json5
+++ b/target/veer/ipc/user/system.json5
@@ -17,37 +17,38 @@
     {
       name: "ipc",
       flash_size_bytes: 32768,
-      ram_size_bytes: 8192,
       processes: [
         {
           name: "initiator",
+          ram_size_bytes: 4096,
           objects: [
             {
-              name: "IPC",
+              name: "ipc",
               type: "channel_initiator",
               handler_process: "handler",
-              handler_object_name: "IPC",
+              handler_object_name: "ipc",
             },
           ],
           threads: [
             {
-              name: "initiator thread",
-              stack_size_bytes: 1024,
+              name: "initiator_thread",
+              kernel_stack_size_bytes: 1024,
             },
           ],
         },
         {
           name: "handler",
+          ram_size_bytes: 4096,
           objects: [
             {
-              name: "IPC",
+              name: "ipc",
               type: "channel_handler",
             },
           ],
           threads: [
             {
-              name: "handler thread",
-              stack_size_bytes: 1024,
+              name: "handler_thread",
+              kernel_stack_size_bytes: 1024,
             },
           ],
         },

--- a/target/veer/syscall_latency/system.json5
+++ b/target/veer/syscall_latency/system.json5
@@ -17,13 +17,13 @@
     {
       name: "syscall_latency",
       flash_size_bytes: 32768,
-      ram_size_bytes: 4096,
       processes: [
         {
-          name: "syscall latency",
+          name: "syscall_latency",
+          ram_size_bytes: 4096,
           memory_mappings: [
             {
-              name: "MCI",
+              name: "mci",
               type: "device",
               start_address: 0x21000000,
               size_bytes: 0x100,
@@ -32,7 +32,7 @@
           threads: [
             {
               name: "syscall_latency",
-              stack_size_bytes: 4096,
+              kernel_stack_size_bytes: 4096,
             },
           ],
         },


### PR DESCRIPTION
- Move `ram_size_bytes` from `apps[]` onto each `processes[]`, matching the new `pw_kernel` `SystemConfig` schema.
- Rename `threads[].stack_size_bytes` to `kernel_stack_size_bytes`.
- Lowercase object / memory-mapping names  and make thread/process names valid snake_case Rust identifiers.

Without this, `system_generator_bin` fails due to parser errors. 
