### PR TITLE
[ci] Fix nightly regression failures in caliptra and veer

### DIFF
--- a/target/veer/ipc/user/BUILD.bazel
+++ b/target/veer/ipc/user/BUILD.bazel
@@ -76,6 +76,11 @@ caliptra_test(
     name = "ipc_runner_emulator_test",
     timeout = "long",
     interface = "emulator",
-    tags = ["emulator"],
+    # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
+    # tests cannot run in parallel without an EADDRINUSE collision.
+    tags = [
+        "emulator",
+        "exclusive",
+    ],
     target = ":ipc",
 )

--- a/target/veer/syscall_latency/BUILD.bazel
+++ b/target/veer/syscall_latency/BUILD.bazel
@@ -105,9 +105,13 @@ caliptra_test(
     name = "measure_syscall_latency_emulator_test",
     timeout = "long",
     interface = "emulator",
+    # DISABLED: this test hits a pw_kernel terminal exception in kernel mode
+    # (mcause=1, epc=0) on process exit.
+    #
     # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
     # tests cannot run in parallel without an EADDRINUSE collision.
     tags = [
+        "disabled",
         "emulator",
         "exclusive",
     ],

--- a/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
@@ -209,6 +209,7 @@ rust_library(
     crate_root = "@caliptra_mcu_sw//:romtime/src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
+    target_compatible_with = ["//third_party/caliptra/platforms:target_caliptra"],
     deps = [
         "//third_party/caliptra:crate_registers-generated",
         "//third_party/caliptra:crate_tock-registers",

--- a/third_party/caliptra/caliptra-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-sw/BUILD.bazel
@@ -226,6 +226,7 @@ rust_library(
         "@rust_caliptra_crates//:caliptra-cfi-derive",
     ],
     rustc_flags = ["--cap-lints=allow"],
+    target_compatible_with = ["//third_party/caliptra/platforms:target_caliptra"],
     deps = [
         ":caliptra_cfi_lib",
         "//third_party/caliptra:crate_bitfield",


### PR DESCRIPTION
The GitHub nightly workflow was failing due to issues with //third_party annd //target/veer targets:

1. Embedded caliptra embedded targets are not compatible with the host tag wildcard. Update embedded targets to skip host build.

2. measure_syscall_latency_emulator_test and ipc_runner_emulator_test collided on caliptra_runner.py's hardcoded --i3c-port=65534. Add the `exclusive` tag to ipc_runner_emulator_test.

3. measure_syscall_latency_emulator_test triggers a pw_kernel terminal exception in kernel mode (mcause=1, epc=0) on process exit. Disabling the test until the issue is addressed.