### PR TITLE
[veer/earlgrey] Fix syscall_latency exit path

### DIFF
--- a/target/earlgrey/syscall_latency/BUILD.bazel
+++ b/target/earlgrey/syscall_latency/BUILD.bazel
@@ -8,7 +8,7 @@ load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_scri
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
 load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
-load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_runner")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_runner", "opentitan_test")
 
 rust_app(
     name = "syscall_latency",
@@ -114,5 +114,13 @@ opentitan_runner(
     ecdsa_key = SILICON_ECDSA_KEY,
     interface = "teacup",
     tags = ["manual"],
+    target = ":measure_syscall_latency",
+)
+
+opentitan_test(
+    name = "measure_syscall_latency_qemu_test",
+    timeout = "moderate",
+    interface = "qemu",
+    tags = ["qemu"],
     target = ":measure_syscall_latency",
 )

--- a/target/earlgrey/syscall_latency/main.rs
+++ b/target/earlgrey/syscall_latency/main.rs
@@ -54,7 +54,11 @@ fn measure_nop_syscall(rv_timer: &RvTimer, n: usize) -> Result<()> {
 #[entry]
 fn entry() -> Result<()> {
     let rv_timer = unsafe { RvTimer::new() };
-    measure_nop_syscall(&rv_timer, 100)
+    let ret = measure_nop_syscall(&rv_timer, 100);
+
+    // Signal completion by shutting down the whole system with the test status.
+    let _ = syscall::debug_shutdown(ret);
+    ret
 }
 
 #[panic_handler]

--- a/target/veer/ipc/user/BUILD.bazel
+++ b/target/veer/ipc/user/BUILD.bazel
@@ -76,6 +76,11 @@ caliptra_test(
     name = "ipc_runner_emulator_test",
     timeout = "long",
     interface = "emulator",
-    tags = ["emulator"],
+    # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
+    # tests cannot run in parallel without an EADDRINUSE collision.
+    tags = [
+        "emulator",
+        "exclusive",
+    ],
     target = ":ipc",
 )

--- a/target/veer/syscall_latency/BUILD.bazel
+++ b/target/veer/syscall_latency/BUILD.bazel
@@ -105,13 +105,9 @@ caliptra_test(
     name = "measure_syscall_latency_emulator_test",
     timeout = "long",
     interface = "emulator",
-    # DISABLED: this test hits a pw_kernel terminal exception in kernel mode
-    # (mcause=1, epc=0) on process exit.
-    #
     # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
     # tests cannot run in parallel without an EADDRINUSE collision.
     tags = [
-        "disabled",
         "emulator",
         "exclusive",
     ],

--- a/target/veer/syscall_latency/BUILD.bazel
+++ b/target/veer/syscall_latency/BUILD.bazel
@@ -105,9 +105,13 @@ caliptra_test(
     name = "measure_syscall_latency_emulator_test",
     timeout = "long",
     interface = "emulator",
+    # DISABLED: this test hits a pw_kernel terminal exception in kernel mode
+    # (mcause=1, epc=0) on process exit.
+    #
     # caliptra_runner.py hardcodes --i3c-port=65534, so caliptra emulator
     # tests cannot run in parallel without an EADDRINUSE collision.
     tags = [
+        "disabled",
         "emulator",
         "exclusive",
     ],

--- a/target/veer/syscall_latency/main.rs
+++ b/target/veer/syscall_latency/main.rs
@@ -44,7 +44,11 @@ fn measure_nop_syscall(n: usize) -> Result<()> {
 
 #[entry]
 fn entry() -> Result<()> {
-    measure_nop_syscall(100)
+    let ret = measure_nop_syscall(100);
+
+    // Signal completion by shutting down the whole system with the test status.
+    let _ = syscall::debug_shutdown(ret);
+    ret
 }
 
 #[panic_handler]

--- a/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
@@ -209,6 +209,7 @@ rust_library(
     crate_root = "@caliptra_mcu_sw//:romtime/src/lib.rs",
     edition = "2021",
     rustc_flags = ["--cap-lints=allow"],
+    target_compatible_with = ["//third_party/caliptra/platforms:target_caliptra"],
     deps = [
         "//third_party/caliptra:crate_registers-generated",
         "//third_party/caliptra:crate_tock-registers",

--- a/third_party/caliptra/caliptra-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-sw/BUILD.bazel
@@ -226,6 +226,7 @@ rust_library(
         "@rust_caliptra_crates//:caliptra-cfi-derive",
     ],
     rustc_flags = ["--cap-lints=allow"],
+    target_compatible_with = ["//third_party/caliptra/platforms:target_caliptra"],
     deps = [
         ":caliptra_cfi_lib",
         "//third_party/caliptra:crate_bitfield",


### PR DESCRIPTION
The `syscall_latency` returned an exit code, as opposed to running in a loop. This triggered a `process_exit` call that resulted in a kernel crash. The root cause of the kernel crash is outside the scope of this change.

Fix the apps to match every other pw_kernel userspace test app: signal  completion with syscall::debug_shutdown(status), which shuts the whole system down with the test status and never enters the per-process teardown path.

- veer: re-enable measure_syscall_latency_emulator_test.
- earlgrey: add measure_syscall_latency_qemu_test (opentitan_test, qemu interface) so this exit path has CI coverage. Add debug_shutdown(status) at the end of the test to avoid crash.

Only review the last commit in this PR. 