### PR TITLE
earlgrey: run opentitantool without a config file

### DIFF
--- a/target/earlgrey/tooling/opentitan_runner.py
+++ b/target/earlgrey/tooling/opentitan_runner.py
@@ -142,6 +142,7 @@ def transport_init(interface: str):
     subprocess.run(
         [
             _OTTO,
+            "--rcfile=",
             f"--interface={interface}",
             "transport",
             "init",
@@ -162,6 +163,7 @@ def load_bitstream(interface: str):
     subprocess.run(
         [
             _OTTO,
+            "--rcfile=",
             f"--interface={interface}",
             "fpga",
             "load-bitstream",
@@ -221,6 +223,7 @@ def load_and_run(
     return (
         [
             _OTTO,
+            "--rcfile=",
             f"--interface={interface}",
         ]
         + load_command


### PR DESCRIPTION
When running under bazel, we don't want to use the per-user config.