### PR TITLE
earlgrey: Fix uart test failures

### DIFF
--- a/target/earlgrey/tests/uart/test_uart.rs
+++ b/target/earlgrey/tests/uart/test_uart.rs
@@ -65,9 +65,9 @@ fn entry() -> Result<()> {
     let ret = test_uart_interrupts();
 
     if ret.is_err() {
-        pw_log::error!("❌ FAILED: {}", ret.status_code() as u32);
+        pw_log::error!("❌ FAIL: {}", ret.status_code() as u32);
     } else {
-        pw_log::info!("✅ PASSED");
+        pw_log::info!("✅ PASS");
     }
 
     ret


### PR DESCRIPTION
Our test tooling expects to see `PASS` or `FAIL` on the console.  The uart test was emitting `PASSED` or `FAILED`.