### PR TITLE
earlgrey: Adjust test categorization 

### DIFF
--- a/target/earlgrey/epmp.rs
+++ b/target/earlgrey/epmp.rs
@@ -83,5 +83,4 @@ pub fn init() {
     unsafe {
         MemoryConfig::KERNEL_THREAD_MEMORY_CONFIG.write();
     }
-    MemoryConfig::KERNEL_THREAD_MEMORY_CONFIG.dump_current();
 }

--- a/target/earlgrey/tests/drivers/gpio/BUILD.bazel
+++ b/target/earlgrey/tests/drivers/gpio/BUILD.bazel
@@ -86,7 +86,6 @@ opentitan_test(
     timeout = "eternal",
     interface = "verilator",
     tags = [
-        "nightly_test",
         "verilator",
     ],
     target = ":gpio",

--- a/target/earlgrey/tests/uart/BUILD.bazel
+++ b/target/earlgrey/tests/uart/BUILD.bazel
@@ -104,7 +104,6 @@ opentitan_test(
     timeout = "eternal",
     interface = "verilator",
     tags = [
-        "nightly_test",
         "verilator",
     ],
     target = ":uart",

--- a/target/veer/ipc/user/BUILD.bazel
+++ b/target/veer/ipc/user/BUILD.bazel
@@ -76,5 +76,6 @@ caliptra_test(
     name = "ipc_runner_emulator_test",
     timeout = "long",
     interface = "emulator",
+    tags = ["emulator"],
     target = ":ipc",
 )

--- a/target/veer/syscall_latency/BUILD.bazel
+++ b/target/veer/syscall_latency/BUILD.bazel
@@ -107,6 +107,9 @@ caliptra_test(
     interface = "emulator",
     # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
     # tests cannot run in parallel without an EADDRINUSE collision.
-    tags = ["exclusive"],
+    tags = [
+        "emulator",
+        "exclusive",
+    ],
     target = ":measure_syscall_latency",
 )

--- a/target/veer/threads/kernel/BUILD.bazel
+++ b/target/veer/threads/kernel/BUILD.bazel
@@ -68,6 +68,9 @@ caliptra_runner(
 caliptra_test(
     name = "threads_runner_emulator_test",
     interface = "emulator",
-    tags = ["manual"],
+    tags = [
+        "emulator",
+        "manual",
+    ],
     target = ":threads",
 )

--- a/target/veer/unittest_runner/BUILD.bazel
+++ b/target/veer/unittest_runner/BUILD.bazel
@@ -24,6 +24,7 @@ target_linker_script(
 caliptra_test(
     name = "emulator_test",
     interface = "emulator",
+    tags = ["emulator"],
     target = ":unittest_runner",
 )
 

--- a/workflows.json
+++ b/workflows.json
@@ -63,8 +63,8 @@
         "build_type": "bazel",
         "args": [
           "--keep_going",
-          "--build_tag_filters=-hardware,-disabled,-verilator",
-          "--test_tag_filters=-hardware,-disabled,-verilator",
+          "--build_tag_filters=-hardware,-disabled,-verilator,-emulator",
+          "--test_tag_filters=-hardware,-disabled,-verilator,-emulator",
           "--test_output=streamed",
           "--"
         ],
@@ -97,6 +97,27 @@
       },
       "targets": [
         "//target/earlgrey/..."
+      ]
+    },
+    {
+      "name": "caliptra_emulator_tests",
+      "build_config": {
+        "name": "caliptra_emulator_tests_config",
+        "description": "Run caliptra emulator-based tests",
+        "build_type": "bazel",
+        "args": [
+          "--keep_going",
+          "--build_tag_filters=+emulator",
+          "--test_tag_filters=+emulator",
+          "--test_output=streamed"
+        ],
+        "driver_options": {
+          "@type": "pw.build.proto.BazelDriverOptions",
+          "no_test": false
+        }
+      },
+      "targets": [
+        "//target/veer/..."
       ]
     },
     {
@@ -171,6 +192,7 @@
       "builds": [
         "ci_tests",
         "ast10x0_qemu_tests",
+        "caliptra_emulator_tests",
         "earlgrey_verilator_tests"
       ]
     }

--- a/workflows.json
+++ b/workflows.json
@@ -86,8 +86,8 @@
         "build_type": "bazel",
         "args": [
           "--keep_going",
-          "--build_tag_filters=+verilator",
-          "--test_tag_filters=+verilator",
+          "--build_tag_filters=+verilator,-nightly_test",
+          "--test_tag_filters=+verilator,-nightly_test",
           "--test_output=streamed"
         ],
         "driver_options": {


### PR DESCRIPTION
1. Reduce the number of tests that run as part of
   `earlgrey_verilator_tests`.  The selected tests excercise the
   functionality of the ipc and threads tests, so those tests are
   redundant.
   - Remove the `nightly_test` tag from the tests that we want to
     run as part of `earlgrey_verilator_tests`.
   - Add `-nightly_test` to the workflow.
2. Don't print the epmp at startup.  In verilator tests, this wastes about 2m of test time.
3. Separate caliptra tests into their own workflow.