### PR TITLE
Create empty hardware-enablement firmware

### DIFF
--- a/hal/blocking/usb/BUILD.bazel
+++ b/hal/blocking/usb/BUILD.bazel
@@ -1,0 +1,29 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "hal_usb",
+    srcs = [
+        "descriptor.rs",
+        "driver.rs",
+        "lib.rs",
+    ],
+    crate_name = "hal_usb",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rust_crates//:aligned",
+        "@rust_crates//:zerocopy",
+    ],
+)
+
+rust_test(
+    name = "hal_usb_test",
+    crate = ":hal_usb",
+    rustc_flags = [
+        "-C",
+        "debug-assertions",
+    ],
+)

--- a/hal/blocking/usb/descriptor.rs
+++ b/hal/blocking/usb/descriptor.rs
@@ -1,0 +1,1062 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! USB descriptor structures and serialization.
+//!
+//! This module provides the tools to define and serialize standard USB
+//! descriptors, including Device, Configuration, Interface, and Endpoint
+//! descriptors.
+
+use aligned::Aligned;
+use aligned::A4;
+#[cfg(feature = "ufmt_console")]
+use ufmt::uWrite;
+
+/// USB Audio class code.
+pub const USB_CLASS_AUDIO: u8 = 0x01;
+/// USB Communications and CDC Control class code.
+pub const USB_CLASS_COMMUNICATIONS: u8 = 0x02;
+/// USB HID (Human Interface Device) class code.
+pub const USB_CLASS_HID: u8 = 0x03;
+/// USB Physical class code.
+pub const USB_CLASS_PHYSICAL: u8 = 0x05;
+/// USB Image class code.
+pub const USB_CLASS_IMAGE: u8 = 0x06;
+/// USB Printer class code.
+pub const USB_CLASS_PRINTER: u8 = 0x07;
+/// USB Mass Storage class code.
+pub const USB_CLASS_MASS_STORAGE: u8 = 0x08;
+/// USB Hub class code.
+pub const USB_CLASS_HUB: u8 = 0x09;
+/// USB CDC-Data class code.
+pub const USB_CLASS_CDC_DATA: u8 = 0x0a;
+/// USB Smart Card class code.
+pub const USB_CLASS_SMART_CARD: u8 = 0x0b;
+/// USB Content Security class code.
+pub const USB_CLASS_CONTENT_SECURITY: u8 = 0x0d;
+/// USB Video class code.
+pub const USB_CLASS_VIDEO: u8 = 0x0e;
+/// USB Personal Healthcare class code.
+pub const USB_CLASS_PERSONAL_HEALTHCARE: u8 = 0x0f;
+/// USB Audio/Video class code.
+pub const USB_CLASS_AUDIO_VIDEO: u8 = 0x10;
+/// USB Billboard class code.
+pub const USB_CLASS_BILLBOARD: u8 = 0x11;
+/// USB Type-C Bridge class code.
+pub const USB_CLASS_USB_TYPEC_BRIDGE: u8 = 0x12;
+/// USB Bulk Display class code.
+pub const USB_CLASS_BULK_DISPLAY: u8 = 0x13;
+/// USB MCTP class code.
+pub const USB_CLASS_MCTP: u8 = 0x14;
+/// USB I3C class code.
+pub const USB_CLASS_I3C: u8 = 0x3c;
+/// USB Diagnostic Device class code.
+pub const USB_CLASS_DIAGNOSTIC_DEVICE: u8 = 0xdc;
+/// USB Wireless Controller class code.
+pub const USB_CLASS_WIRELESS_CONTROLLER: u8 = 0xe0;
+/// USB Miscellaneous class code.
+pub const USB_CLASS_MISC: u8 = 0xef;
+/// USB Application Specific class code.
+pub const USB_CLASS_APPLICATION_SPECIFIC: u8 = 0xfe;
+/// USB Vendor Specific class code.
+pub const USB_CLASS_VENDOR: u8 = 0xff;
+
+/// DFU (Device Firmware Upgrade) subclass code.
+pub const USB_SUBCLASS_APPLICATION_SPECIFIC_DFU: u8 = 0x01;
+
+/// DFU Runtime Mode protocol code.
+pub const USB_PROTOCOL_APPLICATION_SPECIFIC_DFU_RUNTIME_MODE: u8 = 0x01;
+/// DFU Mode protocol code.
+pub const USB_PROTOCOL_APPLICATION_SPECIFIC_DFU_DFU_MODE: u8 = 0x02;
+
+use crate::DescriptorType;
+use crate::Direction;
+
+/// A handle to a USB string descriptor.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct StringHandle(pub u8);
+impl StringHandle {
+    /// Indicates that no string descriptor is provided.
+    pub const NONE: Self = StringHandle(0);
+}
+
+/// A standard USB device descriptor.
+#[derive(Clone, Copy)]
+pub struct DeviceDescriptor {
+    /// The class of the device.
+    pub device_class: DeviceClass,
+    /// The subclass of the device.
+    pub device_sub_class: u8,
+    /// The protocol used by the device.
+    pub device_protocol: u8,
+    /// Maximum packet size for Endpoint 0.
+    pub max_packet_size: u8,
+    /// Vendor ID assigned by the USB-IF.
+    pub vendor_id: u16,
+    /// Product ID assigned by the manufacturer.
+    pub product_id: u16,
+    /// Device release number (in binary-coded decimal).
+    pub device_release_num: u16,
+    /// Handle for the manufacturer string descriptor.
+    pub manufacturer: StringHandle,
+    /// Handle for the product string descriptor.
+    pub product: StringHandle,
+    /// Handle for the serial number string descriptor.
+    pub serial_num: StringHandle,
+}
+impl DeviceDescriptor {
+    const SIZE: usize = 18;
+
+    #[allow(dead_code)]
+    pub(crate) const fn total_size(&self) -> usize {
+        Self::SIZE
+    }
+
+    /// Serializes the device descriptor into a byte array.
+    #[allow(clippy::identity_op)]
+    pub const fn serialize(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+
+        // sizeof descriptor
+        buf[0] = 18;
+        // bDescriptorType = Device
+        buf[1] = 1;
+        // USB version 2.0
+        buf[2] = 0x00;
+        buf[3] = 0x02;
+
+        buf[4] = self.device_class.0;
+        buf[5] = self.device_sub_class;
+        buf[6] = self.device_protocol;
+        buf[7] = self.max_packet_size;
+
+        buf[8] = ((self.vendor_id & 0x00ff) >> 0) as u8;
+        buf[9] = ((self.vendor_id & 0xff00) >> 8) as u8;
+
+        buf[10] = ((self.product_id & 0x00ff) >> 0) as u8;
+        buf[11] = ((self.product_id & 0xff00) >> 8) as u8;
+
+        buf[12] = ((self.device_release_num & 0x00ff) >> 0) as u8;
+        buf[13] = ((self.device_release_num & 0xff00) >> 8) as u8;
+
+        buf[14] = self.manufacturer.0;
+        buf[15] = self.product.0;
+        buf[16] = self.serial_num.0;
+
+        // num configurations
+        buf[17] = 1;
+        buf
+    }
+}
+
+/// A standard USB configuration descriptor.
+#[derive(Clone, Copy)]
+pub struct ConfigDescriptor {
+    /// The configuration value for this configuration.
+    pub configuration_value: u8,
+    /// Maximum power consumption in 2 mA units.
+    pub max_power: u8,
+    /// Indicates if the device is self-powered.
+    pub self_powered: bool,
+    /// Indicates if the device supports remote wakeup.
+    pub remote_wakeup: bool,
+    /// List of interfaces included in this configuration.
+    pub interfaces: &'static [InterfaceDescriptor],
+}
+
+impl ConfigDescriptor {
+    const SIZE: usize = 9;
+
+    /// Returns the total size of the configuration descriptor, including
+    /// all interfaces and endpoints.
+    pub const fn total_size(&self) -> usize {
+        let mut result = Self::SIZE;
+        let mut i = 0;
+        while i < self.interfaces.len() {
+            result += self.interfaces[i].total_size();
+            i += 1;
+        }
+        result
+    }
+
+    /// Serializes the configuration descriptor and its children into a byte array.
+    #[allow(clippy::identity_op)]
+    pub const fn serialize<const RESULT_SIZE: usize>(&self) -> [u8; RESULT_SIZE] {
+        assert!(self.total_size() == RESULT_SIZE);
+        let mut buf = [0u8; RESULT_SIZE];
+
+        // alternates don't count towards total
+        // as interfaces numbers are per spec monotonically increasing, we can use that as the count
+        let mut uniq_interface_count = 0;
+        let mut i = 0;
+        while i < self.interfaces.len() {
+            if self.interfaces[i].interface_number + 1 > uniq_interface_count {
+                uniq_interface_count = self.interfaces[i].interface_number + 1
+            }
+            i += 1;
+        }
+
+        // sizeof descriptor
+        buf[0] = 9;
+        // bDescriptorType = Configuration
+        buf[1] = 2;
+        buf[2] = ((RESULT_SIZE & 0x00ff) >> 0) as u8;
+        buf[3] = ((RESULT_SIZE & 0xff00) >> 8) as u8;
+        buf[4] = uniq_interface_count;
+        buf[5] = self.configuration_value;
+        // iConfiguration
+        buf[6] = 0;
+        buf[7] = (1 << 7) | // must be 1 (USB 1.0 bus powered)
+                 if self.self_powered { 1 << 6 } else { 0 } |
+                 if self.remote_wakeup { 1 << 5 } else { 0 };
+        buf[8] = self.max_power;
+
+        let mut offset = 9;
+
+        let mut i = 0;
+        while i < self.interfaces.len() {
+            let (iface_buf, iface_buf_len) = self.interfaces[i].serialize::<RESULT_SIZE>();
+            let mut iface_offset = 0;
+            while iface_offset < iface_buf_len {
+                buf[offset] = iface_buf[iface_offset];
+                iface_offset += 1;
+                offset += 1;
+            }
+            i += 1;
+        }
+        buf
+    }
+}
+
+/// A standard USB interface descriptor.
+#[derive(Clone, Copy)]
+pub struct InterfaceDescriptor {
+    /// Handle for the interface name string descriptor.
+    pub name: StringHandle,
+    /// The alternate setting for this interface.
+    pub alternate_setting: u8,
+    /// The interface number.
+    pub interface_number: u8,
+    /// The interface class.
+    pub interface_class: u8,
+    /// The interface subclass.
+    pub interface_sub_class: u8,
+    /// The interface protocol.
+    pub interface_protocol: u8,
+    /// List of class-specific functional descriptors.
+    pub func_descs: &'static [FunctionalDescriptor],
+    /// List of endpoints used by this interface.
+    pub endpoints: &'static [EndpointDescriptor],
+}
+impl InterfaceDescriptor {
+    const SIZE: usize = 9;
+
+    pub(crate) const fn total_size(&self) -> usize {
+        let mut result = Self::SIZE;
+        let mut i = 0;
+        while i < self.func_descs.len() {
+            result += self.func_descs[i].total_size();
+            i += 1;
+        }
+        let mut i = 0;
+        while i < self.endpoints.len() {
+            result += self.endpoints[i].total_size();
+            i += 1;
+        }
+        result
+    }
+    /// Serializes the interface descriptor and its children.
+    pub const fn serialize<const RESULT_SIZE: usize>(&self) -> ([u8; RESULT_SIZE], usize) {
+        assert!(RESULT_SIZE >= self.total_size());
+
+        let mut buf = [0u8; RESULT_SIZE];
+
+        // sizeof descriptor
+        buf[0] = 9;
+        // bDescriptorType = Interface
+        buf[1] = 4;
+        buf[2] = self.interface_number;
+        buf[3] = self.alternate_setting;
+        buf[4] = self.endpoints.len() as u8;
+        buf[5] = self.interface_class;
+        buf[6] = self.interface_sub_class;
+        buf[7] = self.interface_protocol;
+        // iInterface: Index of string descriptor describing this interface
+        buf[8] = self.name.0;
+        let mut offset = 9;
+
+        let mut i = 0;
+        while i < self.func_descs.len() {
+            self.func_descs[i].serialize(&mut buf, offset);
+            offset += self.func_descs[i].total_size();
+            i += 1;
+        }
+
+        let mut i = 0;
+        while i < self.endpoints.len() {
+            let ep_buf = self.endpoints[i].serialize(i as u8);
+            let mut ep_offset = 0;
+            while ep_offset < ep_buf.len() {
+                buf[offset] = ep_buf[ep_offset];
+                offset += 1;
+                ep_offset += 1;
+            }
+            i += 1;
+        }
+        (buf, offset)
+    }
+}
+
+/// A standard USB endpoint descriptor.
+#[derive(Clone, Copy)]
+pub struct EndpointDescriptor {
+    /// The data direction of the endpoint.
+    pub direction: Direction,
+    /// The endpoint number (0-15).
+    pub endpoint_num: u8,
+    /// The transfer type of the endpoint.
+    pub transfer_type: TransferType,
+    /// Maximum packet size for this endpoint.
+    pub max_packet_size: u16,
+    /// Polling interval (for interrupt and isochronous endpoints).
+    pub interval: u8,
+}
+impl EndpointDescriptor {
+    const SIZE: usize = 7;
+
+    pub(crate) const fn total_size(&self) -> usize {
+        Self::SIZE
+    }
+
+    #[allow(clippy::identity_op)]
+    const fn serialize(&self, _index: u8) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+
+        // sizeof descriptor
+        buf[0] = Self::SIZE as u8;
+        // bDescriptorType = endpoint
+        buf[1] = 5;
+        buf[2] = self.endpoint_num & 0x7
+            | match self.direction {
+                Direction::HostToDevice => 0,
+                Direction::DeviceToHost => 1 << 7,
+            };
+        buf[3] = match self.transfer_type {
+            TransferType::Control => 0,
+            TransferType::Isochronous(sync_type, usage_type) => {
+                1 | match sync_type {
+                    SynchronizationType::None => 0 << 2,
+                    SynchronizationType::Asynchronous => 1 << 2,
+                    SynchronizationType::Adaptive => 2 << 2,
+                    SynchronizationType::Synchronous => 3 << 3,
+                } | match usage_type {
+                    UsageType::DataEndpoint => 0 << 4,
+                    UsageType::FeedbackEndpoint => 1 << 4,
+                    UsageType::ExplicitFeedbackDataEndpoint => 2 << 4,
+                }
+            }
+            TransferType::Bulk => 2,
+            TransferType::Interrupt => 3,
+        };
+
+        buf[4] = ((self.max_packet_size & 0x00ff) >> 0) as u8;
+        buf[5] = ((self.max_packet_size & 0xff00) >> 8) as u8;
+        buf[6] = self.interval;
+        buf
+    }
+}
+
+/// A standard USB String Descriptor 0 (listing supported languages).
+#[derive(Clone, Copy)]
+pub struct StringDescriptor0 {
+    /// List of supported LANGIDs.
+    pub langs: &'static [u16],
+}
+impl StringDescriptor0 {
+    /// Returns the total size of the descriptor.
+    pub const fn total_size(&self) -> usize {
+        2 + core::mem::size_of_val(self.langs)
+    }
+
+    /// Serializes the language list into a byte array.
+    #[allow(clippy::identity_op)]
+    pub const fn serialize<const RESULT_SIZE: usize>(&self) -> [u8; RESULT_SIZE] {
+        assert!(RESULT_SIZE == self.total_size());
+        assert!(self.total_size() <= (u8::MAX as usize));
+
+        let mut buf = [0u8; RESULT_SIZE];
+        // sizeof descriptor
+        buf[0] = self.total_size() as u8;
+        // bDescriptorType = String
+        buf[1] = 3;
+
+        let mut offset = 2;
+        let mut i = 0;
+        while i < self.langs.len() {
+            let bytes = self.langs[i].to_le_bytes();
+            buf[offset + 0] = bytes[0];
+            buf[offset + 1] = bytes[1];
+            i += 1;
+            offset += 2;
+        }
+        buf
+    }
+}
+
+/// USB transfer type.
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub enum TransferType {
+    /// Control transfer.
+    Control,
+    /// Isochronous transfer.
+    Isochronous(SynchronizationType, UsageType),
+    /// Bulk transfer.
+    Bulk,
+    /// Interrupt transfer.
+    Interrupt,
+}
+impl TransferType {
+    #[allow(dead_code)]
+    fn as_eptyp(self) -> u32 {
+        match self {
+            TransferType::Control => 0,
+            TransferType::Isochronous(_, _) => 1,
+            TransferType::Bulk => 2,
+            TransferType::Interrupt => 3,
+        }
+    }
+}
+
+/// Isochronous synchronization type.
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub enum SynchronizationType {
+    None = 0,
+    Asynchronous = 1,
+    Adaptive = 2,
+    Synchronous = 3,
+}
+
+/// Isochronous usage type.
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code, clippy::enum_variant_names)]
+pub enum UsageType {
+    DataEndpoint,
+    FeedbackEndpoint,
+    ExplicitFeedbackDataEndpoint,
+}
+
+/// USB device class code.
+#[derive(Clone, Copy)]
+pub struct DeviceClass(pub u8);
+impl DeviceClass {
+    /// Class is specified at the interface level.
+    pub const SPECIFIED_BY_INTERFACE: Self = Self(0x00);
+    /// CDC (Communication Device Class).
+    pub const COMMUNICATIONS_AND_CDC: Self = Self(0x02);
+    /// Hub device.
+    pub const HUB: Self = Self(0x09);
+    /// Billboard device.
+    pub const BILLBOARD: Self = Self(0x11);
+    /// Diagnostic device.
+    pub const DIAGNOSTIC_DEVICE: Self = Self(0x3c);
+    /// Miscellaneous device.
+    pub const MISCELLANEOUS: Self = Self(0xef);
+    /// Vendor-specified device class.
+    pub const VENDOR_SPECIFIED: Self = Self(0xff);
+}
+impl From<DeviceClass> for u8 {
+    fn from(val: DeviceClass) -> Self {
+        val.0
+    }
+}
+
+/// A statically-allocated USB string descriptor.
+pub struct StringDescriptor<const BYTE_LEN: usize>(Aligned<A4, [u8; BYTE_LEN]>);
+
+impl<const BYTE_LEN: usize> StringDescriptor<BYTE_LEN> {
+    /// Creates a string descriptor from an ASCII string at compile-time.
+    pub const fn const_from_ascii(s: &str) -> Self {
+        assert!(BYTE_LEN <= (u8::MAX as usize));
+        assert!(s.len() * 2 + 2 == BYTE_LEN);
+        let mut result = [0u8; BYTE_LEN];
+        result[0] = BYTE_LEN as u8;
+        result[1] = 0x03; // DescriptorType string
+
+        let s = s.as_bytes();
+        let mut i = 0;
+        while i < s.len() {
+            if s[i] >= 0x80 {
+                panic!("ascii characters only");
+            }
+            result[2 + i * 2] = s[i];
+            i += 1;
+        }
+        StringDescriptor(Aligned(result))
+    }
+    /// Returns a reference to the string descriptor.
+    pub const fn as_ref(&self) -> StringDescriptorRef<'_> {
+        StringDescriptorRef(&self.0)
+    }
+}
+
+/// A reference to an aligned USB string descriptor.
+#[derive(Clone, Copy)]
+pub struct StringDescriptorRef<'a>(pub &'a Aligned<A4, [u8]>);
+impl<'a> StringDescriptorRef<'a> {
+    /// Returns the descriptor as a byte slice.
+    pub const fn as_bytes(self) -> &'a Aligned<A4, [u8]> {
+        self.0
+    }
+}
+
+/// Macro for easily creating static string descriptors.
+#[macro_export]
+macro_rules! string_descriptor {
+    ($s:expr) => {
+        $crate::StringDescriptor::<{ $s.len() * 2 + 2 }>::const_from_ascii($s)
+    };
+}
+
+/// Descriptor generation error.
+#[derive(Debug)]
+pub enum DescriptorErr {
+    /// Buffer is too small.
+    Overflow,
+    /// Invalid encoding.
+    Encoding,
+}
+
+/// Generates a UTF-16 hex-encoded string descriptor from a byte slice.
+#[inline(always)]
+pub fn hex_utf16_descriptor(dest: &mut [u8], src: &[u8]) -> Result<usize, DescriptorErr> {
+    const { assert!(cfg!(target_endian = "little")) };
+    const HEX_CHARS: [u8; 16] = *b"0123456789abcdef";
+    let total_len = src.len() * 4 + 2;
+    if dest.len() < total_len || total_len > 255 {
+        return Err(DescriptorErr::Overflow);
+    }
+    dest[0] = total_len as u8;
+    dest[1] = DescriptorType::STRING.0;
+
+    let mut i = 2;
+    for src_byte in src.iter() {
+        dest[i] = HEX_CHARS[usize::from(*src_byte >> 4)];
+        dest[i + 1] = 0;
+        dest[i + 2] = HEX_CHARS[usize::from(*src_byte & 0xf)];
+        dest[i + 3] = 0;
+        i += 4;
+    }
+    Ok(total_len)
+}
+
+/// Generates an aligned UTF-16 hex-encoded string descriptor.
+#[inline(always)]
+pub fn hex_utf16_descriptor_aligned<'a>(
+    dest: &'a mut Aligned<A4, [u8]>,
+    src: &[u8],
+) -> Result<StringDescriptorRef<'a>, DescriptorErr> {
+    let len = hex_utf16_descriptor(dest, src)?;
+    Ok(StringDescriptorRef(&dest[..len]))
+}
+
+/// Utility for dynamically writing content into a USB string descriptor.
+pub struct StringDescriptorWritter<'a> {
+    buf: &'a mut Aligned<A4, [u8]>,
+    index: usize,
+}
+impl<'a> StringDescriptorWritter<'a> {
+    /// Creates a new writer using the provided buffer.
+    pub fn new(buf: &'a mut Aligned<A4, [u8]>) -> Result<Self, DescriptorErr> {
+        if buf.len() < 2 || buf.len() > 2 + 255 {
+            return Err(DescriptorErr::Overflow);
+        }
+        *buf.get_mut(1).unwrap() = DescriptorType::STRING.0;
+        Ok(StringDescriptorWritter { buf, index: 2 })
+    }
+    /// Finalizes the descriptor and returns a reference to it.
+    pub fn finalize(self) -> Result<StringDescriptorRef<'a>, DescriptorErr> {
+        *self.buf.get_mut(0).ok_or(DescriptorErr::Overflow)? =
+            u8::try_from(self.index).map_err(|_| DescriptorErr::Overflow)?;
+
+        if self.index > self.buf.len() {
+            return Err(DescriptorErr::Overflow);
+        }
+        Ok(StringDescriptorRef(&self.buf[..self.index]))
+    }
+}
+#[cfg(feature = "ufmt_console")]
+impl uWrite for StringDescriptorWritter<'_> {
+    type Error = core::fmt::Error;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        let bytes = s.as_bytes();
+        let remaining_buf = self.buf.get_mut(self.index..).ok_or(core::fmt::Error)?;
+
+        if remaining_buf.len() < bytes.len() * 2 {
+            return Err(core::fmt::Error);
+        }
+
+        for &b in bytes {
+            if b >= 0x80 {
+                return Err(core::fmt::Error);
+            }
+            *self.buf.get_mut(self.index).ok_or(core::fmt::Error)? = b;
+            *self.buf.get_mut(self.index + 1).ok_or(core::fmt::Error)? = 0;
+            self.index += 2;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_string_descriptor_writter {
+    use aligned::Aligned;
+    use aligned::A4;
+    #[cfg(feature = "ufmt_console")]
+    use core::ops::Deref;
+    #[cfg(feature = "ufmt_console")]
+    use ufmt::uwrite;
+
+    use crate::StringDescriptorWritter;
+
+    #[test]
+    #[cfg(feature = "ufmt_console")]
+    fn works() {
+        let mut buf = Aligned::<A4, _>([0u8; 30]);
+        let mut writter = StringDescriptorWritter::new(&mut buf).unwrap();
+        uwrite!(writter, "Hello").unwrap();
+        uwrite!(writter, " ").unwrap();
+        uwrite!(writter, "World").unwrap();
+        let result = writter.finalize().unwrap();
+        assert_eq!(
+            result.as_bytes().deref(),
+            &[
+                24, 3, b'H', 0, b'e', 0, b'l', 0, b'l', 0, b'o', 0, b' ', 0, b'W', 0, b'o', 0,
+                b'r', 0, b'l', 0, b'd', 0
+            ]
+        );
+    }
+
+    #[test]
+    fn too_small_buffer() {
+        let mut buf = Aligned::<A4, _>([0u8; 1]);
+        assert!(StringDescriptorWritter::new(&mut buf).is_err());
+    }
+
+    #[test]
+    fn too_big_buffer() {
+        let mut buf = Aligned::<A4, _>([0u8; 258]);
+        assert!(StringDescriptorWritter::new(&mut buf).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "ufmt_console")]
+    fn too_small_to_fit() {
+        let mut buf = Aligned::<A4, _>([0u8; 12]);
+        let mut writter = StringDescriptorWritter::new(&mut buf).unwrap();
+        uwrite!(writter, "Hello").unwrap();
+        assert!(uwrite!(writter, " ").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "ufmt_console")]
+    fn non_ascii_char() {
+        let mut buf = Aligned::<A4, _>([0u8; 20]);
+        let mut writter = StringDescriptorWritter::new(&mut buf).unwrap();
+        assert!(uwrite!(writter, "Héllö").is_err());
+    }
+}
+
+/// A DFU functional descriptor.
+#[derive(Clone, Copy)]
+pub struct DfuFunctionalDescriptor {
+    /// New firmware can be received from the host
+    pub can_download: bool,
+    /// Current firmware can be sent back to the host
+    pub can_upload: bool,
+    /// Device can still communicate with the host after the manifestation phase.
+    pub manifestation_tolerant: bool,
+    /// Device will detach from the USB bus autonomously after receiving
+    /// DFU_DETACH; the host does not need to explicitly issue a bus reset.
+    pub will_detach: bool,
+    /// Timeout the device will wait to be reset by host after receiving DFU_DETACH.
+    pub detach_timeout_ms: u16,
+    /// The number of bytes the device can receive per control request.
+    pub transfer_size: u16,
+}
+impl DfuFunctionalDescriptor {
+    /// Returns the total size of the descriptor.
+    pub const fn total_size(&self) -> usize {
+        9
+    }
+    /// Serializes the DFU functional descriptor.
+    pub const fn serialize(&self, dest: &mut [u8], offset: usize) {
+        const fn bit(index: u8, val: bool) -> u8 {
+            (if val { 1 } else { 0 }) << index
+        }
+        const fn copy_u16(dest: &mut [u8], index: usize, val: u16) {
+            let bytes = val.to_le_bytes();
+            dest[index] = bytes[0];
+            dest[index + 1] = bytes[1];
+        }
+        // sizeof descriptor
+        dest[offset] = 9;
+        // bDescriptorType = DFU Functional
+        dest[offset + 1] = 0x21;
+        // bmAttributes
+        dest[offset + 2] = bit(0, self.can_download)
+            | bit(1, self.can_upload)
+            | bit(2, self.manifestation_tolerant)
+            | bit(3, self.will_detach);
+        copy_u16(dest, offset + 3, self.detach_timeout_ms);
+        copy_u16(dest, offset + 5, self.transfer_size);
+        // bcdDFUVersion
+        copy_u16(dest, offset + 7, 0x0100);
+    }
+}
+
+/// A raw class-specific functional descriptor.
+#[derive(Clone, Copy)]
+pub struct RawFunctionalDescriptor {
+    /// The type of the descriptor.
+    pub descriptor_type: u8,
+    /// The raw content length.
+    pub len: u8,
+    /// The raw content of the descriptor.
+    pub content: [u8; 16],
+}
+impl RawFunctionalDescriptor {
+    /// Returns the total size of the descriptor.
+    pub const fn total_size(&self) -> usize {
+        (self.len as usize) + 2
+    }
+    /// Serializes the raw functional descriptor.
+    pub const fn serialize(&self, dest: &mut [u8], offset: usize) {
+        dest[offset] = self.total_size() as u8;
+        dest[offset + 1] = self.descriptor_type;
+        let mut i = 0;
+        while i < (self.len as usize) {
+            dest[offset + 2 + i] = self.content[i];
+            i += 1;
+        }
+    }
+}
+
+/// Represents a class-specific functional descriptor.
+#[derive(Clone, Copy)]
+pub enum FunctionalDescriptor {
+    /// DFU functional descriptor.
+    Dfu(DfuFunctionalDescriptor),
+    /// Raw class-specific functional descriptor.
+    Raw(RawFunctionalDescriptor),
+}
+
+impl FunctionalDescriptor {
+    /// Creates a raw functional descriptor.
+    pub const fn raw(descriptor_type: u8, content: &[u8]) -> Self {
+        let mut buf = [0u8; 16];
+        let mut i = 0;
+        while i < content.len() {
+            buf[i] = content[i];
+            i += 1;
+        }
+        Self::Raw(RawFunctionalDescriptor {
+            descriptor_type,
+            len: content.len() as u8,
+            content: buf,
+        })
+    }
+    /// Returns the total size of the descriptor.
+    pub const fn total_size(&self) -> usize {
+        match self {
+            Self::Dfu(dfu) => dfu.total_size(),
+            Self::Raw(raw) => raw.total_size(),
+        }
+    }
+    /// Serializes the functional descriptor.
+    #[allow(clippy::identity_op)]
+    pub const fn serialize(&self, dest: &mut [u8], offset: usize) {
+        assert!(offset + self.total_size() <= dest.len());
+        match self {
+            Self::Dfu(dfu) => dfu.serialize(dest, offset),
+            Self::Raw(raw) => raw.serialize(dest, offset),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    const INTERFACE_NAME_HANDLE: StringHandle = StringHandle(5);
+
+    const CONFIG_DESC: ConfigDescriptor = ConfigDescriptor {
+        configuration_value: 1,
+        max_power: 250,
+        self_powered: false,
+        remote_wakeup: false,
+        interfaces: &[InterfaceDescriptor {
+            name: INTERFACE_NAME_HANDLE,
+            interface_number: 0,
+            alternate_setting: 0,
+            interface_class: 0xff,
+            interface_sub_class: 0xff,
+            interface_protocol: 0xff,
+            func_descs: &[],
+            endpoints: &[
+                EndpointDescriptor {
+                    direction: Direction::DeviceToHost,
+                    endpoint_num: 1,
+                    transfer_type: TransferType::Bulk,
+                    max_packet_size: 64,
+                    interval: 0,
+                },
+                EndpointDescriptor {
+                    direction: Direction::HostToDevice,
+                    endpoint_num: 2,
+                    transfer_type: TransferType::Bulk,
+                    max_packet_size: 64,
+                    interval: 0,
+                },
+            ],
+        }],
+    };
+    const CONFIG_DESC_RAW: [u8; CONFIG_DESC.total_size()] = CONFIG_DESC.serialize();
+
+    #[test]
+    fn test_config_desc() {
+        assert_eq!(
+            &CONFIG_DESC_RAW,
+            &[
+                0x09, 0x02, 0x20, 0x00, 0x01, 0x01, 0x00, 0x80, 0xfa, 0x09, 0x04, 0x00, 0x00, 0x02,
+                0xff, 0xff, 0xff, 0x05, 0x07, 0x05, 0x81, 0x02, 0x40, 0x00, 0x00, 0x07, 0x05, 0x02,
+                0x02, 0x40, 0x00, 0x00
+            ]
+        )
+    }
+
+    #[test]
+    fn test_config_desc_dfu() {
+        const CONFIG_DESC_DFU: ConfigDescriptor = ConfigDescriptor {
+            configuration_value: 1,
+            max_power: 250,
+            self_powered: false,
+            remote_wakeup: false,
+            interfaces: &[InterfaceDescriptor {
+                name: INTERFACE_NAME_HANDLE,
+                interface_number: 0,
+                alternate_setting: 0,
+                interface_class: 0xfe,
+                interface_sub_class: 0x01,
+                interface_protocol: 0x02,
+                func_descs: &[FunctionalDescriptor::Dfu(DfuFunctionalDescriptor {
+                    can_download: true,
+                    can_upload: false,
+                    manifestation_tolerant: true,
+                    will_detach: true,
+                    transfer_size: 2048,
+                    detach_timeout_ms: 8000,
+                })],
+                endpoints: &[],
+            }],
+        };
+        const CONFIG_DESC_BYTES: [u8; CONFIG_DESC_DFU.total_size()] = CONFIG_DESC_DFU.serialize();
+
+        assert_eq!(
+            &CONFIG_DESC_BYTES,
+            &[
+                0x09, 0x02, 0x1b, 0x00, 0x01, 0x01, 0x00, 0x80, 0xfa, 0x09, 0x04, 0x00, 0x00, 0x00,
+                0xfe, 0x01, 0x02, 0x05, 0x09, 0x21, 0x0d, 0x40, 0x1f, 0x00, 0x08, 0x00, 0x01
+            ]
+        )
+    }
+
+    #[test]
+    fn test_string_descriptor() {
+        use core::ops::Deref;
+        const USB_VENDOR: StringDescriptorRef = string_descriptor!("Mutask").as_ref();
+        assert_eq!(
+            USB_VENDOR.as_bytes().deref(),
+            &[14, 3, b'M', 0, b'u', 0, b't', 0, b'a', 0, b's', 0, b'k', 0,]
+        );
+    }
+
+    #[test]
+    pub fn test_hex_utf16_descriptor() {
+        let mut buf = [0_u8; 80];
+        let len = hex_utf16_descriptor(&mut buf, &[0xab, 0x1c, 0xd2, 0xe3, 0x4f, 0x56, 0x78, 0x90])
+            .unwrap();
+        assert_eq!(
+            [
+                34, 3, b'a', 0, b'b', 0, b'1', 0, b'c', 0, b'd', 0, b'2', 0, b'e', 0, b'3', 0,
+                b'4', 0, b'f', 0, b'5', 0, b'6', 0, b'7', 0, b'8', 0, b'9', 0, b'0', 0
+            ],
+            &buf[..len]
+        );
+
+        // empty string; tight fit
+        let mut buf = [0_u8; 2];
+        let len = hex_utf16_descriptor(&mut buf, b"").unwrap();
+        assert_eq!(&[2, 3], &buf[..len]);
+
+        // 1 byte; tight fit
+        let mut buf = [0_u8; 6];
+        let len = hex_utf16_descriptor(&mut buf, &[0xca]).unwrap();
+        assert_eq!(&[6, 3, b'c', 0, b'a', 0], &buf[..len]);
+
+        // 2 bytes; tight fit
+        let mut buf = [0_u8; 10];
+        let len = hex_utf16_descriptor(&mut buf, &[0xca, 0xfe]).unwrap();
+        assert_eq!(&[10, 3, b'c', 0, b'a', 0, b'f', 0, b'e', 0], &buf[..len]);
+
+        // too small to fit descriptor
+        let mut buf = [0_u8; 1];
+        hex_utf16_descriptor(&mut buf, b"").unwrap_err();
+
+        // too small to fit 1 byte hex string
+        let mut buf = [0_u8; 5];
+        hex_utf16_descriptor(&mut buf, b"H").unwrap_err();
+
+        // too small to fit 2 byte hex string
+        let mut buf = [0_u8; 9];
+        hex_utf16_descriptor(&mut buf, b"Hi").unwrap_err();
+
+        // length too big to fit in length field
+        let mut buf = [0_u8; 258];
+        hex_utf16_descriptor(&mut buf, &[0x42_u8; 64]).unwrap_err();
+    }
+
+    #[test]
+    fn test_composite_config_desc() {
+        const USB_CDC_COMM_HANDLE: StringHandle = StringHandle(4);
+        const USB_CDC_DATA_HANDLE: StringHandle = StringHandle(5);
+        const DFU_FIRMWARE_HANDLE: StringHandle = StringHandle(6);
+        const DFU_UDS_CERT_HANDLE: StringHandle = StringHandle(7);
+        const DFU_CDI0_CERT_HANDLE: StringHandle = StringHandle(8);
+        const DFU_CDI1_CERT_HANDLE: StringHandle = StringHandle(9);
+
+        const CONFIG_DESC: ConfigDescriptor = ConfigDescriptor {
+            configuration_value: 1,
+            max_power: 250,
+            self_powered: false,
+            remote_wakeup: false,
+            interfaces: &[
+                InterfaceDescriptor {
+                    name: USB_CDC_COMM_HANDLE,
+                    interface_number: 0,
+                    alternate_setting: 0,
+                    interface_class: 0x02,
+                    interface_sub_class: 0x02,
+                    interface_protocol: 0x00,
+                    func_descs: &[
+                        FunctionalDescriptor::raw(0x24, &[0x00, 0x10, 0x01]),
+                        FunctionalDescriptor::raw(0x24, &[0x02, 0x02]),
+                        FunctionalDescriptor::raw(0x24, &[0x06, 0x00, 0x01]),
+                    ],
+                    endpoints: &[EndpointDescriptor {
+                        direction: Direction::DeviceToHost,
+                        endpoint_num: 1,
+                        interval: 255,
+                        max_packet_size: 8,
+                        transfer_type: TransferType::Interrupt,
+                    }],
+                },
+                InterfaceDescriptor {
+                    name: USB_CDC_DATA_HANDLE,
+                    interface_number: 1,
+                    alternate_setting: 0,
+                    interface_class: 0x0a,
+                    interface_sub_class: 0,
+                    interface_protocol: 0x00,
+                    func_descs: &[],
+                    endpoints: &[
+                        EndpointDescriptor {
+                            direction: Direction::HostToDevice,
+                            endpoint_num: 2,
+                            interval: 0,
+                            max_packet_size: 64,
+                            transfer_type: TransferType::Bulk,
+                        },
+                        EndpointDescriptor {
+                            direction: Direction::DeviceToHost,
+                            endpoint_num: 3,
+                            interval: 0,
+                            max_packet_size: 64,
+                            transfer_type: TransferType::Bulk,
+                        },
+                    ],
+                },
+                InterfaceDescriptor {
+                    name: DFU_FIRMWARE_HANDLE,
+                    interface_number: 2,
+                    alternate_setting: 0,
+                    interface_class: 0xfe,
+                    interface_sub_class: 0x01,
+                    interface_protocol: 0x01,
+                    func_descs: &[],
+                    endpoints: &[],
+                },
+                InterfaceDescriptor {
+                    name: DFU_UDS_CERT_HANDLE,
+                    interface_number: 2,
+                    alternate_setting: 1,
+                    interface_class: 0xfe,
+                    interface_sub_class: 0x01,
+                    interface_protocol: 0x01,
+                    func_descs: &[],
+                    endpoints: &[],
+                },
+                InterfaceDescriptor {
+                    name: DFU_CDI0_CERT_HANDLE,
+                    interface_number: 2,
+                    alternate_setting: 2,
+                    interface_class: 0xfe,
+                    interface_sub_class: 0x01,
+                    interface_protocol: 0x01,
+                    func_descs: &[],
+                    endpoints: &[],
+                },
+                InterfaceDescriptor {
+                    name: DFU_CDI1_CERT_HANDLE,
+                    interface_number: 2,
+                    alternate_setting: 3,
+                    interface_class: 0xfe,
+                    interface_sub_class: 0x01,
+                    interface_protocol: 0x01,
+                    func_descs: &[FunctionalDescriptor::raw(
+                        0x21,
+                        &[0x07, 0x00, 0x00, 0x00, 0x08, 0x10, 0x01],
+                    )],
+                    endpoints: &[],
+                },
+            ],
+        };
+
+        let bytes = CONFIG_DESC.serialize::<{ CONFIG_DESC.total_size() }>();
+
+        // Print the bytes for manual inspection
+        println!("Serialized: {bytes:?}");
+
+        // Assert size
+        assert_eq!(bytes.len(), 107);
+        assert_eq!(CONFIG_DESC.total_size(), 107);
+
+        // Assert bNumInterfaces (offset 4) is 3
+        assert_eq!(bytes[4], 3);
+
+        // Assert bLength (offset 0) is 9
+        assert_eq!(bytes[0], 9);
+
+        // Assert bDescriptorType (offset 1) is 2
+        assert_eq!(bytes[1], 2);
+
+        // Assert wTotalLength (offset 2, 3) is 107 (0x006b)
+        assert_eq!(bytes[2], 0x6b);
+        assert_eq!(bytes[3], 0x00);
+    }
+}

--- a/hal/blocking/usb/driver.rs
+++ b/hal/blocking/usb/driver.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! USB peripheral driver traits and events.
+//!
+//! This module defines the interface between the USB protocol stack and the
+//! hardware-specific peripheral driver.
+
+use aligned::Aligned;
+use aligned::A4;
+use core::mem::MaybeUninit;
+
+use crate::SetupPacket;
+
+/// A trait implemented by drivers for USB peripheral controllers.
+pub trait UsbDriver {
+    /// The maximum packet size supported by the hardware (typically 64 bytes).
+    const MAX_PACKET_SIZE: usize;
+    /// The type of packet returned by the driver.
+    type Packet<'a>: UsbPacket
+    where
+        Self: 'a;
+
+    /// Store data in a peripheral buffer that will be transferred to the host
+    /// when it requests data from the IN endpoint at `endpoint_idx`.
+    ///
+    /// If `zlp` is true and `data.len()` is a multiple of `MAX_PACKET_SIZE`,
+    /// the driver should send a zero-length packet (ZLP) after all data has
+    /// been acknowledged.
+    ///
+    /// The return value is the number of bytes that were copied into the
+    /// peripheral buffer. It will be either a multiple of `MAX_PACKET_SIZE`,
+    /// or `data.len()`.
+    ///
+    /// This function may fault or panic if `endpoint_idx` is invalid, or if the
+    /// hardware is in an invalid state.
+    fn transfer_in(&mut self, endpoint_idx: u8, data: &Aligned<A4, [u8]>, zlp: bool) -> usize;
+
+    /// Store data in a peripheral buffer that will be transferred to the host.
+    ///
+    /// This version accepts an unaligned data buffer.
+    fn transfer_in_unaligned(&mut self, endpoint_idx: u8, data: &[u8], zlp: bool) -> usize;
+
+    /// Stalls or unstalls an endpoint.
+    ///
+    /// Note: the driver will automatically unstall all endpoints upon a USB
+    /// reset or upon receiving a new SETUP packet on Endpoint 0.
+    fn stall(&mut self, endpoint_num: u8, stalled: bool);
+
+    /// Returns whether the specified endpoint is currently stalled.
+    fn is_stalled(&mut self, endpoint_num: u8) -> bool;
+
+    /// Sets the address the peripheral responds to.
+    ///
+    /// The USB stack must call this function in response to a `SET_ADDRESS`
+    /// control request on Endpoint 0.
+    fn set_address(&mut self, address: u8);
+
+    /// Polls the driver for a USB event.
+    ///
+    /// When a USB interrupt occurs, the USB stack should call this function
+    /// repeatedly until it returns `None`.
+    fn poll(&mut self) -> Option<UsbEvent<Self::Packet<'_>>>;
+}
+
+/// A trait representing a received USB packet.
+pub trait UsbPacket {
+    /// Returns the index of the endpoint the packet was received on.
+    fn endpoint_index(&self) -> usize;
+
+    /// Returns the length of the packet data in bytes.
+    fn len(&self) -> usize;
+
+    /// Copies the packet data from the peripheral buffer into system memory.
+    ///
+    /// This method allows copying into uninitialized memory.
+    /// Will fault if `self.len() > dest.len() * 4`.
+    fn copy_to_uninit(self, dest: &mut [MaybeUninit<u32>]) -> &[u8];
+
+    /// Copies the packet data from the peripheral buffer into system memory.
+    ///
+    /// Will fault if `self.len() > dest.len() * 4`.
+    fn copy_to(self, dest: &mut [u32]) -> &[u8];
+
+    /// Copies the packet data from the peripheral buffer into system memory.
+    ///
+    /// This version accepts an unaligned destination buffer.
+    fn copy_to_unaligned(self, dest: &mut [u8]) -> &[u8];
+
+    /// Returns `true` if the packet is empty (zero-length).
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Events that can be reported by a USB driver.
+pub enum UsbEvent<TPacket: UsbPacket> {
+    /// A SETUP packet has been received from the host.
+    SetupPacket {
+        /// The decoded SETUP packet.
+        pkt: SetupPacket,
+        /// The endpoint index (always 0 for standard SETUP packets).
+        endpoint: u8,
+    },
+
+    /// An OUT packet has been received from the host.
+    DataOutPacket(TPacket),
+
+    /// A packet has been sent by the peripheral and acknowledged by the host.
+    ///
+    /// This indicates that buffer space is now available on the specified
+    /// endpoint for further `transfer_in` calls.
+    PacketSent {
+        /// The index of the endpoint that sent the packet.
+        endpoint: u32,
+    },
+
+    /// VBus presence detected.
+    VBus,
+    /// VBus presence lost.
+    VBusLost,
+    /// USB link is down.
+    LinkDown,
+    /// USB link is up.
+    LinkUp,
+    /// USB bus reset received.
+    UsbReset,
+    /// USB bus suspend received.
+    Suspend,
+    /// USB bus resume received.
+    Resume,
+
+    /// Unexpected buffer ID error.
+    ErrorUnexpectedBufId,
+}

--- a/hal/blocking/usb/lib.rs
+++ b/hal/blocking/usb/lib.rs
@@ -1,0 +1,493 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(not(test), no_std)]
+
+//! USB Hardware Abstraction Layer (HAL) for blocking I/O.
+//!
+//! This module provides the foundational types and traits for implementing
+//! USB device drivers and protocol stacks. It includes definitions for
+//! standard USB requests, setup packets, and descriptors.
+
+mod descriptor;
+pub mod driver;
+
+#[cfg(feature = "ufmt_console")]
+use ufmt::derive::uDebug;
+
+pub use descriptor::*;
+
+// Big endian is dead; code in this file assumes little-endian
+const _: () = assert!(cfg!(target_endian = "little"));
+
+/// Represents a USB control request.
+///
+/// A request combines the `bmRequestType` and `bRequest` fields from a
+/// USB SETUP packet into a single type-safe representation.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Request(u16);
+#[allow(clippy::identity_op)]
+impl Request {
+    /// Creates a new USB request.
+    pub const fn new(
+        direction: Direction,
+        ty: RequestType,
+        recipient: Recipient,
+        request: u8,
+    ) -> Self {
+        Self(
+            ((direction as u16) << 7)
+                | ((ty as u16) << 5)
+                | ((recipient as u16) << 0)
+                | ((request as u16) << 8),
+        )
+    }
+    /// Returns the direction of the request (Host-to-Device or Device-to-Host).
+    pub fn direction(&self) -> Direction {
+        Direction::try_from((u32::from(self.0) >> 7) & 0x1).unwrap()
+    }
+    /// Returns the type of the request (Standard, Class, Vendor, or Reserved).
+    pub fn request_type(&self) -> RequestType {
+        RequestType::try_from(u32::from((self.0 >> 5) & 0x3)).unwrap()
+    }
+    /// Returns the recipient of the request (Device, Interface, Endpoint, or Other).
+    pub fn recipient(&self) -> Recipient {
+        Recipient::try_from(u32::from((self.0 >> 0) & 0x1f)).unwrap()
+    }
+    /// Returns the specific request code.
+    pub fn request(&self) -> u8 {
+        u8::try_from((self.0 >> 8) & 0xff).unwrap()
+    }
+}
+#[cfg(feature = "ufmt_console")]
+impl ufmt::uDebug for Request {
+    fn fmt<W: ufmt::uWrite + ?Sized>(
+        &self,
+        f: &mut ufmt::Formatter<'_, W>,
+    ) -> Result<(), W::Error> {
+        f.debug_struct("usb::Request")?
+            .field("request_type", &self.request_type())?
+            .field("direction", &self.direction())?
+            .field("recipient", &self.recipient())?
+            .field("request", &self.request())?
+            .finish()
+    }
+}
+impl Request {
+    /// Standard DEVICE request to get the current status.
+    pub const DEVICE_GET_STATUS: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Device,
+        0x00,
+    );
+    /// Standard DEVICE request to clear a feature.
+    pub const DEVICE_CLEAR_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Device,
+        0x01,
+    );
+    /// Standard DEVICE request to set a feature.
+    pub const DEVICE_SET_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Device,
+        0x03,
+    );
+    /// Standard DEVICE request to set the device address.
+    pub const DEVICE_SET_ADDRESS: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Device,
+        0x05,
+    );
+    /// Standard DEVICE request to get a descriptor.
+    pub const DEVICE_GET_DESCRIPTOR: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Device,
+        0x06,
+    );
+    /// Standard DEVICE request to set a descriptor.
+    pub const DEVICE_SET_DESCRIPTOR: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Device,
+        0x07,
+    );
+    /// Standard DEVICE request to get the current configuration.
+    pub const DEVICE_GET_CONFIGURATION: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Device,
+        0x08,
+    );
+    /// Standard DEVICE request to set the current configuration.
+    pub const DEVICE_SET_CONFIGURATION: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Device,
+        0x09,
+    );
+    /// Standard INTERFACE request to get the current status.
+    pub const INTERFACE_GET_STATUS: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Interface,
+        0x00,
+    );
+    /// Standard INTERFACE request to clear a feature.
+    pub const INTERFACE_CLEAR_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Interface,
+        0x01,
+    );
+    /// Standard INTERFACE request to set a feature.
+    pub const INTERFACE_SET_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Interface,
+        0x03,
+    );
+    /// Standard INTERFACE request to get the current interface setting.
+    pub const INTERFACE_GET_INTERFACE: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Interface,
+        0x0a,
+    );
+    /// Standard INTERFACE request to set the interface setting.
+    pub const INTERFACE_SET_INTERFACE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Interface,
+        0x0b,
+    );
+    /// Standard ENDPOINT request to get the current status.
+    pub const ENDPOINT_GET_STATUS: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Endpoint,
+        0x00,
+    );
+    /// Standard ENDPOINT request to clear a feature.
+    pub const ENDPOINT_CLEAR_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Endpoint,
+        0x01,
+    );
+    /// Standard ENDPOINT request to set a feature.
+    pub const ENDPOINT_SET_FEATURE: Self = Self::new(
+        Direction::HostToDevice,
+        RequestType::Standard,
+        Recipient::Endpoint,
+        0x03,
+    );
+    /// Standard ENDPOINT request to synchronize frames.
+    pub const ENDPOINT_SYNCH_FRAME: Self = Self::new(
+        Direction::DeviceToHost,
+        RequestType::Standard,
+        Recipient::Endpoint,
+        0x12,
+    );
+}
+impl From<Request> for u16 {
+    fn from(val: Request) -> Self {
+        val.0
+    }
+}
+#[cfg(test)]
+mod request_tests {
+    use super::*;
+    #[test]
+    fn test_constants() {
+        assert_eq!(u16::from(Request::DEVICE_GET_STATUS), 0x0080);
+        assert_eq!(u16::from(Request::DEVICE_CLEAR_FEATURE), 0x0100);
+        assert_eq!(u16::from(Request::DEVICE_SET_FEATURE), 0x0300);
+        assert_eq!(u16::from(Request::DEVICE_SET_ADDRESS), 0x0500);
+        assert_eq!(u16::from(Request::DEVICE_GET_DESCRIPTOR), 0x0680);
+        assert_eq!(u16::from(Request::DEVICE_SET_DESCRIPTOR), 0x0700);
+        assert_eq!(u16::from(Request::DEVICE_GET_CONFIGURATION), 0x0880);
+        assert_eq!(u16::from(Request::DEVICE_SET_CONFIGURATION), 0x0900);
+        assert_eq!(u16::from(Request::INTERFACE_GET_STATUS), 0x0081);
+        assert_eq!(u16::from(Request::INTERFACE_CLEAR_FEATURE), 0x0101);
+        assert_eq!(u16::from(Request::INTERFACE_SET_FEATURE), 0x0301);
+        assert_eq!(u16::from(Request::INTERFACE_GET_INTERFACE), 0x0a81);
+        assert_eq!(u16::from(Request::INTERFACE_SET_INTERFACE), 0x0b01);
+        assert_eq!(u16::from(Request::ENDPOINT_GET_STATUS), 0x0082);
+        assert_eq!(u16::from(Request::ENDPOINT_CLEAR_FEATURE), 0x0102);
+        assert_eq!(u16::from(Request::ENDPOINT_SET_FEATURE), 0x0302);
+        assert_eq!(u16::from(Request::ENDPOINT_SYNCH_FRAME), 0x1282);
+    }
+}
+
+/// Information about a USB descriptor request.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "ufmt_console", derive(uDebug))]
+pub struct DescriptorInfo {
+    /// The index of the descriptor.
+    pub index: u8,
+    /// The type of the descriptor.
+    pub ty: DescriptorType,
+    /// The language ID (for string descriptors).
+    pub lang: u16,
+}
+impl From<&SetupPacket> for DescriptorInfo {
+    fn from(pkt: &SetupPacket) -> Self {
+        DescriptorInfo {
+            index: u8::try_from(pkt.value() & 0xff).unwrap(),
+            ty: DescriptorType::from(u8::try_from((pkt.value() >> 8) & 0xff).unwrap()),
+            lang: pkt.index(),
+        }
+    }
+}
+
+/// Represents a standard USB SETUP packet.
+///
+/// A SETUP packet is always 8 bytes long and is used for all control transfers
+/// on Endpoint 0.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct SetupPacket {
+    buf: [u32; 2],
+}
+impl SetupPacket {
+    /// Creates a new `SetupPacket` from two 32-bit words.
+    pub fn new(buf: [u32; 2]) -> SetupPacket {
+        SetupPacket { buf }
+    }
+    /// Returns the control request information.
+    pub fn request(&self) -> Request {
+        Request(u16::try_from(self.buf[0] & 0xffff).unwrap())
+    }
+    /// Returns the `wValue` field of the SETUP packet.
+    pub fn value(&self) -> u16 {
+        u16::try_from((self.buf[0] >> 16) & 0xffff).unwrap()
+    }
+    /// Returns the `wIndex` field of the SETUP packet.
+    #[allow(clippy::identity_op)]
+    pub fn index(&self) -> u16 {
+        u16::try_from((self.buf[1] >> 0) & 0xffff).unwrap()
+    }
+    /// Returns the `wLength` field of the SETUP packet, which indicates
+    /// the number of bytes to transfer in the data stage.
+    pub fn length(&self) -> u16 {
+        u16::try_from((self.buf[1] >> 16) & 0xffff).unwrap()
+    }
+}
+#[cfg(feature = "ufmt_console")]
+impl ufmt::uDebug for SetupPacket {
+    fn fmt<W: ufmt::uWrite + ?Sized>(
+        &self,
+        f: &mut ufmt::Formatter<'_, W>,
+    ) -> Result<(), W::Error> {
+        f.debug_struct("usb::SetupPacket")?
+            .field("request", &self.request())?
+            .field("value", &self.value())?
+            .field("index", &self.index())?
+            .field("length", &self.length())?
+            .finish()
+    }
+}
+
+/// USB data transfer direction.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "ufmt_console", derive(uDebug))]
+pub enum Direction {
+    /// Host to Device (OUT).
+    HostToDevice = 0,
+    /// Device to Host (IN).
+    DeviceToHost = 1,
+}
+impl From<Direction> for u32 {
+    fn from(val: Direction) -> u32 {
+        val as u32
+    }
+}
+impl TryFrom<u32> for Direction {
+    type Error = ();
+    #[inline(always)]
+    fn try_from(val: u32) -> Result<Direction, ()> {
+        match val {
+            0 => Ok(Self::HostToDevice),
+            1 => Ok(Self::DeviceToHost),
+            _ => Err(()),
+        }
+    }
+}
+
+/// The type of a USB control request.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "ufmt_console", derive(uDebug))]
+pub enum RequestType {
+    /// Standard USB request.
+    Standard = 0,
+    /// Class-specific request.
+    Class = 1,
+    /// Vendor-specific request.
+    Vendor = 2,
+    /// Reserved for future use.
+    Reserved = 3,
+}
+impl TryFrom<u32> for RequestType {
+    type Error = ();
+    #[inline(always)]
+    fn try_from(val: u32) -> Result<RequestType, ()> {
+        match val {
+            0 => Ok(Self::Standard),
+            1 => Ok(Self::Class),
+            2 => Ok(Self::Vendor),
+            3 => Ok(Self::Reserved),
+            _ => Err(()),
+        }
+    }
+}
+impl From<RequestType> for u32 {
+    fn from(val: RequestType) -> Self {
+        val as u32
+    }
+}
+
+/// The intended recipient of a USB control request.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "ufmt_console", derive(uDebug))]
+pub enum Recipient {
+    /// The device itself.
+    Device = 0,
+    /// A specific interface on the device.
+    Interface = 1,
+    /// A specific endpoint on the device.
+    Endpoint = 2,
+    /// Other recipients (e.g., class-specific).
+    Other = 3,
+    Reserved4 = 4,
+    Reserved5 = 5,
+    Reserved6 = 6,
+    Reserved7 = 7,
+    Reserved8 = 8,
+    Reserved9 = 9,
+    Reserved10 = 10,
+    Reserved11 = 11,
+    Reserved12 = 12,
+    Reserved13 = 13,
+    Reserved14 = 14,
+    Reserved15 = 15,
+    Reserved16 = 16,
+    Reserved17 = 17,
+    Reserved18 = 18,
+    Reserved19 = 19,
+    Reserved20 = 20,
+    Reserved21 = 21,
+    Reserved22 = 22,
+    Reserved23 = 23,
+    Reserved24 = 24,
+    Reserved25 = 25,
+    Reserved26 = 26,
+    Reserved27 = 27,
+    Reserved28 = 28,
+    Reserved29 = 29,
+    Reserved30 = 30,
+    Reserved31 = 31,
+}
+impl TryFrom<u32> for Recipient {
+    type Error = ();
+    #[inline(always)]
+    fn try_from(val: u32) -> Result<Recipient, ()> {
+        // TODO: Evaluate whether the optimizer is smart enough for this, and use
+        // transmute if it's not.
+        match val {
+            0 => Ok(Self::Device),
+            1 => Ok(Self::Interface),
+            2 => Ok(Self::Endpoint),
+            3 => Ok(Self::Other),
+            4 => Ok(Self::Reserved4),
+            5 => Ok(Self::Reserved5),
+            6 => Ok(Self::Reserved6),
+            7 => Ok(Self::Reserved7),
+            8 => Ok(Self::Reserved8),
+            9 => Ok(Self::Reserved9),
+            10 => Ok(Self::Reserved10),
+            11 => Ok(Self::Reserved11),
+            12 => Ok(Self::Reserved12),
+            13 => Ok(Self::Reserved13),
+            14 => Ok(Self::Reserved14),
+            15 => Ok(Self::Reserved15),
+            16 => Ok(Self::Reserved16),
+            17 => Ok(Self::Reserved17),
+            18 => Ok(Self::Reserved18),
+            19 => Ok(Self::Reserved19),
+            20 => Ok(Self::Reserved20),
+            21 => Ok(Self::Reserved21),
+            22 => Ok(Self::Reserved22),
+            23 => Ok(Self::Reserved23),
+            24 => Ok(Self::Reserved24),
+            25 => Ok(Self::Reserved25),
+            26 => Ok(Self::Reserved26),
+            27 => Ok(Self::Reserved27),
+            28 => Ok(Self::Reserved28),
+            29 => Ok(Self::Reserved29),
+            30 => Ok(Self::Reserved30),
+            31 => Ok(Self::Reserved31),
+            _ => Err(()),
+        }
+    }
+}
+impl From<Recipient> for u32 {
+    fn from(val: Recipient) -> Self {
+        val as u32
+    }
+}
+
+/// Standard USB descriptor types.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct DescriptorType(u8);
+impl DescriptorType {
+    /// Device descriptor.
+    pub const DEVICE: Self = Self(1);
+    /// Configuration descriptor.
+    pub const CONFIGURATION: Self = Self(2);
+    /// String descriptor.
+    pub const STRING: Self = Self(3);
+    /// Interface descriptor.
+    pub const INTERFACE: Self = Self(4);
+    /// Endpoint descriptor.
+    pub const ENDPOINT: Self = Self(5);
+    /// Device qualifier descriptor.
+    pub const DEVICE_QUALIFIER: Self = Self(6);
+}
+impl From<u8> for DescriptorType {
+    fn from(val: u8) -> Self {
+        DescriptorType(val)
+    }
+}
+impl From<DescriptorType> for u8 {
+    fn from(val: DescriptorType) -> Self {
+        val.0
+    }
+}
+impl From<DescriptorType> for u32 {
+    fn from(val: DescriptorType) -> Self {
+        u32::from(val.0)
+    }
+}
+#[cfg(feature = "ufmt_console")]
+impl ufmt::uDebug for DescriptorType {
+    fn fmt<W: ufmt::uWrite + ?Sized>(
+        &self,
+        f: &mut ufmt::Formatter<'_, W>,
+    ) -> Result<(), W::Error> {
+        match *self {
+            Self::DEVICE => f.write_str("DEVICE"),
+            Self::CONFIGURATION => f.write_str("CONFIGURATION"),
+            Self::STRING => f.write_str("STRING"),
+            Self::INTERFACE => f.write_str("INTERFACE"),
+            Self::ENDPOINT => f.write_str("ENDPOINT"),
+            Self::DEVICE_QUALIFIER => f.write_str("DEVICE_QUALIFIER"),
+            other => ufmt::uwrite!(f, "{}", other.0),
+        }
+    }
+}

--- a/protocol/usb/cdc_acm/BUILD.bazel
+++ b/protocol/usb/cdc_acm/BUILD.bazel
@@ -1,0 +1,20 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+rust_library(
+    name = "cdc_acm",
+    srcs = ["lib.rs"],
+    crate_name = "protocol_usb_cdc_acm",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking/usb:hal_usb",
+        "//protocol/usb/stack",
+        "//target/earlgrey/drivers:usb_driver",
+        "//util/ringbuffer",
+        "@rust_crates//:aligned",
+        "@rust_crates//:zerocopy",
+    ],
+)

--- a/protocol/usb/cdc_acm/lib.rs
+++ b/protocol/usb/cdc_acm/lib.rs
@@ -1,0 +1,415 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! CDC-ACM (Serial) USB class implementation.
+
+#![no_std]
+
+pub use hal_usb::driver::{UsbDriver, UsbEvent, UsbPacket};
+pub use hal_usb::{
+    Direction, EndpointDescriptor, FunctionalDescriptor, InterfaceDescriptor, Recipient, Request,
+    RequestType, SetupPacket, StringHandle, TransferType,
+};
+pub use usb_driver::{EpIn, EpOut};
+use usb_stack::{UsbAction, UsbClass, EMPTY};
+use util_ringbuffer::RingBuffer;
+use zerocopy::{Immutable, IntoBytes};
+
+/// CDC-ACM specific constants.
+pub const USB_CLASS_CDC: u8 = 0x02;
+pub const USB_CLASS_CDC_DATA: u8 = 0x0a;
+pub const CDC_SUBCLASS_ACM: u8 = 0x02;
+pub const CDC_PROTOCOL_NONE: u8 = 0x00;
+
+pub const CS_INTERFACE: u8 = 0x24;
+pub const CDC_TYPE_HEADER: u8 = 0x00;
+pub const CDC_TYPE_ACM: u8 = 0x02;
+pub const CDC_TYPE_UNION: u8 = 0x06;
+
+/// CDC-ACM specific requests.
+pub const REQ_SEND_ENCAPSULATED_COMMAND: Request = Request::new(
+    Direction::HostToDevice,
+    RequestType::Class,
+    Recipient::Interface,
+    0x00,
+);
+pub const REQ_GET_ENCAPSULATED_COMMAND: Request = Request::new(
+    Direction::DeviceToHost,
+    RequestType::Class,
+    Recipient::Interface,
+    0x01,
+);
+pub const REQ_SET_LINE_CODING: Request = Request::new(
+    Direction::HostToDevice,
+    RequestType::Class,
+    Recipient::Interface,
+    0x20,
+);
+pub const REQ_GET_LINE_CODING: Request = Request::new(
+    Direction::DeviceToHost,
+    RequestType::Class,
+    Recipient::Interface,
+    0x21,
+);
+pub const REQ_SET_CONTROL_LINE_STATE: Request = Request::new(
+    Direction::HostToDevice,
+    RequestType::Class,
+    Recipient::Interface,
+    0x22,
+);
+
+#[derive(Copy, Clone, PartialEq, Eq, Default, IntoBytes, Immutable)]
+#[repr(u8)]
+pub enum StopBits {
+    #[default]
+    One = 0,
+    OnePointFive = 1,
+    Two = 2,
+}
+
+impl From<u8> for StopBits {
+    fn from(x: u8) -> Self {
+        match x {
+            0 => StopBits::One,
+            1 => StopBits::OnePointFive,
+            2 => StopBits::Two,
+            _ => StopBits::One,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Default, IntoBytes, Immutable)]
+#[repr(u8)]
+pub enum Parity {
+    #[default]
+    None = 0,
+    Odd = 1,
+    Even = 2,
+    Mark = 3,
+    Space = 4,
+}
+
+impl From<u8> for Parity {
+    fn from(x: u8) -> Self {
+        match x {
+            0 => Parity::None,
+            1 => Parity::Odd,
+            2 => Parity::Even,
+            3 => Parity::Mark,
+            4 => Parity::Space,
+            _ => Parity::None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct LineCoding {
+    pub data_rate: u32,
+    pub stop_bits: StopBits,
+    pub parity: Parity,
+    pub data_bits: u8,
+    // In order to be zerocopy, this struct needs to align and pad as u32.
+    pub _pad: u8,
+}
+
+impl TryFrom<&[u8]> for LineCoding {
+    type Error = ();
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        if data.len() >= 7 {
+            Ok(LineCoding {
+                data_rate: u32::from_le_bytes(data[0..4].try_into().unwrap()),
+                stop_bits: StopBits::from(data[4]),
+                parity: Parity::from(data[5]),
+                data_bits: data[6],
+                _pad: 0,
+            })
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl Default for LineCoding {
+    fn default() -> Self {
+        LineCoding {
+            data_rate: 9600,
+            stop_bits: StopBits::default(),
+            parity: Parity::default(),
+            data_bits: 8,
+            _pad: 0,
+        }
+    }
+}
+
+impl LineCoding {
+    pub fn as_bytes(&self) -> &[u8] {
+        // The size_of::<LineCoding>() is 8, but CDC-ACM uses only 7 bytes.
+        let bytes = <Self as IntoBytes>::as_bytes(self);
+        &bytes[..7]
+    }
+}
+
+/// A builder for CDC-ACM class configuration.
+///
+/// This builder encapsulates the constants and configuration logic for a
+/// CDC-ACM instance. It provides methods to generate descriptor fragments
+/// and the final `InterfaceDescriptor` structs, hiding class-specific details
+/// from the application.
+///
+/// # Convention
+/// USB classes should provide a `Builder` struct with `const` methods that:
+/// 1. Return arrays of child descriptors (functional, endpoints).
+/// 2. Construct fully-populated `InterfaceDescriptor`s from application-provided
+///    handles and static fragments.
+/// 3. Provide hardware configuration (`EpIn`, `EpOut`).
+#[derive(Copy, Clone)]
+pub struct CdcAcmBuilder {
+    pub comm_if: u8,
+    pub data_if: u8,
+    pub comm_ep: u8,
+    pub data_out_ep: u8,
+    pub data_in_ep: u8,
+}
+
+impl CdcAcmBuilder {
+    /// Creates a new CDC-ACM configuration.
+    pub const fn new(
+        comm_if: u8,
+        data_if: u8,
+        comm_ep: u8,
+        data_out_ep: u8,
+        data_in_ep: u8,
+    ) -> Self {
+        Self {
+            comm_if,
+            data_if,
+            comm_ep,
+            data_out_ep,
+            data_in_ep,
+        }
+    }
+
+    /// Returns the functional descriptors for the control interface.
+    pub const fn comm_func_descs(&self) -> [FunctionalDescriptor; 3] {
+        [
+            FunctionalDescriptor::raw(CS_INTERFACE, &[CDC_TYPE_HEADER, 0x10, 0x01]),
+            FunctionalDescriptor::raw(CS_INTERFACE, &[CDC_TYPE_ACM, 0x02]),
+            FunctionalDescriptor::raw(CS_INTERFACE, &[CDC_TYPE_UNION, self.comm_if, self.data_if]),
+        ]
+    }
+
+    /// Returns the endpoints for the control interface.
+    pub const fn comm_endpoints(&self) -> [EndpointDescriptor; 1] {
+        [EndpointDescriptor {
+            direction: Direction::DeviceToHost,
+            endpoint_num: self.comm_ep,
+            interval: 255,
+            max_packet_size: 8,
+            transfer_type: TransferType::Interrupt,
+        }]
+    }
+
+    /// Returns the endpoints for the data interface.
+    pub const fn data_endpoints(&self) -> [EndpointDescriptor; 2] {
+        [
+            EndpointDescriptor {
+                direction: Direction::HostToDevice,
+                endpoint_num: self.data_out_ep,
+                interval: 0,
+                max_packet_size: 64,
+                transfer_type: TransferType::Bulk,
+            },
+            EndpointDescriptor {
+                direction: Direction::DeviceToHost,
+                endpoint_num: self.data_in_ep,
+                interval: 0,
+                max_packet_size: 64,
+                transfer_type: TransferType::Bulk,
+            },
+        ]
+    }
+
+    /// Constructs the CDC-ACM Communication (Control) interface descriptor.
+    pub const fn comm_interface(
+        &self,
+        name: StringHandle,
+        func_descs: &'static [FunctionalDescriptor],
+        endpoints: &'static [EndpointDescriptor],
+    ) -> InterfaceDescriptor {
+        InterfaceDescriptor {
+            name,
+            interface_number: self.comm_if,
+            alternate_setting: 0,
+            interface_class: USB_CLASS_CDC,
+            interface_sub_class: CDC_SUBCLASS_ACM,
+            interface_protocol: CDC_PROTOCOL_NONE,
+            func_descs,
+            endpoints,
+        }
+    }
+
+    /// Constructs the CDC-ACM Data interface descriptor.
+    pub const fn data_interface(
+        &self,
+        name: StringHandle,
+        endpoints: &'static [EndpointDescriptor],
+    ) -> InterfaceDescriptor {
+        InterfaceDescriptor {
+            name,
+            interface_number: self.data_if,
+            alternate_setting: 0,
+            interface_class: USB_CLASS_CDC_DATA,
+            interface_sub_class: 0,
+            interface_protocol: CDC_PROTOCOL_NONE,
+            func_descs: &[],
+            endpoints,
+        }
+    }
+
+    /// Returns the hardware endpoint configuration for this CDC-ACM instance.
+    pub const fn eps(&self) -> ([EpIn; 2], [EpOut; 1]) {
+        (
+            [
+                EpIn {
+                    num: self.comm_ep,
+                    buf_pool_size: 1,
+                },
+                EpIn {
+                    num: self.data_in_ep,
+                    buf_pool_size: 1,
+                },
+            ],
+            [EpOut {
+                num: self.data_out_ep,
+                set_nak: false,
+            }],
+        )
+    }
+}
+
+/// CDC-ACM class handler.
+pub struct CdcAcm<const RX_SIZE: usize, const TX_SIZE: usize> {
+    config: CdcAcmBuilder,
+    line_coding: LineCoding,
+    expecting_control_out: bool,
+    control_buf: [u8; 8],
+    pub rx_queue: RingBuffer<u8, RX_SIZE>,
+    pub tx_queue: RingBuffer<u8, TX_SIZE>,
+}
+
+impl<const RX_SIZE: usize, const TX_SIZE: usize> CdcAcm<RX_SIZE, TX_SIZE> {
+    /// Creates a new CDC-ACM class handler from a builder.
+    pub fn new(config: CdcAcmBuilder) -> Self {
+        Self {
+            config,
+            line_coding: LineCoding::default(),
+            expecting_control_out: false,
+            control_buf: [0u8; 8],
+            rx_queue: RingBuffer::default(),
+            tx_queue: RingBuffer::default(),
+        }
+    }
+
+    /// Returns the configuration builder for this instance.
+    pub fn config(&self) -> &CdcAcmBuilder {
+        &self.config
+    }
+
+    fn handle_setup<'a>(&'a mut self, pkt: SetupPacket) -> (UsbAction<'a>, bool) {
+        if !(pkt.request().recipient() == Recipient::Interface
+            && (pkt.index() as u8) == self.config.comm_if)
+        {
+            return (UsbAction::None, false);
+        }
+
+        match pkt.request() {
+            REQ_SEND_ENCAPSULATED_COMMAND => (
+                UsbAction::TransferIn {
+                    endpoint: 0,
+                    data: EMPTY,
+                    zlp: true,
+                },
+                false,
+            ),
+            REQ_GET_ENCAPSULATED_COMMAND => (UsbAction::StallInAndOut { endpoint: 0 }, false),
+            REQ_SET_LINE_CODING => {
+                self.expecting_control_out = true;
+                (UsbAction::None, true)
+            }
+            REQ_GET_LINE_CODING => (
+                UsbAction::TransferInUnaligned {
+                    endpoint: 0,
+                    data: self.line_coding.as_bytes(),
+                    zlp: true,
+                },
+                false,
+            ),
+            REQ_SET_CONTROL_LINE_STATE => (
+                UsbAction::TransferIn {
+                    endpoint: 0,
+                    data: EMPTY,
+                    zlp: true,
+                },
+                false,
+            ),
+            _ => (UsbAction::StallInAndOut { endpoint: 0 }, false),
+        }
+    }
+
+    fn handle_control_out<'a>(&'a mut self, pkt: impl UsbPacket) -> UsbAction<'a> {
+        let buf = pkt.copy_to_unaligned(&mut self.control_buf);
+        self.expecting_control_out = false;
+        match LineCoding::try_from(buf) {
+            Ok(x) => {
+                self.line_coding = x;
+                UsbAction::TransferIn {
+                    endpoint: 0,
+                    data: EMPTY,
+                    zlp: true,
+                }
+            }
+            Err(_) => UsbAction::StallInAndOut { endpoint: 0 },
+        }
+    }
+
+    /// Polls the send buffer and initiates IN transfers if data is available.
+    pub fn poll_transmit<D: UsbDriver>(&mut self, driver: &mut D) {
+        let data = self.tx_queue.as_slice();
+        if !data.is_empty() {
+            let n = driver.transfer_in_unaligned(self.config.data_in_ep, data, true);
+            self.tx_queue.consume(n);
+        }
+    }
+}
+
+impl<const RX_SIZE: usize, const TX_SIZE: usize> UsbClass for CdcAcm<RX_SIZE, TX_SIZE> {
+    fn handle_event<'a, P: UsbPacket>(
+        &'a mut self,
+        event: UsbEvent<P>,
+    ) -> Result<UsbAction<'a>, UsbEvent<P>> {
+        match event {
+            UsbEvent::SetupPacket { pkt, endpoint } if endpoint == 0 => {
+                let (action, claimed) = self.handle_setup(pkt);
+                if action != UsbAction::None || claimed {
+                    Ok(action)
+                } else {
+                    Err(UsbEvent::SetupPacket { pkt, endpoint })
+                }
+            }
+            UsbEvent::DataOutPacket(pkt) => {
+                if pkt.endpoint_index() == 0 && self.expecting_control_out {
+                    Ok(self.handle_control_out(pkt))
+                } else if pkt.endpoint_index() == self.config.data_out_ep as usize {
+                    let mut tmp = [0u8; 64];
+                    let buf = pkt.copy_to_unaligned(&mut tmp);
+                    let _ = self.rx_queue.push_slice(buf);
+                    Ok(UsbAction::None)
+                } else {
+                    Err(UsbEvent::DataOutPacket(pkt))
+                }
+            }
+            _ => Err(event),
+        }
+    }
+}

--- a/protocol/usb/stack/BUILD.bazel
+++ b/protocol/usb/stack/BUILD.bazel
@@ -1,0 +1,29 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "stack",
+    srcs = [
+        "lib.rs",
+    ],
+    crate_name = "usb_stack",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking/usb:hal_usb",
+        "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:aligned",
+        "@rust_crates//:zerocopy",
+    ],
+)
+
+rust_test(
+    name = "stack_test",
+    crate = ":stack",
+    rustc_flags = [
+        "-C",
+        "debug-assertions",
+    ],
+)

--- a/protocol/usb/stack/lib.rs
+++ b/protocol/usb/stack/lib.rs
@@ -1,0 +1,1129 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic USB protocol stack.
+//!
+//! This module provides the core logic for a USB device stack, including
+//! Endpoint 0 control request handling, descriptor management, and
+//! multi-packet transfer accumulation.
+
+#![no_std]
+
+use aligned::Aligned;
+use aligned::A4;
+use core::mem::size_of;
+use hal_usb::driver::UsbDriver;
+use hal_usb::driver::UsbEvent;
+use hal_usb::driver::UsbPacket;
+use hal_usb::DescriptorInfo;
+use hal_usb::DescriptorType;
+use hal_usb::Request;
+use hal_usb::SetupPacket;
+use hal_usb::StringDescriptorRef;
+use hal_usb::StringHandle;
+use zerocopy::IntoBytes;
+
+use pw_status::Error;
+
+pub const CONFIG_0: Aligned<A4, [u8; 1]> = Aligned([0]);
+pub const CONFIG_1: Aligned<A4, [u8; 1]> = Aligned([1]);
+pub const STATUS_OK: Aligned<A4, [u8; 2]> = Aligned([0, 0]);
+pub const STATUS_HALTED: Aligned<A4, [u8; 2]> = Aligned([1, 0]);
+
+#[inline(always)]
+const fn endpoint_number(endpoint_addr: u8) -> u8 {
+    endpoint_addr & 0x0f
+}
+
+#[inline(always)]
+const fn endpoint_is_in(endpoint_addr: u8) -> bool {
+    (endpoint_addr & 0x80) != 0
+}
+
+#[inline(always)]
+const fn endpoint_bit_index(endpoint_addr: u8) -> u32 {
+    let num = endpoint_number(endpoint_addr) as u32;
+    if endpoint_is_in(endpoint_addr) {
+        16 + num
+    } else {
+        num
+    }
+}
+
+/// A trait for providing USB descriptors to the stack.
+///
+/// Applications must implement this trait to define the device's identity
+/// and capabilities.
+pub trait DescriptorSource {
+    /// Device descriptor bytes.
+    const DEVICE_DESC_BYTES: &'static Aligned<A4, [u8]>;
+    /// Configuration descriptor bytes (including interfaces and endpoints).
+    const CONFIG_DESC_BYTES: &'static Aligned<A4, [u8]>;
+    /// String descriptor 0 bytes (supported languages).
+    const STRING_DESC_0_BYTES: &'static Aligned<A4, [u8]>;
+    /// Device status bytes (2 bytes, usually [0, 0]).
+    const DEVICE_STATUS: Aligned<A4, [u8; 2]>;
+
+    /// Returns a string descriptor by handle and language ID.
+    fn get_string(&self, handle: StringHandle, lang: u16) -> Option<StringDescriptorRef<'_>>;
+    /// Returns the device status bytes.
+    fn get_device_status(&self) -> &Aligned<A4, [u8]> {
+        &Self::DEVICE_STATUS
+    }
+}
+
+/// An empty aligned buffer.
+pub const EMPTY: &Aligned<A4, [u8]> = &Aligned([]);
+
+/// A simple implementation of USB Endpoint 0 (control endpoint).
+pub struct SimpleEp0 {
+    new_address: Option<u8>,
+    configuration: u8,
+    halted_endpoints: u32,
+    pending_halt: Option<(u8, bool)>,
+}
+
+/// A trait for modular USB class implementations.
+pub trait UsbClass {
+    /// Attempt to handle a USB event.
+    ///
+    /// If the event is handled by this class, it returns `Ok(UsbAction)`.
+    /// Otherwise, it returns the original event in `Err`.
+    fn handle_event<'a, P: UsbPacket>(
+        &'a mut self,
+        event: UsbEvent<P>,
+    ) -> Result<UsbAction<'a>, UsbEvent<P>>;
+}
+
+/// Indicates the result of running a USB action.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum UsbActionRun {
+    /// No operation was performed.
+    NoOp,
+    /// The action has more data to transfer.
+    HasMoreData,
+    /// The action is complete.
+    Done,
+}
+
+/// Actions to be performed on a USB driver.
+pub enum UsbAction<'a> {
+    /// No action.
+    None,
+    /// Perform an IN transfer on the specified endpoint.
+    TransferIn {
+        /// The endpoint index.
+        endpoint: u8,
+        /// The data to transfer.
+        data: &'a Aligned<A4, [u8]>,
+        /// If true, send a zero-length packet (ZLP) if the data length
+        /// is a multiple of the maximum packet size.
+        zlp: bool,
+    },
+    /// Perform an IN transfer on the specified endpoint using unaligned data.
+    TransferInUnaligned {
+        /// The endpoint index.
+        endpoint: u8,
+        /// The data to transfer.
+        data: &'a [u8],
+        /// If true, send a zero-length packet (ZLP) if the data length
+        /// is a multiple of the maximum packet size.
+        zlp: bool,
+    },
+    /// Stall both IN and OUT directions on the specified endpoint.
+    StallInAndOut {
+        /// The endpoint index.
+        endpoint: u8,
+    },
+    /// Set the device address.
+    SetAddress {
+        /// The new device address.
+        new_address: u8,
+    },
+    /// Set the stall status of an endpoint.
+    EndpointHalt {
+        /// The endpoint address.
+        endpoint_addr: u8,
+        /// Whether to stall or unstall the endpoint.
+        halted: bool,
+    },
+}
+
+impl PartialEq for UsbAction<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::None, Self::None) => true,
+            (
+                Self::TransferIn {
+                    endpoint: e1,
+                    data: d1,
+                    zlp: z1,
+                },
+                Self::TransferIn {
+                    endpoint: e2,
+                    data: d2,
+                    zlp: z2,
+                },
+            ) => e1 == e2 && core::ptr::eq(*d1, *d2) && z1 == z2,
+            (
+                Self::TransferInUnaligned {
+                    endpoint: e1,
+                    data: d1,
+                    zlp: z1,
+                },
+                Self::TransferInUnaligned {
+                    endpoint: e2,
+                    data: d2,
+                    zlp: z2,
+                },
+            ) => e1 == e2 && core::ptr::eq(*d1, *d2) && z1 == z2,
+            (Self::StallInAndOut { endpoint: e1 }, Self::StallInAndOut { endpoint: e2 }) => {
+                e1 == e2
+            }
+            (Self::SetAddress { new_address: a1 }, Self::SetAddress { new_address: a2 }) => {
+                a1 == a2
+            }
+            (
+                Self::EndpointHalt {
+                    endpoint_addr: a1,
+                    halted: h1,
+                },
+                Self::EndpointHalt {
+                    endpoint_addr: a2,
+                    halted: h2,
+                },
+            ) => a1 == a2 && h1 == h2,
+            _ => false,
+        }
+    }
+}
+impl Eq for UsbAction<'_> {}
+
+impl<'a> UsbAction<'a> {
+    /// Helper to create a TransferIn action for a control transfer,
+    /// or a StallInAndOut if the requested length is too small.
+    #[inline(always)]
+    #[track_caller]
+    pub fn control_transfer_in_or_stall(
+        endpoint: u8,
+        pkt: &SetupPacket,
+        data: &'a Aligned<A4, [u8]>,
+    ) -> Self {
+        if data.len() > pkt.length().into() {
+            Self::StallInAndOut { endpoint }
+        } else {
+            Self::TransferIn {
+                endpoint,
+                data,
+                // Per USB Specs 5.5.3, we need to send ZLP for control transfers
+                // if the response is less than requested.
+                zlp: data.is_empty() || data.len() < pkt.length().into(),
+            }
+        }
+    }
+    /// Merges another action into this one.
+    pub fn merge(&mut self, new_action: UsbAction<'a>) {
+        match new_action {
+            UsbAction::None => {}
+            _ => *self = new_action,
+        }
+    }
+
+    /// Executes the action on the provided driver.
+    pub fn run<TDriver: UsbDriver>(&mut self, driver: &mut TDriver) -> UsbActionRun {
+        match self {
+            Self::None => return UsbActionRun::NoOp,
+            Self::TransferIn {
+                endpoint,
+                data,
+                zlp,
+            } => {
+                let bytes_transferred = driver.transfer_in(*endpoint, data, *zlp);
+                // Note: bytes_transferred is guaranteed to be a multiple of
+                // UsbDriver::MAX_PACKET_SIZE, which is guaranteed to be a
+                // multiple of 4.
+                if bytes_transferred < data.len() && (bytes_transferred & 3) == 0 {
+                    // We're not done yet...
+                    *data = &data[bytes_transferred..];
+                    return UsbActionRun::HasMoreData;
+                }
+            }
+            Self::TransferInUnaligned {
+                endpoint,
+                data,
+                zlp,
+            } => {
+                let bytes_transferred = driver.transfer_in_unaligned(*endpoint, data, *zlp);
+                if bytes_transferred < data.len() {
+                    // We're not done yet...
+                    *data = &data[bytes_transferred..];
+                    return UsbActionRun::HasMoreData;
+                }
+            }
+            Self::SetAddress { new_address } => driver.set_address(*new_address),
+            Self::StallInAndOut { endpoint } => {
+                driver.stall((*endpoint) & 0x7f, true);
+                driver.stall((*endpoint) | 0x80, true);
+            }
+            Self::EndpointHalt {
+                endpoint_addr,
+                halted,
+            } => {
+                driver.stall(*endpoint_addr, *halted);
+            }
+        }
+        *self = UsbAction::None;
+        UsbActionRun::Done
+    }
+}
+
+impl SimpleEp0 {
+    /// Creates a new `SimpleEp0` handler.
+    pub fn new() -> Self {
+        Self {
+            new_address: None,
+            configuration: 0,
+            halted_endpoints: 0,
+            pending_halt: None,
+        }
+    }
+
+    pub fn is_endpoint_halted(&self, endpoint_addr: u8) -> bool {
+        let idx = endpoint_bit_index(endpoint_addr);
+        (self.halted_endpoints & (1 << idx)) != 0
+    }
+
+    pub fn set_endpoint_halted(&mut self, endpoint_addr: u8, halted: bool) {
+        let idx = endpoint_bit_index(endpoint_addr);
+        if halted {
+            self.halted_endpoints |= 1 << idx;
+        } else {
+            self.halted_endpoints &= !(1 << idx);
+        }
+    }
+
+    /// A helper function to process a driver UsbEvent.
+    ///
+    /// This function returns the action that should be performed on the driver.
+    pub fn handle_event<'a, P: UsbPacket>(
+        &mut self,
+        ev: UsbEvent<P>,
+        descriptor_source: &'a impl DescriptorSource,
+    ) -> Result<UsbAction<'a>, UsbEvent<P>> {
+        match ev {
+            UsbEvent::SetupPacket { endpoint: 0, pkt } => {
+                use hal_usb::RequestType;
+                if pkt.request().request_type() == RequestType::Standard {
+                    Ok(self.handle_setup(pkt, descriptor_source))
+                } else {
+                    Err(ev)
+                }
+            }
+            UsbEvent::PacketSent { endpoint: 0 } => Ok(self.handle_packet_sent()),
+            UsbEvent::UsbReset => {
+                self.configuration = 0;
+                self.new_address = None;
+                self.halted_endpoints = 0;
+                self.pending_halt = None;
+                Ok(UsbAction::None)
+            }
+            _ => Err(ev),
+        }
+    }
+
+    /// Process a SETUP transfer and return the resulting action.
+    fn handle_setup<'a, TDescriptorSource: DescriptorSource>(
+        &mut self,
+        setup_pkt: SetupPacket,
+        descriptor_source: &'a TDescriptorSource,
+    ) -> UsbAction<'a> {
+        match setup_pkt.request() {
+            Request::DEVICE_GET_DESCRIPTOR => {
+                let descriptor = DescriptorInfo::from(&setup_pkt);
+                #[rustfmt::skip]
+                let mut response: Option<&Aligned<A4, [u8]>> = match descriptor {
+                    DescriptorInfo { ty: DescriptorType::DEVICE, index: 0, .. } => {
+                        Some(TDescriptorSource::DEVICE_DESC_BYTES)
+                    }
+                    DescriptorInfo { ty: DescriptorType::CONFIGURATION, index: 0, .. } => {
+                        Some(TDescriptorSource::CONFIG_DESC_BYTES)
+                    }
+                    DescriptorInfo { ty: DescriptorType::STRING, index: 0, .. } => {
+                        Some(TDescriptorSource::STRING_DESC_0_BYTES)
+                    }
+                    DescriptorInfo { ty: DescriptorType::STRING, index, .. } => {
+                        descriptor_source
+                            .get_string(StringHandle(index), setup_pkt.index())
+                            .map(|desc| desc.as_bytes())
+                    }
+                    _ => None,
+                };
+                if let Some(response) = &mut response {
+                    if response.len() > setup_pkt.length().into() {
+                        *response = &(*response)[..setup_pkt.length().into()];
+                    }
+                    UsbAction::control_transfer_in_or_stall(0, &setup_pkt, response)
+                } else {
+                    UsbAction::StallInAndOut { endpoint: 0 }
+                }
+            }
+            Request::DEVICE_GET_STATUS => UsbAction::control_transfer_in_or_stall(
+                0,
+                &setup_pkt,
+                descriptor_source.get_device_status(),
+            ),
+            Request::INTERFACE_GET_STATUS => {
+                UsbAction::control_transfer_in_or_stall(0, &setup_pkt, &STATUS_OK)
+            }
+            Request::ENDPOINT_GET_STATUS => {
+                let ep_addr = u8::try_from(setup_pkt.index() & 0xff).unwrap();
+                let data = if self.is_endpoint_halted(ep_addr) {
+                    &STATUS_HALTED
+                } else {
+                    &STATUS_OK
+                };
+                UsbAction::control_transfer_in_or_stall(0, &setup_pkt, data)
+            }
+            Request::ENDPOINT_SET_FEATURE => {
+                match setup_pkt.value() {
+                    0 => {
+                        // ENDPOINT_HALT
+                        let ep_addr = u8::try_from(setup_pkt.index() & 0xff).unwrap();
+                        if endpoint_number(ep_addr) == 0 {
+                            // Endpoint 0 cannot be halted. Stall the control pipe to reject the request.
+                            UsbAction::StallInAndOut { endpoint: 0 }
+                        } else {
+                            self.set_endpoint_halted(ep_addr, true);
+                            self.pending_halt = Some((ep_addr, true));
+                            UsbAction::TransferIn {
+                                endpoint: 0,
+                                data: EMPTY,
+                                zlp: true,
+                            }
+                        }
+                    }
+                    _ => {
+                        // Feature not supported.
+                        UsbAction::StallInAndOut { endpoint: 0 }
+                    }
+                }
+            }
+            Request::ENDPOINT_CLEAR_FEATURE => {
+                match setup_pkt.value() {
+                    0 => {
+                        // ENDPOINT_HALT
+                        let ep_addr = u8::try_from(setup_pkt.index() & 0xff).unwrap();
+                        if endpoint_number(ep_addr) == 0 {
+                            // Endpoint 0 cannot be cleared. Stall the control pipe to reject the request.
+                            UsbAction::StallInAndOut { endpoint: 0 }
+                        } else {
+                            self.set_endpoint_halted(ep_addr, false);
+                            self.pending_halt = Some((ep_addr, false));
+                            UsbAction::TransferIn {
+                                endpoint: 0,
+                                data: EMPTY,
+                                zlp: true,
+                            }
+                        }
+                    }
+                    _ => {
+                        // Feature not supported.
+                        UsbAction::StallInAndOut { endpoint: 0 }
+                    }
+                }
+            }
+            Request::DEVICE_SET_ADDRESS => {
+                self.new_address = Some(setup_pkt.value() as u8);
+                UsbAction::TransferIn {
+                    endpoint: 0,
+                    data: EMPTY,
+                    zlp: true,
+                }
+            }
+            Request::DEVICE_SET_CONFIGURATION => {
+                let val = setup_pkt.value();
+                if val == 0 || val == 1 {
+                    self.configuration = val as u8;
+                    UsbAction::TransferIn {
+                        endpoint: 0,
+                        data: EMPTY,
+                        zlp: true,
+                    }
+                } else {
+                    UsbAction::StallInAndOut { endpoint: 0 }
+                }
+            }
+            Request::DEVICE_GET_CONFIGURATION => {
+                let data = match self.configuration {
+                    1 => &CONFIG_1,
+                    _ => &CONFIG_0,
+                };
+                UsbAction::control_transfer_in_or_stall(0, &setup_pkt, data)
+            }
+            Request::INTERFACE_GET_INTERFACE => {
+                UsbAction::control_transfer_in_or_stall(0, &setup_pkt, &CONFIG_0)
+            }
+            Request::INTERFACE_SET_INTERFACE => {
+                if setup_pkt.value() == 0 {
+                    UsbAction::TransferIn {
+                        endpoint: 0,
+                        data: EMPTY,
+                        zlp: true,
+                    }
+                } else {
+                    UsbAction::StallInAndOut { endpoint: 0 }
+                }
+            }
+            _ => UsbAction::StallInAndOut { endpoint: 0 },
+        }
+    }
+    fn handle_packet_sent(&mut self) -> UsbAction<'static> {
+        if let Some(new_address) = self.new_address.take() {
+            // Now that the transfer is complete it's safe to change the address..
+            return UsbAction::SetAddress { new_address };
+        }
+        if let Some((endpoint_addr, halted)) = self.pending_halt.take() {
+            return UsbAction::EndpointHalt {
+                endpoint_addr,
+                halted,
+            };
+        }
+        UsbAction::None
+    }
+}
+
+impl Default for SimpleEp0 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A helper struct to handle multi-packet USB transfers.
+///
+/// It accumulates incoming USB packets into an internal buffer until a short
+/// packet or a zero-length packet (ZLP) is received, indicating the end of a transfer.
+///
+/// `N` is the number of **words** (`u32`s) in the internal buffer and NOT bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Transfer<const N: usize> {
+    buffer: [u32; N],
+    word_offset: usize,
+}
+
+impl<const N: usize> Transfer<N> {
+    /// Maximum packet size supported (fixed at 64 bytes).
+    pub const MAX_PACKET_SIZE: usize = 64;
+
+    /// Creates a new `Transfer` buffer.
+    pub fn new() -> Self {
+        Self {
+            buffer: [0; N],
+            word_offset: 0,
+        }
+    }
+
+    /// Splices a USB packet into the buffer.
+    ///
+    /// Returns `Ok(Some(slice))` if the transfer is complete, `Ok(None)` otherwise.
+    pub fn splice(&mut self, packet: impl UsbPacket) -> Result<Option<&Aligned<A4, [u8]>>, Error> {
+        const {
+            assert!(Self::MAX_PACKET_SIZE % size_of::<u32>() == 0);
+        }
+        let packet_len = packet.len();
+        let dest = {
+            let start = self.word_offset;
+            let end = start + packet_len.div_ceil(size_of::<u32>());
+            self.buffer.get_mut(start..end).ok_or(Error::OutOfRange)?
+        };
+        packet.copy_to(dest);
+        if packet_len < Self::MAX_PACKET_SIZE {
+            let result = &self
+                .buffer
+                .as_bytes()
+                .get(..self.word_offset * size_of::<u32>() + packet_len)
+                .ok_or(Error::OutOfRange)?;
+            self.word_offset = 0;
+            Ok(Some(
+                // nosemgrep
+                unsafe {
+                    // SAFETY: `self.buffer` is `[u32]` which has alignment of 4.
+                    core::mem::transmute::<&[u8], &Aligned<A4, [u8]>>(result)
+                },
+            ))
+        } else {
+            self.word_offset += Self::MAX_PACKET_SIZE / size_of::<u32>();
+            Ok(None)
+        }
+    }
+}
+
+impl<const N: usize> Default for Transfer<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub mod testing {
+    use aligned::Aligned;
+    use aligned::A4;
+    use hal_usb::driver::UsbPacket;
+    use zerocopy::IntoBytes;
+
+    #[derive(Debug)]
+    pub struct FakeUsbPacket<'a> {
+        pub data: &'a [u8],
+        pub ep: usize,
+    }
+
+    impl UsbPacket for FakeUsbPacket<'_> {
+        fn endpoint_index(&self) -> usize {
+            self.ep
+        }
+
+        fn len(&self) -> usize {
+            self.data.len()
+        }
+
+        fn copy_to_uninit(self, _dest: &mut [core::mem::MaybeUninit<u32>]) -> &[u8] {
+            unimplemented!()
+        }
+
+        fn copy_to(self, dest: &mut [u32]) -> &[u8] {
+            let dest_bytes = dest.as_mut_bytes();
+            let copy_len = self.data.len().min(dest_bytes.len());
+            dest_bytes[..copy_len].copy_from_slice(&self.data[..copy_len]);
+            // nosemgrep
+            unsafe {
+                // SAFETY: `dest` is a `&mut [u32]`, which is guaranteed to be 4-byte
+                // aligned. `dest_bytes` is a byte slice view of the same memory, so it's also
+                // 4-byte aligned. The subslice `&dest_bytes[..copy_len]` maintains this alignment.
+                core::mem::transmute::<&[u8], &Aligned<A4, [u8]>>(&dest_bytes[..copy_len])
+            }
+        }
+
+        fn copy_to_unaligned(self, dest: &mut [u8]) -> &[u8] {
+            let copy_len = self.data.len().min(dest.len());
+            dest[..copy_len].copy_from_slice(&self.data[..copy_len]);
+            &dest[..copy_len]
+        }
+    }
+}
+
+#[cfg(test)]
+mod splice_tests {
+    use super::testing::FakeUsbPacket;
+    use super::*;
+
+    const MAX_PACKET_SIZE: usize = Transfer::<0>::MAX_PACKET_SIZE;
+
+    #[test]
+    fn test_splice_single_short_packet() {
+        let packet_data = [1, 2, 3, 4];
+        let packet = FakeUsbPacket {
+            data: &packet_data,
+            ep: 0,
+        };
+
+        let mut transfer = Transfer::<32>::new();
+        let result = transfer.splice(packet).unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_ref(), &packet_data[..]);
+    }
+
+    #[test]
+    fn test_splice_single_full_packet_then_zlp() {
+        let packet_data = [42; MAX_PACKET_SIZE];
+        let packet = FakeUsbPacket {
+            data: &packet_data,
+            ep: 0,
+        };
+
+        let mut transfer = Transfer::<32>::new();
+        let result = transfer.splice(packet).unwrap();
+
+        assert!(result.is_none());
+
+        let zlp = FakeUsbPacket { data: &[], ep: 0 };
+        let result = transfer.splice(zlp).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().as_ref(), &packet_data[..]);
+    }
+
+    #[test]
+    fn test_splice_multiple_packets() {
+        let packet1_data = [1; MAX_PACKET_SIZE];
+        let packet2_data = [2; MAX_PACKET_SIZE];
+        let packet3_data = [3; 32];
+
+        // Packet 1
+        let packet1 = FakeUsbPacket {
+            data: &packet1_data,
+            ep: 0,
+        };
+        let mut transfer = Transfer::<64>::new();
+        let result = transfer.splice(packet1).unwrap();
+        assert!(result.is_none());
+
+        // Packet 2
+        let packet2 = FakeUsbPacket {
+            data: &packet2_data,
+            ep: 0,
+        };
+        let result = transfer.splice(packet2).unwrap();
+        assert!(result.is_none());
+
+        // Packet 3 (short packet)
+        let packet3 = FakeUsbPacket {
+            data: &packet3_data,
+            ep: 0,
+        };
+        let result = transfer.splice(packet3).unwrap();
+        assert!(result.is_some());
+
+        let mut expected_data = [0u8; 2 * MAX_PACKET_SIZE + 32];
+        expected_data[..MAX_PACKET_SIZE].copy_from_slice(&packet1_data);
+        expected_data[MAX_PACKET_SIZE..2 * MAX_PACKET_SIZE].copy_from_slice(&packet2_data);
+        expected_data[2 * MAX_PACKET_SIZE..].copy_from_slice(&packet3_data);
+
+        assert_eq!(result.unwrap().as_ref(), &expected_data[..]);
+    }
+
+    #[test]
+    fn test_splice_buffer_overflow() {
+        let packet_data = [1; 1];
+        let packet = FakeUsbPacket {
+            data: &packet_data,
+            ep: 0,
+        };
+
+        let mut transfer = Transfer::<16>::new();
+        transfer
+            .splice(FakeUsbPacket {
+                data: &[0; MAX_PACKET_SIZE],
+                ep: 0,
+            })
+            .unwrap();
+        let result = transfer.splice(packet);
+        assert_eq!(result.err(), Some(Error::OutOfRange));
+    }
+
+    #[test]
+    fn test_full_capacity_with_full_packets_then_partial_packet() {
+        const PARTIAL_SIZE: usize = 16;
+        const FULL1_DATA: &[u8] = &[0xaa; MAX_PACKET_SIZE];
+        const FULL2_DATA: &[u8] = &[0xbb; MAX_PACKET_SIZE];
+        const PARTIAL_DATA: &[u8] = &[0xcc; PARTIAL_SIZE];
+        const RECEIVE_BUFFER_WORDS: usize =
+            (FULL1_DATA.len() + FULL2_DATA.len() + PARTIAL_DATA.len()) / size_of::<u32>();
+        let full1 = FakeUsbPacket {
+            data: FULL1_DATA,
+            ep: 0,
+        };
+        let full2 = FakeUsbPacket {
+            data: FULL2_DATA,
+            ep: 0,
+        };
+        let partial = FakeUsbPacket {
+            data: PARTIAL_DATA,
+            ep: 0,
+        };
+        let mut transfer = Transfer::<RECEIVE_BUFFER_WORDS>::new();
+        assert!(transfer.splice(full1).unwrap().is_none());
+        assert!(transfer.splice(full2).unwrap().is_none());
+        let buffer = transfer.splice(partial).unwrap().unwrap().as_ref();
+        assert_eq!(&buffer[..MAX_PACKET_SIZE], FULL1_DATA);
+        assert_eq!(&buffer[MAX_PACKET_SIZE..2 * MAX_PACKET_SIZE], FULL2_DATA);
+    }
+}
+
+#[cfg(test)]
+mod simple_ep0_tests {
+    use super::*;
+    use aligned::Aligned;
+    use aligned::A4;
+    use hal_usb::Request;
+    use hal_usb::SetupPacket;
+    use hal_usb::StringDescriptorRef;
+    use hal_usb::StringHandle;
+
+    struct DummyDescriptors;
+    impl DescriptorSource for DummyDescriptors {
+        const DEVICE_DESC_BYTES: &'static Aligned<A4, [u8]> = &Aligned([]);
+        const CONFIG_DESC_BYTES: &'static Aligned<A4, [u8]> = &Aligned([]);
+        const STRING_DESC_0_BYTES: &'static Aligned<A4, [u8]> = &Aligned([]);
+        const DEVICE_STATUS: Aligned<A4, [u8; 2]> = Aligned([0, 0]);
+
+        fn get_string(&self, _handle: StringHandle, _lang: u16) -> Option<StringDescriptorRef<'_>> {
+            None
+        }
+    }
+
+    fn unwrap_action<'a, P: UsbPacket>(res: Result<UsbAction<'a>, UsbEvent<P>>) -> UsbAction<'a> {
+        match res {
+            Ok(a) => a,
+            Err(_) => panic!("Expected Ok action"),
+        }
+    }
+
+    #[test]
+    fn test_set_configuration() {
+        let mut ep0 = SimpleEp0::new();
+        let descriptors = DummyDescriptors;
+
+        // Value = 0 (de-configure/address state) should be accepted
+        let req = Request::DEVICE_SET_CONFIGURATION;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(
+            action,
+            UsbAction::TransferIn {
+                endpoint: 0,
+                zlp: true,
+                ..
+            }
+        ));
+
+        // Value = 1 (active configuration) should be accepted
+        let buf0 = (u16::from(req) as u32) | (1u32 << 16);
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(
+            action,
+            UsbAction::TransferIn {
+                endpoint: 0,
+                zlp: true,
+                ..
+            }
+        ));
+
+        // Value = 2 (invalid configuration) should be stalled
+        let buf0 = (u16::from(req) as u32) | (2u32 << 16);
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(action, UsbAction::StallInAndOut { endpoint: 0 }));
+    }
+
+    #[test]
+    fn test_get_configuration() {
+        let mut ep0 = SimpleEp0::new();
+        let descriptors = DummyDescriptors;
+
+        // Initial state should be unconfigured (0)
+        let req = Request::DEVICE_GET_CONFIGURATION;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0001_0000]); // Length = 1
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // Set configuration to 1
+        let req_set = Request::DEVICE_SET_CONFIGURATION;
+        let buf0 = (u16::from(req_set) as u32) | (1u32 << 16);
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let _ = ep0.handle_event(ev, &descriptors);
+
+        // Now GET_CONFIGURATION should return 1
+        let req_get = Request::DEVICE_GET_CONFIGURATION;
+        let buf0 = u16::from(req_get) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0001_0000]); // Length = 1
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[1]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // USB reset should reset configuration back to 0
+        let ev_reset: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::UsbReset;
+        let _ = ep0.handle_event(ev_reset, &descriptors);
+
+        // Now GET_CONFIGURATION should return 0
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+    }
+
+    #[test]
+    fn test_get_status() {
+        let mut ep0 = SimpleEp0::new();
+        let descriptors = DummyDescriptors;
+
+        // Device recipient
+        let req = Request::DEVICE_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0000]); // Length = 2
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0, 0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // Interface recipient
+        let req = Request::INTERFACE_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0000]); // Length = 2
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0, 0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // Endpoint recipient
+        let req = Request::ENDPOINT_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0000]); // Length = 2
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0, 0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+    }
+
+    #[test]
+    fn test_fallback_interface_requests() {
+        let mut ep0 = SimpleEp0::new();
+        let descriptors = DummyDescriptors;
+
+        // GET_INTERFACE should return alternate setting 0
+        let req = Request::INTERFACE_GET_INTERFACE;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0001_0000]); // Length = 1
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // SET_INTERFACE with alternate setting 0 should succeed
+        let req = Request::INTERFACE_SET_INTERFACE;
+        let buf0 = u16::from(req) as u32; // Value = 0
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(
+            action,
+            UsbAction::TransferIn {
+                endpoint: 0,
+                zlp: true,
+                ..
+            }
+        ));
+
+        // SET_INTERFACE with alternate setting 1 should be stalled (only 0 supported as fallback)
+        let buf0 = (u16::from(req) as u32) | (1u32 << 16); // Value = 1
+        let setup_pkt = SetupPacket::new([buf0, 0]);
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(action, UsbAction::StallInAndOut { endpoint: 0 }));
+    }
+
+    #[test]
+    fn test_endpoint_halt_requests() {
+        let mut ep0 = SimpleEp0::new();
+        let descriptors = DummyDescriptors;
+
+        // 1. Check Endpoint 1 IN status (initially not halted)
+        let req = Request::ENDPOINT_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0081]); // Length = 2, Endpoint = 0x81 (1 IN)
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0, 0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // 2. SET_FEATURE(ENDPOINT_HALT) to Endpoint 1 IN
+        let req = Request::ENDPOINT_SET_FEATURE;
+        let buf0 = u16::from(req) as u32; // Value = 0 (ENDPOINT_HALT)
+        let setup_pkt = SetupPacket::new([buf0, 0x0000_0081]); // Endpoint = 0x81
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(
+            action,
+            UsbAction::TransferIn {
+                endpoint: 0,
+                zlp: true,
+                ..
+            }
+        ));
+
+        // Verify that handle_packet_sent returns EndpointHalt action
+        let action_sent = ep0.handle_packet_sent();
+        assert!(matches!(
+            action_sent,
+            UsbAction::EndpointHalt {
+                endpoint_addr: 0x81,
+                halted: true
+            }
+        ));
+
+        // 3. Check Endpoint 1 IN status again (should be halted)
+        let req = Request::ENDPOINT_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0081]); // Length = 2, Endpoint = 0x81
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[1, 0]); // Halt bit set
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // 4. CLEAR_FEATURE(ENDPOINT_HALT) to Endpoint 1 IN
+        let req = Request::ENDPOINT_CLEAR_FEATURE;
+        let buf0 = u16::from(req) as u32; // Value = 0 (ENDPOINT_HALT)
+        let setup_pkt = SetupPacket::new([buf0, 0x0000_0081]); // Endpoint = 0x81
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(
+            action,
+            UsbAction::TransferIn {
+                endpoint: 0,
+                zlp: true,
+                ..
+            }
+        ));
+
+        // Verify that handle_packet_sent returns EndpointHalt action (halted = false)
+        let action_sent = ep0.handle_packet_sent();
+        assert!(matches!(
+            action_sent,
+            UsbAction::EndpointHalt {
+                endpoint_addr: 0x81,
+                halted: false
+            }
+        ));
+
+        // 5. Check Endpoint 1 IN status again (should be not halted)
+        let req = Request::ENDPOINT_GET_STATUS;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0002_0081]); // Length = 2, Endpoint = 0x81
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        if let UsbAction::TransferIn {
+            endpoint: 0, data, ..
+        } = action
+        {
+            assert_eq!(data.as_ref(), &[0, 0]);
+        } else {
+            panic!("Expected TransferIn action");
+        }
+
+        // 6. Trying to halt Endpoint 0 should fail/stall
+        let req = Request::ENDPOINT_SET_FEATURE;
+        let buf0 = u16::from(req) as u32;
+        let setup_pkt = SetupPacket::new([buf0, 0x0000_0000]); // Endpoint = 0
+        let ev: UsbEvent<testing::FakeUsbPacket<'static>> = UsbEvent::SetupPacket {
+            endpoint: 0,
+            pkt: setup_pkt,
+        };
+        let action = unwrap_action(ep0.handle_event(ev, &descriptors));
+        assert!(matches!(action, UsbAction::StallInAndOut { endpoint: 0 }));
+    }
+}

--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
 
 rust_library(
@@ -28,6 +28,29 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "//target/earlgrey/registers",
+    ],
+)
+
+rust_library(
+    name = "usb_driver",
+    srcs = ["usb_driver.rs"],
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking/usb:hal_usb",
+        "//target/earlgrey/registers:usbdev",
+        "//util/regcpy",
+        "@rust_crates//:aligned",
+        "@rust_crates//:zerocopy",
         "@ureg",
+    ],
+)
+
+rust_test(
+    name = "usb_driver_test",
+    crate = ":usb_driver",
+    rustc_flags = [
+        "-C",
+        "debug-assertions",
     ],
 )

--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -28,6 +28,7 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "//target/earlgrey/registers",
+        "@ureg",
     ],
 )
 

--- a/target/earlgrey/drivers/usb_driver.rs
+++ b/target/earlgrey/drivers/usb_driver.rs
@@ -254,8 +254,8 @@ impl Usb {
         });
         regs.usbctrl().modify(|w| w.enable(true));
 
-        let stat = regs.usbstat().read();
         // TODO: decide what to do about tracing.
+        //let stat = regs.usbstat().read();
         //traceln!(
         //    "Usb out_depth={} setup_depth={}",
         //    stat.av_out_depth(),

--- a/target/earlgrey/drivers/usb_driver.rs
+++ b/target/earlgrey/drivers/usb_driver.rs
@@ -1,0 +1,1142 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+
+use aligned::Aligned;
+use aligned::A4;
+use core::cmp::min;
+use hal_usb::driver::UsbDriver;
+use hal_usb::driver::UsbEvent;
+use hal_usb::driver::UsbPacket;
+use hal_usb::SetupPacket;
+use util_regcpy::{copy_from_reg_array_unaligned, copy_to_reg_array, copy_to_reg_array_unaligned};
+use zerocopy::IntoBytes;
+
+const MAX_PACKET_SIZE: usize = 64;
+const BUFFER_SLOT_SIZE_WORDS: usize = MAX_PACKET_SIZE / 4;
+const BUFFER_SLOT_COUNT: usize = 32;
+
+use buf_pool::BufId;
+use buf_pool::BufPool;
+use buf_pool::BuffPoolAllocator;
+use core::cmp;
+use ureg::RealMmio;
+
+use crate::transmit_queue::TransmitQueues;
+
+pub struct PacketHandle<TMmio: ureg::Mmio + Copy> {
+    // A reference to 16 words of packet data in the peripheral MMIO memory.
+    data: ureg::Array<16, ureg::RegRef<ureg::ReadWriteReg32<0, u32, u32>, TMmio>>,
+    // The length of the packet in bytes
+    packet_len: u16,
+    ep: u8,
+}
+
+impl<TMmio: ureg::Mmio + Copy> UsbPacket for PacketHandle<TMmio> {
+    fn endpoint_index(&self) -> usize {
+        self.ep.into()
+    }
+    fn len(&self) -> usize {
+        self.packet_len.into()
+    }
+
+    fn copy_to_uninit(self, dest: &mut [core::mem::MaybeUninit<u32>]) -> &[u8] {
+        #![allow(clippy::needless_range_loop)]
+
+        // TODO: Are we sure we want to silently truncate if dest isn't big enough?
+        let word_len = min(min(dest.len(), MAX_PACKET_SIZE / 4), self.len().div_ceil(4));
+        for i in 0..word_len {
+            dest[i].write(self.data.at(i).read());
+        }
+        //let result = unsafe { mutask_subtle::slice_assume_init(&dest[..word_len]) };
+
+        // This is feature(maybe_uninit_slice).
+        let result = &dest[..word_len];
+        let result = unsafe { &*(result as *const [core::mem::MaybeUninit<u32>] as *const [u32]) };
+
+        &result.as_bytes()[..min(self.len(), word_len * 4)]
+    }
+
+    fn copy_to(self, dest: &mut [u32]) -> &[u8] {
+        #![allow(clippy::needless_range_loop)]
+
+        // TODO: Are we sure we want to silently truncate if dest isn't big enough?
+        let word_len = min(min(dest.len(), MAX_PACKET_SIZE / 4), self.len().div_ceil(4));
+        for i in 0..word_len {
+            dest[i] = self.data.at(i).read();
+        }
+        &dest.as_bytes()[..min(self.len(), dest.as_bytes().len())]
+    }
+
+    fn copy_to_unaligned(self, dest: &mut [u8]) -> &[u8] {
+        copy_from_reg_array_unaligned(dest, &self.data);
+        &dest[..min(self.len(), dest.len())]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NextInPacket {
+    buf_id: u8,
+    len: u8,
+}
+impl NextInPacket {
+    const NONE: Self = Self {
+        buf_id: 0xff,
+        len: 0xff,
+    };
+}
+
+#[derive(Clone, Copy)]
+pub struct EpIn {
+    pub num: u8,
+    pub buf_pool_size: u32,
+}
+
+#[derive(Clone, Copy)]
+pub struct EpOut {
+    pub num: u8,
+    /// If true, hardware will NAK OUT transfers on this endpoint after the first
+    /// until software re-enables by setting `rxenable_out`
+    pub set_nak: bool,
+}
+
+const NB_EP: usize = 12;
+
+pub struct Usb {
+    mmio: usbdev::Usbdev,
+
+    // buffer pool for SETUP transfers from host, technically common, but only used for EP0.
+    buf_pool_setup: BufPool,
+    // buffer pool for OUT transfers from host, common for all EPs.
+    buf_pool_out: BufPool,
+
+    // buffer pools for IN transfers.
+    buf_pools_in: [BufPool; NB_EP],
+
+    transmit_queues: TransmitQueues,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct UsbConfig {
+    buf_pool_setup: BufPool,
+    buf_pool_out: BufPool,
+    buf_pools_in: [BufPool; NB_EP],
+    in_mask: u32,
+    out_mask: u32,
+    set_nak_mask: u32,
+}
+impl UsbConfig {
+    /// Construct a USB config. This should typically be done within a const
+    /// block so any errors become compile-time panics.
+    ///
+    /// # Panic
+    ///
+    /// This function will panic if the supplied endpoints are invalid.
+    #[inline(always)]
+    pub const fn new(eps_in: &[EpIn], eps_out: &[EpOut]) -> Self {
+        let mut buf_pool_allocator = BuffPoolAllocator::new();
+        let buf_pool_setup = buf_pool_allocator.new_bufpool(4).unwrap();
+        let buf_pool_out = buf_pool_allocator.new_bufpool(12).unwrap();
+
+        let mut buf_pools_in = [BufPool::EMPTY; NB_EP];
+        let mut i = 0;
+        while i < eps_in.len() {
+            let ep = &eps_in[i];
+            if ep.num == 0 || ep.num as usize >= NB_EP {
+                panic!("Invalid endpoint number");
+            }
+            let Some(new_pool) = buf_pool_allocator.new_bufpool(ep.buf_pool_size) else {
+                panic!("Bufpool allocation overflow");
+            };
+            buf_pools_in[ep.num as usize] = new_pool;
+            i += 1;
+        }
+        let Some(new_pool) = buf_pool_allocator.remainder_bufpool() else {
+            panic!("Bufpool allocation overflow");
+        };
+        buf_pools_in[0] = new_pool;
+
+        let in_mask: u32 = {
+            let mut v = 1; // always enable EP0
+            let mut i = 0;
+            while i < eps_in.len() {
+                v |= 1 << eps_in[i].num;
+                i += 1;
+            }
+            v
+        };
+
+        let out_mask: u32 = {
+            let mut v = 1; // always enable EP0
+            let mut i = 0;
+            while i < eps_out.len() {
+                v |= 1 << eps_out[i].num;
+                i += 1;
+            }
+            v
+        };
+
+        let set_nak_mask: u32 = {
+            let mut v = 0u32;
+            let mut i = 0;
+            while i < eps_out.len() {
+                if eps_out[i].set_nak {
+                    v |= 1 << eps_out[i].num;
+                }
+                i += 1;
+            }
+
+            // Writes to `rxenable_out` are not atomic - therefore we must
+            // guarantee that `set_nak_out` is only set for up to a single
+            // endpoint (github.com/lowRISC/opentitan/issues/27434)
+            assert!(
+                v.count_ones() <= 1,
+                "set_nak_out can be enabled on at most one endpoint"
+            );
+            v
+        };
+
+        Self {
+            buf_pool_setup,
+            buf_pool_out,
+            buf_pools_in,
+            in_mask,
+            out_mask,
+            set_nak_mask,
+        }
+    }
+}
+
+impl Usb {
+    pub fn new(mmio: usbdev::Usbdev, config: UsbConfig) -> Self {
+        let mut result = Self {
+            mmio,
+            buf_pool_setup: config.buf_pool_setup,
+            buf_pool_out: config.buf_pool_out,
+            buf_pools_in: config.buf_pools_in,
+            transmit_queues: TransmitQueues::new(),
+        };
+        result.init(&config);
+        result
+    }
+    fn init(&mut self, config: &UsbConfig) {
+        self.fill_setup_buffer_fifo();
+        self.fill_out_buffer_fifo();
+
+        let regs = self.mmio.regs_mut();
+
+        regs.ep_in_enable0().write(|_| config.in_mask.into());
+        regs.ep_out_enable0().write(|_| config.out_mask.into());
+        regs.rxenable_out0().write(|_| config.out_mask.into());
+        regs.set_nak_out0().write(|_| config.set_nak_mask.into());
+
+        regs.rxenable_setup0().write(|w| w.setup0(true));
+        regs.intr_enable().write(|w| {
+            w.pkt_received(true)
+                .pkt_sent(true)
+                .disconnected(true)
+                .host_lost(true)
+                .link_reset(true)
+                .link_suspend(true)
+                .link_resume(true)
+                .av_out_empty(true)
+                .rx_full(true)
+                .av_overflow(true)
+                .link_in_err(false)
+                .rx_crc_err(false)
+                .rx_pid_err(false)
+                .rx_bitstuff_err(false)
+                .frame(false)
+                .powered(true)
+                .link_out_err(false)
+                .av_setup_empty(true)
+        });
+        regs.usbctrl().modify(|w| w.enable(true));
+
+        let stat = regs.usbstat().read();
+        // TODO: decide what to do about tracing.
+        //traceln!(
+        //    "Usb out_depth={} setup_depth={}",
+        //    stat.av_out_depth(),
+        //    stat.av_setup_depth()
+        //);
+    }
+
+    fn reset_in(&mut self) {
+        let regs = self.mmio.regs_mut();
+        for (i, pool) in &mut self.buf_pools_in.iter_mut().enumerate() {
+            pool.reset();
+            let configin = regs.configin().at(i);
+            if configin.read().pend() {
+                // link reset will cancel any pending transactions. Since we're
+                // resetting the pool/queue state there's nothing else to do but
+                // clear the notification.
+                configin.write(|w| w.pend_clear());
+            }
+        }
+        self.transmit_queues.reset();
+    }
+
+    fn fill_setup_buffer_fifo(&mut self) {
+        // Setup buffers for incoming SETUP packets from host.
+        while !self.mmio.regs().usbstat().read().av_setup_full() {
+            let Some(buf_id) = self.buf_pool_setup.take() else {
+                break;
+            };
+            self.mmio
+                .regs_mut()
+                .avsetupbuffer()
+                .write(|w| w.buffer(buf_id.into()));
+        }
+    }
+    fn fill_out_buffer_fifo(&mut self) {
+        // Setup buffers for incoming OUT packets from host.
+        while !self.mmio.regs().usbstat().read().av_out_full() {
+            let Some(buf_id) = self.buf_pool_out.take() else {
+                break;
+            };
+            self.mmio
+                .regs_mut()
+                .avoutbuffer()
+                .write(|w| w.buffer(buf_id.into()));
+        }
+    }
+
+    /// Flush packets bufferred to transmit on `endpoint` starting with `buf_id`.
+    fn clear_ep_tx_queue(&mut self, endpoint: u32, mut buf_id: BufId) {
+        let buf_pool_in = &mut self.buf_pools_in[usize::try_from(endpoint).unwrap()];
+        buf_pool_in.put(buf_id);
+        while let Some(pkt) = self.transmit_queues.deque_next_packet(endpoint, buf_id) {
+            buf_id = BufId(pkt.buf_id.into());
+            buf_pool_in.put(buf_id);
+        }
+    }
+
+    /// Resume accepting OUT transfers on this endpoint.
+    ///
+    /// This should be called after processing an OUT transfer on a given endpoint
+    /// that was configured with `EpOut { set_nak: true }`. The `set_nak` option causes
+    /// the hardware to automatically NAK subsequent OUT transactions until this function
+    /// is called to re-enable reception.
+    pub fn set_rxenable(&mut self, ep_num: u8) {
+        self.mmio
+            .regs_mut()
+            .rxenable_out0()
+            .modify(|w| bit_setval(u32::from(w), ep_num.into(), true).into());
+    }
+
+    /// Common internal implementation for transfer_in and transfer_in_unaligned.
+    ///
+    /// # Safety
+    ///
+    /// If `aligned` is true, `data` MUST be 4-byte aligned. Failure to ensure
+    /// alignment will result in undefined behavior when the data is transmuted
+    /// to an aligned reference.
+    unsafe fn transfer_in_internal(
+        &mut self,
+        endpoint: u8,
+        mut data: &[u8],
+        zlp: bool,
+        aligned: bool,
+    ) -> usize {
+        let mut bytes_queued = 0;
+        let zlp = zlp && (data.len() % MAX_PACKET_SIZE) == 0;
+        loop {
+            if data.is_empty() && !zlp {
+                break;
+            }
+            let regs = self.mmio.regs_mut();
+            let Some(configin_reg) = regs.configin().get(endpoint.into()) else {
+                // Fault?
+                return 0;
+            };
+
+            let pkt = &data[..cmp::min(MAX_PACKET_SIZE, data.len())];
+            if pkt.len() == MAX_PACKET_SIZE {
+                data = &data[pkt.len()..];
+            } else {
+                data = &[];
+            }
+
+            let buf_pool = self.buf_pools_in.get_mut(usize::from(endpoint)).unwrap();
+
+            // Check to see if we have enough buffers to send both
+            // the last data packet and a ZLP if necessary. If not, leave last
+            // data packet unsent so caller knows to retry transfer
+            if zlp && pkt.len() == MAX_PACKET_SIZE && buf_pool.len() < 2 {
+                // TODO: decide what to do about tracing.
+                //traceln!("Couldn't find buf in pool for last IN + ZLP");
+                break;
+            }
+
+            let Some(buf_id) = buf_pool.take() else {
+                // TODO: decide what to do about tracing.
+                //traceln!("Couldn't find buf in pool for next IN");
+                break;
+            };
+
+            let Some(buffer) = regs
+                .buffer()
+                .get_sub_array::<BUFFER_SLOT_SIZE_WORDS>(buf_id.offset())
+            else {
+                // Shouldn't fail to get buffer offset
+                unreachable!();
+            };
+            if aligned {
+                // SAFETY: The caller of transfer_in_internal has guaranteed that 'data'
+                // is 4-byte aligned when the 'aligned' flag is set.
+                copy_to_reg_array(&buffer, unsafe {
+                    core::mem::transmute::<&[u8], &aligned::Aligned<aligned::A4, [u8]>>(pkt)
+                });
+            } else {
+                copy_to_reg_array_unaligned(&buffer, pkt);
+            }
+
+            match self.transmit_queues.queue(
+                endpoint.into(),
+                NextInPacket {
+                    buf_id: u32::from(buf_id) as u8,
+                    len: pkt.len() as u8,
+                },
+            ) {
+                TransmitQueueAction::None => {}
+                TransmitQueueAction::SendNow => {
+                    if configin_reg.read().rdy() {
+                        // TODO: decide what to do about tracing.
+                        //traceln!("WARN: Packet already queued in hardware");
+                    }
+                    configin_reg.write(|w| {
+                        w.buffer(buf_id.into())
+                            .rdy(true)
+                            .size(u32::try_from(pkt.len()).unwrap())
+                    });
+                }
+            }
+            bytes_queued += pkt.len();
+
+            if pkt.is_empty() {
+                break;
+            }
+        }
+        bytes_queued
+    }
+}
+
+#[inline(always)]
+fn bit_setval(bits: u32, index: usize, value: bool) -> u32 {
+    let mask = 1 << index;
+    if value {
+        bits | mask
+    } else {
+        bits & !mask
+    }
+}
+
+impl UsbDriver for Usb {
+    const MAX_PACKET_SIZE: usize = 64;
+    type Packet<'a> = PacketHandle<RealMmio<'a>>;
+
+    #[inline(always)]
+    fn stall(&mut self, endpoint_num: u8, stalled: bool) {
+        if endpoint_num & 0x80 != 0 {
+            self.mmio
+                .regs_mut()
+                .in_stall0()
+                .modify(|w| bit_setval(u32::from(w), (endpoint_num & 0x0f).into(), stalled).into());
+        } else {
+            self.mmio
+                .regs_mut()
+                .out_stall0()
+                .modify(|w| bit_setval(u32::from(w), (endpoint_num & 0x0f).into(), stalled).into());
+        }
+    }
+
+    #[inline(always)]
+    fn is_stalled(&mut self, endpoint_num: u8) -> bool {
+        if endpoint_num & 0x80 != 0 {
+            u32::from(self.mmio.regs().in_stall0().read()) & (1 << (endpoint_num & 0x0f)) != 0
+        } else {
+            u32::from(self.mmio.regs().out_stall0().read()) & (1 << (endpoint_num & 0x0f)) != 0
+        }
+    }
+
+    /// Store data in peripheral buffer that will be transferred when the host requests it.
+    #[inline(never)]
+    fn transfer_in(&mut self, endpoint: u8, data: &Aligned<A4, [u8]>, zlp: bool) -> usize {
+        // SAFETY: Aligned<A4, [u8]> is guaranteed to be 4-byte aligned.
+        unsafe { self.transfer_in_internal(endpoint, data.as_ref(), zlp, true) }
+    }
+
+    #[inline(never)]
+    fn transfer_in_unaligned(&mut self, endpoint_idx: u8, data: &[u8], zlp: bool) -> usize {
+        // SAFETY: The 'aligned' flag is set to false, so transfer_in_internal
+        // will use the unaligned copy helper.
+        unsafe { self.transfer_in_internal(endpoint_idx, data, zlp, false) }
+    }
+
+    fn set_address(&mut self, address: u8) {
+        self.mmio
+            .regs_mut()
+            .usbctrl()
+            .modify(|w| w.device_address(address.into()));
+    }
+
+    #[inline(never)]
+    fn poll(&mut self) -> Option<UsbEvent<PacketHandle<RealMmio<'_>>>> {
+        let intr = self.mmio.regs_mut().intr_state().read();
+
+        // TODO: use count_leading_zeros() to iterate over the pending interrupts
+        if intr.pkt_received() {
+            let fifo_entry = self.mmio.regs_mut().rxfifo().read();
+
+            if fifo_entry.setup() {
+                self.fill_setup_buffer_fifo();
+
+                if let Some(configin_reg) = self
+                    .mmio
+                    .regs_mut()
+                    .configin()
+                    .get(fifo_entry.ep() as usize)
+                {
+                    let configin = configin_reg.read();
+                    if configin.pend() {
+                        // Previous transmission was cancelled by an incoming setup packet
+                        configin_reg.write(|w| w.pend_clear());
+                        self.clear_ep_tx_queue(fifo_entry.ep(), BufId(configin.buffer()));
+                    }
+                }
+            } else {
+                self.fill_out_buffer_fifo();
+            }
+
+            let offset = usize::try_from(fifo_entry.buffer()).unwrap() * BUFFER_SLOT_SIZE_WORDS;
+            let Some(pkt_buffer) = self
+                .mmio
+                .regs()
+                .into_buffer()
+                .get_sub_array::<BUFFER_SLOT_SIZE_WORDS>(offset)
+            else {
+                return Some(UsbEvent::ErrorUnexpectedBufId);
+            };
+
+            if fifo_entry.setup() {
+                let buf_id = BufId(fifo_entry.buffer());
+
+                // Return the buffer back to the pool, but don't call
+                // self.fill_setup_buffer_fifo() yet, as the caller to poll()
+                // may look at this data from the returned event, and we don't want
+                // the peripheral to change it while they're reading the data
+                // (because the returned Event is exclusively holding self, it won't be possible
+                // to call fill_setup_buffer_fifo() until after they lose the event).
+                self.buf_pool_setup.put(buf_id);
+
+                let ep = u8::try_from(fifo_entry.ep()).unwrap();
+                let pkt_handle = PacketHandle {
+                    data: pkt_buffer,
+                    // These unwraps will optimize out
+                    ep,
+                    packet_len: u16::try_from(fifo_entry.size()).unwrap(),
+                };
+                let mut pkt_words = [0_u32; 2];
+                pkt_handle.copy_to(&mut pkt_words);
+                return Some(UsbEvent::SetupPacket {
+                    endpoint: ep,
+                    pkt: SetupPacket::new(pkt_words),
+                });
+            } else {
+                let buf_id = BufId(fifo_entry.buffer());
+                self.buf_pool_out.put(buf_id);
+                return Some(UsbEvent::DataOutPacket(PacketHandle {
+                    data: pkt_buffer,
+                    // These unwraps will optimize out
+                    ep: u8::try_from(fifo_entry.ep()).unwrap(),
+                    packet_len: u16::try_from(fifo_entry.size()).unwrap(),
+                }));
+            }
+        }
+        if intr.pkt_sent() {
+            let regs = self.mmio.regs_mut();
+            loop {
+                let endpoint_bits: u32 = regs.in_sent0().read().into();
+                if endpoint_bits == 0 {
+                    break;
+                }
+                let endpoint_id = endpoint_bits.trailing_zeros();
+
+                // Ensure we don't get interrupted about this packet again (w1c)
+                regs.in_sent0().write(|_| (1 << endpoint_id).into());
+
+                let Some(configin_reg) = regs.configin().get(usize::try_from(endpoint_id).unwrap())
+                else {
+                    // TODO: Log weird hardware behavior?
+                    continue;
+                };
+                let configin = configin_reg.read();
+
+                if configin.rdy() {
+                    // TODO: Log weird hardware behavior...
+                    continue;
+                }
+
+                let buf_pool = self
+                    .buf_pools_in
+                    .get_mut(usize::try_from(endpoint_id).unwrap())
+                    .unwrap();
+                let sent_buf_id = BufId(configin.buffer());
+                buf_pool.put(sent_buf_id);
+
+                if let Some(next_pkt) = self
+                    .transmit_queues
+                    .deque_next_packet(endpoint_id, sent_buf_id)
+                {
+                    // We have more packets for this endpoint already in the
+                    // peripheral SRAM; let's tell the hardware to prep the next
+                    // one for sending.
+                    configin_reg.write(|w| {
+                        w.buffer(next_pkt.buf_id.into())
+                            .size(next_pkt.len.into())
+                            .rdy(true)
+                    });
+                }
+                return Some(UsbEvent::PacketSent {
+                    endpoint: endpoint_id,
+                });
+            }
+        }
+        if intr.host_lost() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.host_lost_clear());
+            return Some(UsbEvent::LinkDown);
+        }
+        if intr.powered() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.powered_clear());
+            return Some(UsbEvent::VBus);
+        }
+        if intr.disconnected() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.disconnected_clear());
+            return Some(UsbEvent::VBusLost);
+        }
+        if intr.link_reset() {
+            self.reset_in();
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.link_reset_clear());
+            return Some(UsbEvent::UsbReset);
+        }
+        if intr.av_overflow() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.av_overflow_clear());
+            // TODO: decide what to do about tracing.
+            //traceln!("av_overflow");
+        }
+        if intr.link_suspend() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.link_suspend_clear());
+        }
+        if intr.link_resume() {
+            self.mmio
+                .regs_mut()
+                .intr_state()
+                .write(|w| w.link_resume_clear());
+        }
+        if intr.av_out_empty() {
+            // TODO: decide what to do about tracing.
+            //traceln!("av_out_empty");
+            self.fill_out_buffer_fifo();
+        }
+        if intr.av_setup_empty() {
+            // TODO: decide what to do about tracing.
+            //traceln!("av_setup_empty");
+            self.fill_setup_buffer_fifo();
+        }
+        if intr.rx_full() {
+            // TODO: decide what to do about tracing.
+            //traceln!("rx_full");
+        }
+
+        None
+    }
+}
+
+#[derive(Eq, PartialEq, Debug)]
+pub enum TransmitQueueAction {
+    None,
+    SendNow,
+}
+
+pub mod transmit_queue {
+    use super::*;
+
+    pub struct TransmitQueues {
+        slots: [NextInPacket; BUFFER_SLOT_COUNT],
+
+        /// Indexed by endpoint num, this is the slot index of the last packet
+        /// queued for transmission on that endpoint.
+        last_pkt_idx: [Option<u8>; NB_EP],
+    }
+    impl TransmitQueues {
+        pub const fn new() -> Self {
+            Self {
+                slots: [NextInPacket::NONE; BUFFER_SLOT_COUNT],
+                last_pkt_idx: [None; NB_EP],
+            }
+        }
+        pub fn reset(&mut self) {
+            *self = Self::new()
+        }
+
+        #[must_use]
+        #[inline(always)]
+        pub fn queue(&mut self, ep_id: u32, pkt: NextInPacket) -> TransmitQueueAction {
+            let ep_id = usize::try_from(ep_id).unwrap();
+            let last_pkt_idx = &mut self.last_pkt_idx[ep_id];
+            let result = if let Some(last_pkt_idx) = *last_pkt_idx
+                && let Some(entry) = self.slots.get_mut(usize::from(last_pkt_idx))
+            {
+                *entry = pkt;
+                TransmitQueueAction::None
+            } else {
+                if let Some(entry) = self.slots.get_mut(usize::from(pkt.buf_id)) {
+                    *entry = NextInPacket::NONE;
+                }
+                TransmitQueueAction::SendNow
+            };
+            *last_pkt_idx = Some(pkt.buf_id);
+            result
+        }
+
+        #[inline(always)]
+        pub fn deque_next_packet(
+            &mut self,
+            ep_id: u32,
+            sent_buf_id: BufId,
+        ) -> Option<NextInPacket> {
+            let ep_id = usize::try_from(ep_id).unwrap();
+            let sent_buf_id = usize::from(sent_buf_id);
+            let next_pkt = &mut self.slots[sent_buf_id];
+            if usize::from(next_pkt.buf_id) >= BUFFER_SLOT_COUNT {
+                self.last_pkt_idx[ep_id] = None;
+                return None;
+            }
+            Some(core::mem::replace(next_pkt, NextInPacket::NONE))
+        }
+    }
+    impl Default for TransmitQueues {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_transmit_queues() {
+            let mut queues = TransmitQueues::new();
+            assert_eq!(
+                queues.queue(0, NextInPacket { buf_id: 4, len: 64 }),
+                TransmitQueueAction::SendNow
+            );
+            assert_eq!(
+                queues.queue(0, NextInPacket { buf_id: 5, len: 64 }),
+                TransmitQueueAction::None
+            );
+            assert_eq!(
+                queues.queue(
+                    1,
+                    NextInPacket {
+                        buf_id: 10,
+                        len: 64
+                    }
+                ),
+                TransmitQueueAction::SendNow
+            );
+            assert_eq!(
+                queues.queue(
+                    1,
+                    NextInPacket {
+                        buf_id: 11,
+                        len: 64
+                    }
+                ),
+                TransmitQueueAction::None
+            );
+            assert_eq!(
+                queues.queue(0, NextInPacket { buf_id: 6, len: 0 }),
+                TransmitQueueAction::None
+            );
+            assert_eq!(
+                queues.queue(1, NextInPacket { buf_id: 12, len: 3 }),
+                TransmitQueueAction::None
+            );
+
+            assert_eq!(
+                queues.deque_next_packet(1, BufId(10)),
+                Some(NextInPacket {
+                    buf_id: 11,
+                    len: 64
+                })
+            );
+            assert_eq!(
+                queues.deque_next_packet(0, BufId(4)),
+                Some(NextInPacket { buf_id: 5, len: 64 })
+            );
+            assert_eq!(
+                queues.deque_next_packet(0, BufId(5)),
+                Some(NextInPacket { buf_id: 6, len: 0 })
+            );
+            assert_eq!(queues.deque_next_packet(0, BufId(6)), None);
+
+            assert_eq!(
+                queues.queue(
+                    1,
+                    NextInPacket {
+                        buf_id: 10,
+                        len: 33
+                    }
+                ),
+                TransmitQueueAction::None
+            );
+            assert_eq!(
+                queues.queue(0, NextInPacket { buf_id: 4, len: 64 }),
+                TransmitQueueAction::SendNow
+            );
+            assert_eq!(
+                queues.queue(0, NextInPacket { buf_id: 5, len: 9 }),
+                TransmitQueueAction::None
+            );
+
+            assert_eq!(
+                queues.deque_next_packet(1, BufId(11)),
+                Some(NextInPacket { buf_id: 12, len: 3 })
+            );
+            assert_eq!(
+                queues.deque_next_packet(1, BufId(12)),
+                Some(NextInPacket {
+                    buf_id: 10,
+                    len: 33
+                })
+            );
+            assert_eq!(
+                queues.deque_next_packet(0, BufId(4)),
+                Some(NextInPacket { buf_id: 5, len: 9 })
+            );
+            assert_eq!(queues.deque_next_packet(0, BufId(5)), None);
+            assert_eq!(queues.deque_next_packet(1, BufId(10)), None);
+
+            // Make sure we cleaned up after ourselves...
+            assert!(queues.slots.iter().all(|s| *s == NextInPacket::NONE));
+            assert!(queues.last_pkt_idx.iter().all(|i| i.is_none()));
+        }
+    }
+}
+
+pub mod buf_pool {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(transparent)]
+    pub struct BufId(pub u32);
+    impl BufId {
+        pub const fn offset(&self) -> usize {
+            self.0 as usize * BUFFER_SLOT_SIZE_WORDS
+        }
+    }
+    impl From<BufId> for u32 {
+        fn from(value: BufId) -> Self {
+            value.0
+        }
+    }
+    impl From<BufId> for usize {
+        fn from(value: BufId) -> Self {
+            usize::try_from(value.0).unwrap()
+        }
+    }
+    impl From<u32> for BufId {
+        fn from(value: u32) -> Self {
+            Self(value)
+        }
+    }
+
+    pub struct BuffPoolAllocator {
+        allocated_buf_ids: u32,
+    }
+    impl Default for BuffPoolAllocator {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+    impl BuffPoolAllocator {
+        pub const fn new() -> Self {
+            Self {
+                allocated_buf_ids: 0,
+            }
+        }
+        pub const fn new_bufpool(&mut self, len: u32) -> Option<BufPool> {
+            let start_id = self.allocated_buf_ids.trailing_ones();
+            if len == 0 || start_id + len > 32 {
+                return None;
+            }
+            let mask = (((1_u64 << len) - 1) << start_id) as u32;
+            self.allocated_buf_ids |= mask;
+            Some(BufPool {
+                init_value: mask,
+                available_bufs: mask,
+            })
+        }
+        pub const fn remainder_bufpool(mut self) -> Option<BufPool> {
+            let left = self.allocated_buf_ids.leading_zeros();
+            self.new_bufpool(left)
+        }
+    }
+
+    #[cfg(test)]
+    mod test_buff_pool_allocator {
+        use super::*;
+
+        #[test]
+        fn test_next() {
+            let mut allocator = BuffPoolAllocator::new();
+            assert_eq!(
+                allocator.new_bufpool(1),
+                Some(BufPool {
+                    available_bufs: 0b01,
+                    init_value: 0b01
+                })
+            );
+            assert_eq!(
+                allocator.new_bufpool(1),
+                Some(BufPool {
+                    available_bufs: 0b10,
+                    init_value: 0b10,
+                })
+            );
+            assert_eq!(
+                allocator.new_bufpool(2),
+                Some(BufPool {
+                    available_bufs: 0b1100,
+                    init_value: 0b1100,
+                })
+            );
+            assert_eq!(allocator.new_bufpool(0), None);
+            assert_eq!(allocator.new_bufpool(30), None);
+            assert_eq!(
+                allocator.new_bufpool(28),
+                Some(BufPool {
+                    available_bufs: (0xffff_ffffu64 << 4) as u32,
+                    init_value: (0xffff_ffffu64 << 4) as u32,
+                })
+            );
+            assert_eq!(allocator.new_bufpool(1), None);
+        }
+        #[test]
+        fn test_remainder() {
+            let mut allocator = BuffPoolAllocator::new();
+            assert_eq!(
+                allocator.new_bufpool(1),
+                Some(BufPool {
+                    available_bufs: 0b01,
+                    init_value: 0b01,
+                })
+            );
+            assert_eq!(
+                allocator.new_bufpool(1),
+                Some(BufPool {
+                    available_bufs: 0b10,
+                    init_value: 0b10,
+                })
+            );
+            assert_eq!(
+                allocator.new_bufpool(2),
+                Some(BufPool {
+                    available_bufs: 0b1100,
+                    init_value: 0b1100,
+                })
+            );
+            assert_eq!(
+                allocator.remainder_bufpool(),
+                Some(BufPool {
+                    available_bufs: (0xffff_ffffu64 << 4) as u32,
+                    init_value: (0xffff_ffffu64 << 4) as u32,
+                })
+            );
+        }
+    }
+
+    #[derive(PartialEq, Eq, Debug, Clone, Copy)]
+    pub struct BufPool {
+        // bitset of bufs that are currently available for taking with take().
+        available_bufs: u32,
+        init_value: u32,
+    }
+    impl BufPool {
+        pub const EMPTY: Self = Self {
+            available_bufs: 0,
+            init_value: 0,
+        };
+
+        #[cfg(test)]
+        pub const fn new(start_id: usize, len: usize) -> Self {
+            assert!(start_id < 32);
+            assert!(len > 0);
+            assert!(start_id + len <= 32);
+            let available_bufs = (((1_u64 << len) - 1) << start_id) as u32;
+            Self {
+                available_bufs,
+                init_value: available_bufs,
+            }
+        }
+        pub fn reset(&mut self) {
+            self.available_bufs = self.init_value;
+        }
+        pub fn take(&mut self) -> Option<BufId> {
+            if self.is_empty() {
+                return None;
+            }
+            let buf_id = self.available_bufs.trailing_zeros();
+            let mask = 1 << buf_id;
+            debug_assert!((self.available_bufs & mask) != 0);
+            self.available_bufs &= !mask;
+            Some(BufId(buf_id))
+        }
+        pub fn put(&mut self, buf_id: BufId) {
+            let mask = 1 << u32::from(buf_id);
+            debug_assert!((self.available_bufs & mask) == 0);
+            self.available_bufs |= mask;
+        }
+
+        pub fn len(&self) -> usize {
+            usize::try_from(self.available_bufs.count_ones()).unwrap()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.available_bufs == 0
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_full_size() {
+            let mut pool = BufPool::new(0, 32);
+            assert_eq!(pool.available_bufs, 0xffff_ffff);
+            for i in 0..32 {
+                assert_eq!(Some(BufId::from(i)), pool.take());
+            }
+            assert_eq!(None, pool.take());
+            pool.put(5.into());
+            pool.put(7.into());
+            pool.put(3.into());
+            assert_eq!(Some(3.into()), pool.take());
+            assert_eq!(Some(5.into()), pool.take());
+            assert_eq!(Some(7.into()), pool.take());
+            assert_eq!(None, pool.take());
+            assert_eq!(None, pool.take());
+        }
+
+        #[test]
+        fn test_5_bits() {
+            let mut pool = BufPool::new(4, 5);
+            assert_eq!(pool.available_bufs, 0x0000_01f0);
+            assert_eq!(Some(BufId::from(4)), pool.take());
+            assert_eq!(Some(BufId::from(5)), pool.take());
+            assert_eq!(Some(BufId::from(6)), pool.take());
+            assert_eq!(Some(BufId::from(7)), pool.take());
+            assert_eq!(Some(BufId::from(8)), pool.take());
+            assert_eq!(None, pool.take());
+
+            pool.put(5.into());
+            pool.put(6.into());
+            assert_eq!(Some(5.into()), pool.take());
+            assert_eq!(Some(6.into()), pool.take());
+            assert_eq!(None, pool.take());
+        }
+
+        #[test]
+        fn test_config() {
+            assert_eq!(
+                UsbConfig::new(
+                    &[
+                        EpIn {
+                            num: 1,
+                            buf_pool_size: 3,
+                        },
+                        EpIn {
+                            num: 3,
+                            buf_pool_size: 5,
+                        },
+                    ],
+                    &[
+                        EpOut {
+                            num: 2,
+                            set_nak: true
+                        },
+                        EpOut {
+                            num: 4,
+                            set_nak: false
+                        },
+                    ]
+                ),
+                UsbConfig {
+                    buf_pool_setup: BufPool::new(0, 4),
+                    buf_pool_out: BufPool::new(4, 12),
+                    buf_pools_in: [
+                        BufPool::new(24, 8),
+                        BufPool::new(16, 3),
+                        BufPool::EMPTY,
+                        BufPool::new(19, 5),
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                        BufPool::EMPTY,
+                    ],
+                    in_mask: 0b01011,
+                    out_mask: 0b10101,
+                    set_nak_mask: 0b100,
+                },
+            );
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_config_too_many_set_nak() {
+            UsbConfig::new(
+                &[EpIn {
+                    num: 1,
+                    buf_pool_size: 3,
+                }],
+                &[
+                    EpOut {
+                        num: 2,
+                        set_nak: true,
+                    },
+                    EpOut {
+                        num: 4,
+                        set_nak: true,
+                    },
+                ],
+            );
+        }
+    }
+}

--- a/target/earlgrey/firmware/hwe/BUILD.bazel
+++ b/target/earlgrey/firmware/hwe/BUILD.bazel
@@ -1,0 +1,204 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:multi_process_app.bzl", "multi_process_app")
+load("@pigweed//pw_kernel/tooling:rust_process.bzl", "rust_process")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+
+rust_process(
+    name = "logmgr",
+    srcs = [
+        "logmgr.rs",
+    ],
+    codegen_crate_name = "logmgr_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+rust_process(
+    name = "usbmgr",
+    srcs = [
+        "usbmgr.rs",
+    ],
+    codegen_crate_name = "usbmgr_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+rust_process(
+    name = "flash_server",
+    srcs = [
+        "flash_server.rs",
+    ],
+    codegen_crate_name = "flash_server_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+rust_process(
+    name = "sysmgr",
+    srcs = [
+        "sysmgr.rs",
+    ],
+    codegen_crate_name = "sysmgr_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+rust_process(
+    name = "platform",
+    srcs = [
+        "platform.rs",
+    ],
+    codegen_crate_name = "platform_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+    ],
+)
+
+multi_process_app(
+    name = "hwe",
+    processes = [
+        ":logmgr",
+        ":sysmgr",
+        ":platform",
+        ":flash_server",
+        ":usbmgr",
+    ],
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+)
+
+system_image(
+    name = "hwe_firmware",
+    apps = [
+        ":hwe",
+    ],
+    kernel = ":target",
+    platform = "//target/earlgrey",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/earlgrey:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/earlgrey:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+opentitan_test(
+    name = "hwe_verilator_test",
+    timeout = "eternal",
+    interface = "verilator",
+    tags = [
+        "nightly_test",
+        "verilator",
+    ],
+    target = ":hwe_firmware",
+)
+
+opentitan_test(
+    name = "hwe_hyper310_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = ":hwe_firmware",
+)
+
+opentitan_test(
+    name = "hwe_hyper340_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
+    ],
+    target = ":hwe_firmware",
+)
+
+opentitan_test(
+    name = "hwe_silicon_test",
+    ecdsa_key = SILICON_ECDSA_KEY,
+    interface = "teacup",
+    tags = [
+        "earlgrey_silicon",
+        "hardware",
+    ],
+    target = ":hwe_firmware",
+)

--- a/target/earlgrey/firmware/hwe/README.md
+++ b/target/earlgrey/firmware/hwe/README.md
@@ -1,0 +1,48 @@
+# Earlgrey HWE Firmware
+
+This directory contains the source code and configuration for the Earlgrey Hardware Enablement (HWE) firmware. It is a multi-process application designed to run on the OpenTitan Earlgrey target, built on top of the Pigweed microkernel (`pw_kernel`).
+
+Currently, the firmware structure is defined, but the individual services are stubs.
+
+## File Structure
+
+*   `BUILD.bazel`: Defines the Bazel build targets for the kernel, userspace processes, the combined system image, and tests.
+*   `system.json5`: The system configuration file. It defines the memory layout, processes, IPC channels, interrupts, and device memory mappings.
+*   `target.rs`: The entry point for the kernel.
+*   `logmgr.rs`: Stub for the Log Manager process.
+*   `sysmgr.rs`: Stub for the System Manager process.
+*   `platform.rs`: Stub for the Platform Server process.
+*   `flash_server.rs`: Stub for the Flash Server process.
+*   `usbmgr.rs`: Stub for the USB Manager process.
+
+## System Configuration (`system.json5`)
+
+The system configuration defines a single application `hwe` containing five processes:
+
+1.  **`logmgr`**: Intended to manage logging. It defines several `channel_handler` objects to receive logs from other processes (`logger_flash`, `logger_platform`, `logger_sysmgr`, `logger_usb`). It also maps the `rv_timer` device.
+2.  **`sysmgr`**: Intended for system management. It has a channel initiator to `logmgr` and maps `retram`, `rstmgr`, and `lc_ctrl` devices.
+3.  **`platform`**: Intended for platform-specific services. It has a channel initiator to `logmgr`.
+4.  **`flash_server`**: Intended to provide flash access. It has a channel initiator to `logmgr`, a `flash_service` channel handler, maps the `flash_ctrl_core` device, and handles the `flash_ctrl_op_done` interrupt.
+5.  **`usbmgr`**: Intended to manage USB. It has a channel initiator to `logmgr`, maps `usbdev` and `pinmux` devices, and handles various USB interrupts.
+
+## Build and Test
+
+The `BUILD.bazel` file defines several targets:
+
+*   `//target/earlgrey/firmware/hwe:hwe_firmware`: The main system image target.
+*   `//target/earlgrey/firmware/hwe:target`: The kernel binary.
+
+### Tests
+
+Several `opentitan_test` targets are defined for different environments:
+
+*   `hwe_verilator_test`: Runs in the Verilator simulator.
+*   `hwe_hyper310_test`: Runs on the CW310 FPGA board.
+*   `hwe_hyper340_test`: Runs on the CW340 FPGA board.
+*   `hwe_silicon_test`: Runs on silicon.
+
+You can run these tests using `bazelisk test`. For example:
+
+```bash
+bazelisk test //target/earlgrey/firmware/hwe:hwe_verilator_test
+```

--- a/target/earlgrey/firmware/hwe/flash_server.rs
+++ b/target/earlgrey/firmware/hwe/flash_server.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::Result;
+use userspace::time::{sleep_until, Instant};
+use userspace::{process_entry, syscall};
+
+/*
+ * TODO: implement flash server.
+ */
+
+#[process_entry("flash_server")]
+fn entry() -> Result<()> {
+    pw_log::debug!("TODO: implement flash server");
+    loop {
+        let wake_time = syscall::debug_clock_now().ticks() + 10_000_000;
+        sleep_until(Instant::from_ticks(wake_time))?;
+    }
+}

--- a/target/earlgrey/firmware/hwe/logmgr.rs
+++ b/target/earlgrey/firmware/hwe/logmgr.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::Result;
+use userspace::time::{sleep_until, Instant};
+use userspace::{process_entry, syscall};
+
+/*
+ * TODO: implement log manager.
+ */
+
+#[process_entry("logmgr")]
+fn entry() -> Result<()> {
+    pw_log::debug!("TODO: implement logmgr");
+    loop {
+        let wake_time = syscall::debug_clock_now().ticks() + 10_000_000;
+        sleep_until(Instant::from_ticks(wake_time))?;
+    }
+}

--- a/target/earlgrey/firmware/hwe/platform.rs
+++ b/target/earlgrey/firmware/hwe/platform.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::Result;
+use userspace::time::{sleep_until, Instant};
+use userspace::{process_entry, syscall};
+
+/*
+ * TODO: implement platform server.
+ */
+
+#[process_entry("platform")]
+fn entry() -> Result<()> {
+    pw_log::debug!("TODO: implement platform server");
+    loop {
+        let wake_time = syscall::debug_clock_now().ticks() + 10_000_000;
+        sleep_until(Instant::from_ticks(wake_time))?;
+    }
+}

--- a/target/earlgrey/firmware/hwe/sysmgr.rs
+++ b/target/earlgrey/firmware/hwe/sysmgr.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::Result;
+use userspace::time::{sleep_until, Instant};
+use userspace::{process_entry, syscall};
+
+/*
+ * TODO: implement sysmgr server.
+ */
+
+#[process_entry("sysmgr")]
+fn entry() -> Result<()> {
+    pw_log::debug!("TODO: implement sysmgr");
+    loop {
+        let wake_time = syscall::debug_clock_now().ticks() + 10_000_000;
+        sleep_until(Instant::from_ticks(wake_time))?;
+    }
+}

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -1,0 +1,223 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv"
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {
+      }
+    }
+  },
+  apps: [
+    {
+      name: "hwe",
+      flash_size_bytes: 32768,
+      processes: [
+        {
+          name: "logmgr",
+          ram_size_bytes: 4096,
+          objects: [
+            {
+              name: "logmgr_wait_group",
+              type: "wait_group"
+            },
+            {
+              name: "logger_flash",
+              type: "channel_handler"
+            },
+            {
+              name: "logger_platform",
+              type: "channel_handler"
+            },
+            {
+              name: "logger_sysmgr",
+              type: "channel_handler"
+            },
+            {
+              name: "logger_usb",
+              type: "channel_handler"
+            },
+            {
+              name: "logmgr_thread",
+              kernel_stack_size_bytes: 2048,
+              type: "thread"
+            }
+          ],
+          memory_mappings: [
+            {
+              name: "rv_timer",
+              type: "device",
+              start_address: 0x40100000,
+              size_bytes: 0x200
+            }
+          ]
+        },
+        {
+          name: "sysmgr",
+          ram_size_bytes: 4096,
+          objects: [
+            {
+              name: "logger_sysmgr",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "logger_sysmgr"
+            },
+            {
+              name: "sysmgr_thread",
+              kernel_stack_size_bytes: 2048,
+              type: "thread"
+            }
+          ],
+          memory_mappings: [
+            {
+              name: "retram",
+              type: "device",
+              start_address: 0x40600000,
+              size_bytes: 0x1000
+            },
+            {
+              name: "rstmgr",
+              type: "device",
+              start_address: 0x40410000,
+              size_bytes: 0x80
+            },
+            {
+              name: "lc_ctrl",
+              type: "device",
+              start_address: 0x40140000,
+              size_bytes: 0x100
+            }
+          ]
+        },
+        {
+          name: "platform",
+          ram_size_bytes: 4096,
+          objects: [
+            {
+              name: "logger_platform",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "logger_platform"
+            },
+            {
+              name: "platform_thread",
+              kernel_stack_size_bytes: 2048,
+              type: "thread"
+            }
+          ],
+          memory_mappings: [
+          ]
+        },
+        {
+          name: "flash_server",
+          ram_size_bytes: 4096,
+          objects: [
+            {
+              name: "logger_flash",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "logger_flash"
+            },
+            {
+              name: "flash_service",
+              type: "channel_handler"
+            },
+            {
+              name: "flash_interrupts",
+              type: "interrupt",
+              irqs: [
+                // { name: "flash_ctrl_prog_empty", number: 160 },
+                // { name: "flash_ctrl_prog_lvl", number: 161 },
+                // { name: "flash_ctrl_rd_full", number: 162 },
+                // { name: "flash_ctrl_rd_lvl", number: 163 },
+                { name: "flash_ctrl_op_done", number: 164 },
+                // { name: "flash_ctrl_corr_err", number: 165 },
+              ]
+            },
+            {
+              name: "flash_server_thread",
+              kernel_stack_size_bytes: 2048,
+              type: "thread"
+            }
+          ],
+          memory_mappings: [
+            {
+              name: "flash_ctrl_core",
+              type: "device",
+              start_address: 0x41000000,
+              size_bytes: 0x200
+            }
+          ]
+        },
+        {
+          name: "usbmgr",
+          ram_size_bytes: 6144,
+          objects: [
+            {
+              name: "logger_usb",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "logger_usb"
+            },
+            {
+              name: "usb_wait_group",
+              type: "wait_group"
+            },
+            {
+              name: "usbdev_interrupts",
+              type: "interrupt",
+              irqs: [
+                { name: "usbdev_pkt_received", number: 135 },
+                { name: "usbdev_pkt_sent", number: 136 },
+                { name: "usbdev_disconnected", number: 137 },
+                { name: "usbdev_host_lost", number: 138 },
+                { name: "usbdev_link_reset", number: 139 },
+                { name: "usbdev_link_suspend", number: 140 },
+                { name: "usbdev_link_resume", number: 141 },
+                { name: "usbdev_av_out_empty", number: 142 },
+                { name: "usbdev_rx_full", number: 143 },
+                { name: "usbdev_av_overflow", number: 144 },
+                // { name: "usbdev_link_in_err", number: 145 },
+                // { name: "usbdev_link_in_err", number: 145 },
+                // { name: "usbdev_rx_crc_err", number: 146 },
+                // { name: "usbdev_rx_pid_err", number: 147 },
+                // { name: "usbdev_rx_bitstuff_err", number: 148 },
+                // { name: "usbdev_frame", number: 149 },
+                { name: "usbdev_powered", number: 150 },
+                // { name: "usbdev_link_out_err", number: 151 },
+                { name: "usbdev_av_setup_empty", number: 152 }
+              ]
+            },
+            {
+              name: "usbmgr_thread",
+              kernel_stack_size_bytes: 2048,
+              type: "thread"
+            }
+          ],
+          memory_mappings: [
+            {
+              name: "usbdev",
+              type: "device",
+              start_address: 0x40320000,
+              size_bytes: 0x1000
+            },
+            {
+              // TODO: eliminate pinmux from usbmgr after implementing pinmux
+              // configuration in the platform task.
+              name: "pinmux",
+              type: "device",
+              start_address: 0x40460000,
+              size_bytes: 0x1000
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/target/earlgrey/firmware/hwe/target.rs
+++ b/target/earlgrey/firmware/hwe/target.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey Userspace UART";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => pw_log::info!("PASS"),
+            _ => pw_log::info!("FAIL: {}", code as u32),
+        };
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/earlgrey/firmware/hwe/usbmgr.rs
+++ b/target/earlgrey/firmware/hwe/usbmgr.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::Result;
+use userspace::time::{sleep_until, Instant};
+use userspace::{process_entry, syscall};
+
+/*
+ * TODO: implement usb task.
+ */
+
+#[process_entry("usbmgr")]
+fn entry() -> Result<()> {
+    pw_log::debug!("TODO: implement usbmgr");
+    loop {
+        let wake_time = syscall::debug_clock_now().ticks() + 10_000_000;
+        sleep_until(Instant::from_ticks(wake_time))?;
+    }
+}

--- a/target/earlgrey/tests/usbdev/BUILD.bazel
+++ b/target/earlgrey/tests/usbdev/BUILD.bazel
@@ -1,0 +1,130 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:rust_app.bzl", "rust_app")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+
+rust_app(
+    name = "test_usb",
+    srcs = [
+        "test_usb.rs",
+    ],
+    codegen_crate_name = "test_usb_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking/usb:hal_usb",
+        "//protocol/usb/stack",
+        "//target/earlgrey/drivers:usb_driver",
+        "//target/earlgrey/registers:pinmux",
+        "//target/earlgrey/registers:top_earlgrey",
+        "//target/earlgrey/registers:usbdev",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:aligned",
+    ],
+)
+
+system_image(
+    name = "usb",
+    apps = [
+        ":test_usb",
+    ],
+    kernel = ":target",
+    platform = "//target/earlgrey",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/earlgrey:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/earlgrey:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+opentitan_test(
+    name = "usb_verilator_test",
+    timeout = "eternal",
+    interface = "verilator",
+    tags = [
+        "nightly_test",
+        "verilator",
+    ],
+    target = ":usb",
+)
+
+# TODO(cfrantz): these tests need to verify that the USB function got enumerated.
+opentitan_test(
+    name = "usb_hyper310_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = ":usb",
+)
+
+opentitan_test(
+    name = "usb_hyper340_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
+    ],
+    target = ":usb",
+)
+
+opentitan_test(
+    name = "usb_silicon_test",
+    ecdsa_key = SILICON_ECDSA_KEY,
+    interface = "teacup",
+    tags = [
+        "earlgrey_silicon",
+        "hardware",
+    ],
+    target = ":usb",
+)

--- a/target/earlgrey/tests/usbdev/system.json5
+++ b/target/earlgrey/tests/usbdev/system.json5
@@ -1,0 +1,76 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "test_usb",
+      flash_size_bytes: 16384,
+      processes: [{
+        name: "test_usb_process",
+        ram_size_bytes: 4096,
+        objects: [
+          {
+            name: "usbdev_interrupts",
+            type: "interrupt",
+            irqs: [
+                { name: "usbdev_pkt_received", number: 135 },
+                { name: "usbdev_pkt_sent", number: 136 },
+                { name: "usbdev_disconnected", number: 137 },
+                { name: "usbdev_host_lost", number: 138 },
+
+                { name: "usbdev_link_reset", number: 139 },
+                { name: "usbdev_link_suspend", number: 140 },
+                { name: "usbdev_link_resume", number: 141 },
+                { name: "usbdev_av_out_empty", number: 142 },
+
+                { name: "usbdev_rx_full", number: 143 },
+                { name: "usbdev_av_overflow", number: 144 },
+                //{ name: "usbdev_link_in_err", number: 145 },
+                { name: "usbdev_rx_crc_err", number: 146 },
+
+                { name: "usbdev_rx_pid_err", number: 147 },
+                { name: "usbdev_rx_bitstuff_err", number: 148 },
+                { name: "usbdev_frame", number: 149 },
+                //{ name: "usbdev_powered", number: 150 },
+
+                //{ name: "usbdev_link_out_err", number: 151 },
+                { name: "usbdev_av_setup_empty", number: 152 },
+            ],
+          },
+          {
+            type: "thread",
+            name: "usb_thread",
+            kernel_stack_size_bytes: 2048,
+          },
+        ],
+        memory_mappings: [
+          {
+            name: "usbdev",
+            type: "device",
+            start_address: 0x40320000,
+            size_bytes: 0x1000,
+          },
+          {
+            name: "pinmux",
+            type: "device",
+            start_address: 0x40460000,
+            size_bytes: 0x1000,
+          }
+
+        ],
+      }],
+    },
+  ],
+}

--- a/target/earlgrey/tests/usbdev/target.rs
+++ b/target/earlgrey/tests/usbdev/target.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey Userspace UART";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => pw_log::info!("PASS"),
+            _ => pw_log::info!("FAIL: {}", code as u32),
+        };
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/earlgrey/tests/usbdev/test_usb.rs
+++ b/target/earlgrey/tests/usbdev/test_usb.rs
@@ -1,0 +1,245 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use pw_status::{Error, Result, StatusCode};
+
+use test_usb_codegen::{handle, signals};
+use userspace::time::Instant;
+use userspace::{entry, syscall};
+
+use aligned::{Aligned, A4};
+use hal_usb::driver::{UsbDriver, UsbEvent, UsbPacket};
+use hal_usb::{Direction, StringDescriptorRef, USB_CLASS_VENDOR};
+use usb_driver::{EpIn, EpOut, UsbConfig};
+use usb_stack::{
+    //UsbActionRun,
+    DescriptorSource,
+    UsbAction,
+};
+
+const USB_VENDOR_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(1);
+const USB_PRODUCT_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(2);
+const USB_SERIAL_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(3);
+const USB_TEST_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(4);
+
+static DEVICE_DESC: hal_usb::DeviceDescriptor = hal_usb::DeviceDescriptor {
+    device_class: hal_usb::DeviceClass::SPECIFIED_BY_INTERFACE,
+    device_sub_class: 0x00,
+    device_protocol: 0x00,
+    max_packet_size: 64,
+    vendor_id: 0x18d1,  // Google, Inc.
+    product_id: 0x503a, // STWG USB Fullspeed IP.
+    device_release_num: 0x0100,
+    manufacturer: USB_VENDOR_HANDLE,
+    product: USB_PRODUCT_HANDLE,
+    serial_num: USB_SERIAL_HANDLE,
+};
+const CONFIG_DESC: hal_usb::ConfigDescriptor = hal_usb::ConfigDescriptor {
+    configuration_value: 1,
+    max_power: 250,
+    self_powered: false,
+    remote_wakeup: false,
+    interfaces: &[hal_usb::InterfaceDescriptor {
+        name: USB_TEST_HANDLE,
+        interface_number: 1,
+        alternate_setting: 0,
+        interface_class: USB_CLASS_VENDOR,
+        interface_sub_class: 0xFF,
+        interface_protocol: 1,
+        func_descs: &[],
+        endpoints: &[
+            hal_usb::EndpointDescriptor {
+                direction: Direction::DeviceToHost,
+                endpoint_num: 1,
+                interval: 0,
+                max_packet_size: 64,
+                transfer_type: hal_usb::TransferType::Bulk,
+            },
+            hal_usb::EndpointDescriptor {
+                direction: Direction::HostToDevice,
+                endpoint_num: 2,
+                interval: 0,
+                max_packet_size: 64,
+                transfer_type: hal_usb::TransferType::Bulk,
+            },
+        ],
+    }],
+};
+
+const STRING_DESC_0: hal_usb::StringDescriptor0 = hal_usb::StringDescriptor0 {
+    langs: &[
+        // English - United States
+        0x0409,
+    ],
+};
+
+const VENDOR_ID: hal_usb::StringDescriptorRef = hal_usb::string_descriptor!("Google Inc.").as_ref();
+const PRODUCT_ID_DEFAULT: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("OpenPRoT Earlgrey").as_ref();
+const USB_TEST: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("USB Test Interface").as_ref();
+
+struct MyDescriptors<'a> {
+    serial_desc_bytes: StringDescriptorRef<'a>,
+    product_desc_bytes: StringDescriptorRef<'a>,
+}
+
+impl DescriptorSource for MyDescriptors<'_> {
+    const DEVICE_DESC_BYTES: &'static Aligned<A4, [u8]> = &Aligned(DEVICE_DESC.serialize());
+    const CONFIG_DESC_BYTES: &'static Aligned<A4, [u8]> =
+        &Aligned(CONFIG_DESC.serialize::<{ CONFIG_DESC.total_size() }>());
+    const STRING_DESC_0_BYTES: &'static Aligned<A4, [u8]> =
+        &Aligned(STRING_DESC_0.serialize::<{ STRING_DESC_0.total_size() }>());
+    // We advertise that we are self-powered and do not support remote wakeup.
+    const DEVICE_STATUS: Aligned<A4, [u8; 2]> = Aligned([1u8, 0]);
+
+    fn get_string(
+        &self,
+        handle: hal_usb::StringHandle,
+        _lang: u16,
+    ) -> Option<hal_usb::StringDescriptorRef<'_>> {
+        match handle {
+            USB_VENDOR_HANDLE => Some(VENDOR_ID),
+            USB_PRODUCT_HANDLE => Some(self.product_desc_bytes),
+            USB_SERIAL_HANDLE => Some(self.serial_desc_bytes),
+            USB_TEST_HANDLE => Some(USB_TEST),
+            _ => None,
+        }
+    }
+}
+
+const CONTROL_EP_OUT_NUM: u8 = 0;
+
+fn handle_usb() -> Result<()> {
+    let mut serial_num_buffer = Aligned::<A4, _>([0_u8; 130]);
+    // TODO: build proper descriptors.
+    //let mut product_desc_buffer = Aligned::<A4, _>([0_u8; 100]);
+    let descriptors = MyDescriptors {
+        serial_desc_bytes: hal_usb::hex_utf16_descriptor_aligned(&mut serial_num_buffer, b"12345")
+            .unwrap(),
+        product_desc_bytes: PRODUCT_ID_DEFAULT,
+    };
+    const USB_EP_IN: EpIn = EpIn {
+        num: 1,
+        buf_pool_size: 8,
+    };
+    const USB_EP_OUT: EpOut = EpOut {
+        num: 2,
+        set_nak: true,
+    };
+
+    const USB_CONFIG: UsbConfig = UsbConfig::new(&[USB_EP_IN], &[USB_EP_OUT]);
+    let mut usb = usb_driver::Usb::new(unsafe { usbdev::Usbdev::new() }, USB_CONFIG);
+    let mut ep0 = usb_stack::SimpleEp0::new();
+    let mut ep0_action: UsbAction<'_> = UsbAction::None;
+
+    loop {
+        let wait_return = syscall::object_wait(
+            handle::USBDEV_INTERRUPTS,
+            signals::USBDEV_PKT_RECEIVED
+                | signals::USBDEV_PKT_SENT
+                | signals::USBDEV_DISCONNECTED
+                | signals::USBDEV_HOST_LOST
+                | signals::USBDEV_LINK_RESET
+                | signals::USBDEV_LINK_SUSPEND
+                | signals::USBDEV_LINK_RESUME
+                | signals::USBDEV_AV_OUT_EMPTY
+                | signals::USBDEV_RX_FULL
+                | signals::USBDEV_AV_OVERFLOW
+                //| signals::USBDEV_LINK_IN_ERR
+                | signals::USBDEV_RX_CRC_ERR
+                | signals::USBDEV_RX_PID_ERR
+                | signals::USBDEV_RX_BITSTUFF_ERR
+                | signals::USBDEV_FRAME
+                //| signals::USBDEV_POWERED
+                //| signals::USBDEV_LINK_OUT_ERR
+                | signals::USBDEV_AV_SETUP_EMPTY,
+            Instant::MAX,
+        )?;
+
+        if wait_return.user_data != 0 {
+            pw_log::error!("Incorrect WaitReturn values");
+            return Err(Error::Unknown);
+        }
+        let _ = syscall::interrupt_ack(handle::USBDEV_INTERRUPTS, wait_return.pending_signals);
+        while let Some(event) = usb.poll() {
+            match event {
+                UsbEvent::SetupPacket { pkt, endpoint } => {
+                    if endpoint == 0 {
+                        let dir = pkt.request().direction() as u32;
+                        let ty = pkt.request().request_type() as u32;
+                        let recip = pkt.request().recipient() as u32;
+                        let bmreq = (dir << 7) | (ty << 5) | (recip);
+                        let request = pkt.request().request();
+                        pw_log::debug!(
+                            "SETUP: {:02x} {:02x} val={:04x} idx={:04x} len={:04x}",
+                            bmreq as u32,
+                            request as u8,
+                            pkt.value() as u16,
+                            pkt.index() as u16,
+                            pkt.length() as u16,
+                        );
+
+                        ep0_action = ep0.handle_event(event, &descriptors).unwrap_or(UsbAction::None);
+                    } else {
+                        pw_log::debug!("Setup on bad EP {}", endpoint as u8);
+                    }
+                }
+
+                UsbEvent::DataOutPacket(pkt) => match u8::try_from(pkt.endpoint_index()).unwrap() {
+                    CONTROL_EP_OUT_NUM => {
+                        pw_log::debug!("OUT on control ep");
+                    }
+                    ep => {
+                        pw_log::debug!(
+                            "Unhandled OUT on EP {} len={}",
+                            ep as u8,
+                            pkt.len() as usize
+                        );
+                    }
+                },
+                UsbEvent::UsbReset => {
+                    pw_log::debug!("USB reset");
+                }
+                _ => {
+                    ep0_action.merge(ep0.handle_event(event, &descriptors).unwrap_or(UsbAction::None));
+                }
+            }
+            ep0_action.run(&mut usb);
+        }
+    }
+}
+
+fn usb_setup_pinmux() {
+    use top_earlgrey::{PinmuxInsel, PinmuxPeripheralIn};
+    let mut pinmux = unsafe { pinmux::PinmuxAon::new() };
+
+    pinmux
+        .regs_mut()
+        .mio_periph_insel()
+        .at(PinmuxPeripheralIn::UsbdevSense as usize)
+        .modify(|_| (PinmuxInsel::ConstantOne as u32).into());
+}
+
+#[entry]
+fn entry() -> Result<()> {
+    pw_log::info!("🔄 RUNNING");
+    usb_setup_pinmux();
+    let ret = handle_usb();
+
+    if ret.is_err() {
+        pw_log::error!("❌ FAIL: {}", ret.status_code() as u32);
+    } else {
+        pw_log::info!("✅ PASS");
+    }
+
+    ret
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    pw_log::error!("FAIL: panic in {}", module_path!() as &str);
+    loop {}
+}

--- a/target/earlgrey/tests/usbserial/BUILD.bazel
+++ b/target/earlgrey/tests/usbserial/BUILD.bazel
@@ -1,0 +1,130 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:rust_app.bzl", "rust_app")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+
+rust_app(
+    name = "test_usb",
+    srcs = [
+        "test_usb.rs",
+    ],
+    codegen_crate_name = "test_usb_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//hal/blocking/usb:hal_usb",
+        "//protocol/usb/cdc_acm",
+        "//protocol/usb/stack",
+        "//target/earlgrey/drivers:usb_driver",
+        "//target/earlgrey/registers:pinmux",
+        "//target/earlgrey/registers:top_earlgrey",
+        "//target/earlgrey/registers:usbdev",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:aligned",
+    ],
+)
+
+system_image(
+    name = "usb",
+    apps = [
+        ":test_usb",
+    ],
+    kernel = ":target",
+    platform = "//target/earlgrey",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/earlgrey:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/earlgrey:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+opentitan_test(
+    name = "usb_verilator_test",
+    timeout = "eternal",
+    interface = "verilator",
+    tags = [
+        "nightly_test",
+        "verilator",
+    ],
+    target = ":usb",
+)
+
+opentitan_test(
+    name = "usb_hyper310_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = ":usb",
+)
+
+opentitan_test(
+    name = "usb_hyper340_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
+    ],
+    target = ":usb",
+)
+
+opentitan_test(
+    name = "usb_silicon_test",
+    ecdsa_key = SILICON_ECDSA_KEY,
+    interface = "teacup",
+    tags = [
+        "earlgrey_silicon",
+        "hardware",
+    ],
+    target = ":usb",
+)

--- a/target/earlgrey/tests/usbserial/system.json5
+++ b/target/earlgrey/tests/usbserial/system.json5
@@ -1,0 +1,76 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "test_usb",
+      flash_size_bytes: 16384,
+      processes: [{
+        ram_size_bytes: 4096,
+        name: "test_uart_listener",
+        objects: [
+          {
+            name: "usbdev_interrupts",
+            type: "interrupt",
+            irqs: [
+                { name: "usbdev_pkt_received", number: 135 },
+                { name: "usbdev_pkt_sent", number: 136 },
+                { name: "usbdev_disconnected", number: 137 },
+                { name: "usbdev_host_lost", number: 138 },
+
+                { name: "usbdev_link_reset", number: 139 },
+                { name: "usbdev_link_suspend", number: 140 },
+                { name: "usbdev_link_resume", number: 141 },
+                { name: "usbdev_av_out_empty", number: 142 },
+
+                { name: "usbdev_rx_full", number: 143 },
+                { name: "usbdev_av_overflow", number: 144 },
+                //{ name: "usbdev_link_in_err", number: 145 },
+                { name: "usbdev_rx_crc_err", number: 146 },
+
+                { name: "usbdev_rx_pid_err", number: 147 },
+                { name: "usbdev_rx_bitstuff_err", number: 148 },
+                { name: "usbdev_frame", number: 149 },
+                //{ name: "usbdev_powered", number: 150 },
+
+                //{ name: "usbdev_link_out_err", number: 151 },
+                { name: "usbdev_av_setup_empty", number: 152 },
+            ],
+          },
+          {
+            type: "thread",
+            name: "usb_thread",
+            kernel_stack_size_bytes: 2048,
+          },
+        ],
+        memory_mappings: [
+          {
+            name: "usbdev",
+            type: "device",
+            start_address: 0x40320000,
+            size_bytes: 0x1000,
+          },
+          {
+            name: "pinmux",
+            type: "device",
+            start_address: 0x40460000,
+            size_bytes: 0x1000,
+          }
+
+        ],
+      }],
+    },
+  ],
+}

--- a/target/earlgrey/tests/usbserial/target.rs
+++ b/target/earlgrey/tests/usbserial/target.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey Userspace UART";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => pw_log::info!("PASS"),
+            _ => pw_log::info!("FAIL: {}", code as u32),
+        };
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/earlgrey/tests/usbserial/test_usb.rs
+++ b/target/earlgrey/tests/usbserial/test_usb.rs
@@ -3,28 +3,37 @@
 
 #![no_std]
 #![no_main]
-use pw_status::{Error, Result, StatusCode};
+#![allow(dead_code)]
 
+use pw_status::{Error, Result, StatusCode};
 use test_usb_codegen::{handle, signals};
 use userspace::time::Instant;
 use userspace::{entry, syscall};
 
 use aligned::{Aligned, A4};
-use hal_usb::driver::{UsbDriver, UsbEvent, UsbPacket};
-use hal_usb::{Direction, StringDescriptorRef, USB_CLASS_VENDOR};
-use usb_driver::{EpIn, EpOut, UsbConfig};
-use usb_stack::{
-    //UsbActionRun,
-    DescriptorSource,
-    UsbAction,
-};
+use hal_usb::{ConfigDescriptor, DeviceDescriptor, StringDescriptorRef};
+
+use hal_usb::driver::UsbDriver;
+use usb_driver::UsbConfig;
+use usb_stack::{DescriptorSource, UsbAction, UsbClass};
+
+use protocol_usb_cdc_acm::{CdcAcm, CdcAcmBuilder};
 
 const USB_VENDOR_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(1);
 const USB_PRODUCT_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(2);
 const USB_SERIAL_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(3);
-const USB_TEST_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(4);
+const USB_CDC_COMM_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(4);
+const USB_CDC_DATA_HANDLE: hal_usb::StringHandle = hal_usb::StringHandle(5);
 
-static DEVICE_DESC: hal_usb::DeviceDescriptor = hal_usb::DeviceDescriptor {
+const CDC_BUILDER: CdcAcmBuilder = CdcAcmBuilder::new(
+    0, // comm_if: Communication Interface index
+    1, // data_if: Data Interface index
+    1, // comm_ep: Communication IN endpoint (Interrupt)
+    2, // data_out_ep: Data OUT endpoint (Bulk)
+    3, // data_in_ep: Data IN endpoint (Bulk)
+);
+
+const DEVICE_DESC: DeviceDescriptor = DeviceDescriptor {
     device_class: hal_usb::DeviceClass::SPECIFIED_BY_INTERFACE,
     device_sub_class: 0x00,
     device_protocol: 0x00,
@@ -36,36 +45,20 @@ static DEVICE_DESC: hal_usb::DeviceDescriptor = hal_usb::DeviceDescriptor {
     product: USB_PRODUCT_HANDLE,
     serial_num: USB_SERIAL_HANDLE,
 };
-const CONFIG_DESC: hal_usb::ConfigDescriptor = hal_usb::ConfigDescriptor {
+
+const CONFIG_DESC: ConfigDescriptor = ConfigDescriptor {
     configuration_value: 1,
     max_power: 250,
     self_powered: false,
     remote_wakeup: false,
-    interfaces: &[hal_usb::InterfaceDescriptor {
-        name: USB_TEST_HANDLE,
-        interface_number: 1,
-        alternate_setting: 0,
-        interface_class: USB_CLASS_VENDOR,
-        interface_sub_class: 0xFF,
-        interface_protocol: 1,
-        func_descs: &[],
-        endpoints: &[
-            hal_usb::EndpointDescriptor {
-                direction: Direction::DeviceToHost,
-                endpoint_num: 1,
-                interval: 0,
-                max_packet_size: 64,
-                transfer_type: hal_usb::TransferType::Bulk,
-            },
-            hal_usb::EndpointDescriptor {
-                direction: Direction::HostToDevice,
-                endpoint_num: 2,
-                interval: 0,
-                max_packet_size: 64,
-                transfer_type: hal_usb::TransferType::Bulk,
-            },
-        ],
-    }],
+    interfaces: &[
+        CDC_BUILDER.comm_interface(
+            USB_CDC_COMM_HANDLE,
+            &CDC_BUILDER.comm_func_descs(),
+            &CDC_BUILDER.comm_endpoints(),
+        ),
+        CDC_BUILDER.data_interface(USB_CDC_DATA_HANDLE, &CDC_BUILDER.data_endpoints()),
+    ],
 };
 
 const STRING_DESC_0: hal_usb::StringDescriptor0 = hal_usb::StringDescriptor0 {
@@ -78,8 +71,10 @@ const STRING_DESC_0: hal_usb::StringDescriptor0 = hal_usb::StringDescriptor0 {
 const VENDOR_ID: hal_usb::StringDescriptorRef = hal_usb::string_descriptor!("Google Inc.").as_ref();
 const PRODUCT_ID_DEFAULT: hal_usb::StringDescriptorRef =
     hal_usb::string_descriptor!("OpenPRoT Earlgrey").as_ref();
-const USB_TEST: hal_usb::StringDescriptorRef =
-    hal_usb::string_descriptor!("USB Test Interface").as_ref();
+const USB_COMM: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("CDC Comm Interface").as_ref();
+const USB_DATA: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("CDC Data Interface").as_ref();
 
 struct MyDescriptors<'a> {
     serial_desc_bytes: StringDescriptorRef<'a>,
@@ -92,7 +87,6 @@ impl DescriptorSource for MyDescriptors<'_> {
         &Aligned(CONFIG_DESC.serialize::<{ CONFIG_DESC.total_size() }>());
     const STRING_DESC_0_BYTES: &'static Aligned<A4, [u8]> =
         &Aligned(STRING_DESC_0.serialize::<{ STRING_DESC_0.total_size() }>());
-    // We advertise that we are self-powered and do not support remote wakeup.
     const DEVICE_STATUS: Aligned<A4, [u8; 2]> = Aligned([1u8, 0]);
 
     fn get_string(
@@ -104,36 +98,29 @@ impl DescriptorSource for MyDescriptors<'_> {
             USB_VENDOR_HANDLE => Some(VENDOR_ID),
             USB_PRODUCT_HANDLE => Some(self.product_desc_bytes),
             USB_SERIAL_HANDLE => Some(self.serial_desc_bytes),
-            USB_TEST_HANDLE => Some(USB_TEST),
+            USB_CDC_COMM_HANDLE => Some(USB_COMM),
+            USB_CDC_DATA_HANDLE => Some(USB_DATA),
             _ => None,
         }
     }
 }
 
-const CONTROL_EP_OUT_NUM: u8 = 0;
-
 fn handle_usb() -> Result<()> {
     let mut serial_num_buffer = Aligned::<A4, _>([0_u8; 130]);
-    // TODO: build proper descriptors.
-    //let mut product_desc_buffer = Aligned::<A4, _>([0_u8; 100]);
     let descriptors = MyDescriptors {
-        serial_desc_bytes: hal_usb::hex_utf16_descriptor_aligned(&mut serial_num_buffer, b"12345")
-            .unwrap(),
+        serial_desc_bytes: hal_usb::hex_utf16_descriptor_aligned(
+            &mut serial_num_buffer,
+            b"12345678",
+        )
+        .unwrap(),
         product_desc_bytes: PRODUCT_ID_DEFAULT,
     };
-    const USB_EP_IN: EpIn = EpIn {
-        num: 1,
-        buf_pool_size: 8,
-    };
-    const USB_EP_OUT: EpOut = EpOut {
-        num: 2,
-        set_nak: true,
-    };
 
-    const USB_CONFIG: UsbConfig = UsbConfig::new(&[USB_EP_IN], &[USB_EP_OUT]);
+    const USB_CONFIG: UsbConfig = UsbConfig::new(&CDC_BUILDER.eps().0, &CDC_BUILDER.eps().1);
+
     let mut usb = usb_driver::Usb::new(unsafe { usbdev::Usbdev::new() }, USB_CONFIG);
     let mut ep0 = usb_stack::SimpleEp0::new();
-    let mut ep0_action: UsbAction<'_> = UsbAction::None;
+    let mut cdc_acm = CdcAcm::<256, 256>::new(CDC_BUILDER);
 
     loop {
         let wait_return = syscall::object_wait(
@@ -148,13 +135,10 @@ fn handle_usb() -> Result<()> {
                 | signals::USBDEV_AV_OUT_EMPTY
                 | signals::USBDEV_RX_FULL
                 | signals::USBDEV_AV_OVERFLOW
-                //| signals::USBDEV_LINK_IN_ERR
                 | signals::USBDEV_RX_CRC_ERR
                 | signals::USBDEV_RX_PID_ERR
                 | signals::USBDEV_RX_BITSTUFF_ERR
                 | signals::USBDEV_FRAME
-                //| signals::USBDEV_POWERED
-                //| signals::USBDEV_LINK_OUT_ERR
                 | signals::USBDEV_AV_SETUP_EMPTY,
             Instant::MAX,
         )?;
@@ -163,57 +147,24 @@ fn handle_usb() -> Result<()> {
             pw_log::error!("Incorrect WaitReturn values");
             return Err(Error::Unknown);
         }
+
         let _ = syscall::interrupt_ack(handle::USBDEV_INTERRUPTS, wait_return.pending_signals);
         while let Some(event) = usb.poll() {
-            match event {
-                UsbEvent::SetupPacket { pkt, endpoint } => {
-                    if endpoint == 0 {
-                        let dir = pkt.request().direction() as u32;
-                        let ty = pkt.request().request_type() as u32;
-                        let recip = pkt.request().recipient() as u32;
-                        let bmreq = (dir << 7) | (ty << 5) | (recip);
-                        let request = pkt.request().request();
-                        pw_log::debug!(
-                            "SETUP: {:02x} {:02x} val={:04x} idx={:04x} len={:04x}",
-                            bmreq as u32,
-                            request as u8,
-                            pkt.value() as u16,
-                            pkt.index() as u16,
-                            pkt.length() as u16,
-                        );
-
-                        ep0_action = ep0
-                            .handle_event(event, &descriptors)
-                            .unwrap_or(UsbAction::None);
-                    } else {
-                        pw_log::debug!("Setup on bad EP {}", endpoint as u8);
-                    }
-                }
-
-                UsbEvent::DataOutPacket(pkt) => match u8::try_from(pkt.endpoint_index()).unwrap() {
-                    CONTROL_EP_OUT_NUM => {
-                        pw_log::debug!("OUT on control ep");
-                    }
-                    ep => {
-                        pw_log::debug!(
-                            "Unhandled OUT on EP {} len={}",
-                            ep as u8,
-                            pkt.len() as usize
-                        );
-                    }
-                },
-                UsbEvent::UsbReset => {
-                    pw_log::debug!("USB reset");
-                }
-                _ => {
-                    ep0_action.merge(
-                        ep0.handle_event(event, &descriptors)
-                            .unwrap_or(UsbAction::None),
-                    );
-                }
-            }
-            ep0_action.run(&mut usb);
+            let mut action = match cdc_acm.handle_event(event) {
+                Ok(a) => a,
+                Err(e) => ep0.handle_event(e, &descriptors).unwrap_or(UsbAction::None),
+            };
+            action.run(&mut usb);
         }
+
+        // Loopback received data to send buffer
+        while let Some(byte) = cdc_acm.rx_queue.pop() {
+            pw_log::info!("CDC-ACM echo byte {:#04x}", byte as u8);
+            let _ = cdc_acm.tx_queue.push(byte);
+        }
+
+        // Initiate any pending transmissions
+        cdc_acm.poll_transmit(&mut usb);
     }
 }
 

--- a/util/ringbuffer/BUILD.bazel
+++ b/util/ringbuffer/BUILD.bazel
@@ -1,0 +1,27 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "ringbuffer",
+    srcs = [
+        "lib.rs",
+    ],
+    crate_name = "util_ringbuffer",
+    edition = "2024",
+    deps = [
+    ],
+)
+
+rust_test(
+    name = "ringbuffer_test",
+    crate = ":ringbuffer",
+)
+
+rust_doc(
+    name = "ringbuffer_doc",
+    crate = ":ringbuffer",
+)

--- a/util/ringbuffer/lib.rs
+++ b/util/ringbuffer/lib.rs
@@ -1,0 +1,184 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(not(test), no_std)]
+
+/// A simple single-threaded ring buffer of type `T` with a backing array of size `N`.
+///
+/// The effective capacity of this queue is `N - 1`.
+///
+/// If producer == consumer, the queue is empty.
+/// If (producer + 1) % N == consumer, the queue is full.
+pub struct RingBuffer<T: Copy + Default, const N: usize> {
+    producer: usize,
+    consumer: usize,
+    data: [T; N],
+}
+
+/// Creates a default empty `RingBuffer`.
+///
+/// # Panics
+///
+/// Panics at compile time if `N <= 1`.
+impl<T: Copy + Default, const N: usize> Default for RingBuffer<T, N> {
+    fn default() -> Self {
+        // The queue requires at least 2 slots to store 1 item (N-1 capacity).
+        // Using a const block to ensure this is checked at compile time.
+        const { assert!(N > 1, "RingBuffer size N must be greater than 1") };
+        Self {
+            producer: 0,
+            consumer: 0,
+            data: [T::default(); N],
+        }
+    }
+}
+
+impl<T: Copy + Default, const N: usize> RingBuffer<T, N> {
+    /// Pushes an item into the buffer.
+    ///
+    /// Returns `Ok(())` if the item was successfully added, or `Err(item)` if the buffer is full.
+    pub fn push(&mut self, item: T) -> Result<(), T> {
+        let next = (self.producer + 1) % N;
+        if next != self.consumer {
+            self.data[self.producer] = item;
+            self.producer = next;
+            Ok(())
+        } else {
+            Err(item)
+        }
+    }
+
+    /// Removes and returns the first item from the buffer.
+    ///
+    /// Returns `Some(item)` if the buffer is not empty, or `None` if it is.
+    pub fn pop(&mut self) -> Option<T> {
+        if self.consumer != self.producer {
+            let item = self.data[self.consumer];
+            self.consumer = (self.consumer + 1) % N;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of items currently in the buffer.
+    pub fn len(&self) -> usize {
+        (self.producer + N - self.consumer) % N
+    }
+
+    /// Returns the number of slots available in the buffer.
+    pub fn available(&self) -> usize {
+        (self.consumer + N - self.producer - 1) % N
+    }
+
+    /// Returns `true` if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.producer == self.consumer
+    }
+
+    /// Returns `true` if the buffer is full.
+    pub fn is_full(&self) -> bool {
+        (self.producer + 1) % N == self.consumer
+    }
+
+    /// Pushes as many items from the slice into the buffer as possible.
+    ///
+    /// Returns `Ok(())` if all items were added, or `Err(&[T])` containing the
+    /// remaining unbuffered items if the buffer became full.
+    pub fn push_slice<'a>(&mut self, s: &'a [T]) -> Result<(), &'a [T]> {
+        let free = (self.consumer + N - self.producer - 1) % N;
+        let n = core::cmp::min(s.len(), free);
+
+        let mut remaining = n;
+        let mut src_idx = 0;
+
+        let chunk1 = core::cmp::min(remaining, N - self.producer);
+        if chunk1 > 0 {
+            self.data[self.producer..self.producer + chunk1]
+                .copy_from_slice(&s[src_idx..src_idx + chunk1]);
+            self.producer = (self.producer + chunk1) % N;
+            remaining -= chunk1;
+            src_idx += chunk1;
+        }
+
+        if remaining > 0 {
+            self.data[0..remaining].copy_from_slice(&s[src_idx..src_idx + remaining]);
+            self.producer = remaining;
+        }
+
+        if n < s.len() {
+            Err(&s[n..])
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns a slice containing the contiguous part of the buffered data.
+    ///
+    /// If the data wraps around the end of the backing array, this only returns
+    /// the first part. Callers should use `consume()` and `as_slice()` again to
+    /// retrieve the wrapped portion.
+    pub fn as_slice(&self) -> &[T] {
+        if self.consumer <= self.producer {
+            // The available slice is contiguous in the array.
+            &self.data[self.consumer..self.producer]
+        } else {
+            // Slices can't wrap around the end of the array, so give just the chunk we can give.
+            &self.data[self.consumer..]
+        }
+    }
+
+    /// Advances the consumer pointer by `n` items, effectively removing them from the buffer.
+    ///
+    /// If `n` is greater than the current length, only the available items are consumed.
+    pub fn consume(&mut self, n: usize) {
+        let n = core::cmp::min(n, self.len());
+        self.consumer = (self.consumer + n) % N;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_pop() {
+        let mut q = RingBuffer::<u8, 4>::default();
+
+        assert_eq!(q.push(b'b'), Ok(()));
+        assert_eq!(q.push(b'y'), Ok(()));
+        assert_eq!(q.push(b'e'), Ok(()));
+        assert_eq!(q.push(b'x'), Err(b'x')); // Overflow
+        assert_eq!(q.len(), 3);
+        assert_eq!(q.is_empty(), false);
+        assert_eq!(q.is_full(), true);
+
+        assert_eq!(q.pop(), Some(b'b'));
+        assert_eq!(q.pop(), Some(b'y'));
+        assert_eq!(q.pop(), Some(b'e'));
+        assert_eq!(q.pop(), None); // No more items.
+        assert_eq!(q.len(), 0);
+        assert_eq!(q.is_empty(), true);
+        assert_eq!(q.is_full(), false);
+    }
+
+    #[test]
+    fn test_as_slice() {
+        let mut q = RingBuffer::<u8, 8>::default();
+        assert_eq!(q.push_slice(b"Hello"), Ok(()));
+
+        assert_eq!(q.as_slice(), b"Hello");
+        q.consume(5);
+        assert_eq!(q.is_empty(), true);
+
+        // This part will be wrapped around the end of the array,
+        // so we need to perform two `as_slice` ops to get the whole thing.
+        assert_eq!(q.push_slice(b"World"), Ok(()));
+        assert_eq!(q.as_slice(), b"Wor");
+        q.consume(3);
+        assert_eq!(q.as_slice(), b"ld");
+        q.consume(2);
+        assert_eq!(q.is_empty(), true);
+    }
+}


### PR DESCRIPTION
This creates an empty shell of the hardware enablement firmware
1. Add the usb stack and driver.
2. Add basic usb tests
3. Construct HWE firmware with empty tasks.