### PR TITLE
[caliptra] Fix sandbox leak.

### DIFF
--- a/third_party/caliptra/caliptra-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-sw/BUILD.bazel
@@ -8,6 +8,7 @@ load(
     "caliptra_firmware_bundle",
     "caliptra_rom_package",
 )
+load("//third_party/caliptra:cc_preprocess.bzl", "cc_preprocess")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -491,11 +492,11 @@ rust_library(
 # lands in this package's bin dir so OUT_DIR (set on caliptra_rom below) can
 # point at it — letting upstream main.rs compile with its verbatim
 # `include_str!(concat!(env!("OUT_DIR"), "/start_preprocessed.S"))`.
-genrule(
+cc_preprocess(
     name = "rom_start_preprocessed",
-    srcs = ["@caliptra_sw//:rom/dev/src/start.S"],
-    outs = ["start_preprocessed.S"],
-    cmd = "cpp -E $(location @caliptra_sw//:rom/dev/src/start.S) -o $@",
+    src = "@caliptra_sw//:rom/dev/src/start.S",
+    out = "start_preprocessed.S",
+    target_compatible_with = ["//third_party/caliptra/platforms:target_caliptra"],
 )
 
 # Linker scripts: source files must go through copy genrules so Bazel properly

--- a/third_party/caliptra/cc_preprocess.bzl
+++ b/third_party/caliptra/cc_preprocess.bzl
@@ -1,0 +1,45 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _cpp_preprocess_impl(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    # Use the C compiler with -E as it is the most reliable way to preprocess
+    c_compiler = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = "c-compile",
+    )
+
+    args = ctx.actions.args()
+    args.add("-E")
+    args.add(ctx.file.src.path)
+    args.add("-o", ctx.outputs.out.path)
+
+    ctx.actions.run(
+        outputs = [ctx.outputs.out],
+        inputs = [ctx.file.src] + cc_toolchain.all_files.to_list(),
+        executable = c_compiler,
+        arguments = [args],
+        mnemonic = "CppPreprocess",
+        use_default_shell_env = False,
+    )
+
+cc_preprocess = rule(
+    implementation = _cpp_preprocess_impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+        "src": attr.label(allow_single_file = True, mandatory = True),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+    incompatible_use_toolchain_transition = True,
+)


### PR DESCRIPTION
Add `cc_preprocess` rule to encapsulate toolchain preprocessor command used in Caliptra ROM targets. This is required to fix a sandbox violation where a previous genrule was calling a host tool to run the preprocessing command.