### PR TITLE
automation: update `earlgrey-hwe` sync action

### DIFF
--- a/.github/workflows/sync-main-to-earlgrey-hwe.yml
+++ b/.github/workflows/sync-main-to-earlgrey-hwe.yml
@@ -25,7 +25,7 @@ jobs:
           git fetch origin main:main
 
           # Merge main into the currently checked-out dev branch
-          git merge main --no-edit
+          git merge main --no-commit --no-ff || echo "Conflicts found; resolve in the PR."
 
       - name: Generate GitHub App Token
         id: generate-token
@@ -43,8 +43,10 @@ jobs:
           title: 'chore: sync main into earlgrey hwe'
           reviewers: cfrantz, moidx
           body: |
-            This is an automated PR to sync the latest commits from `main` into `earlgrey-hwe`.
-            Please review and resolve any merge conflicts if they arise.
+            This is an automated PR to sync `main` into `earlgrey-hwe`.
+            Please review and resolve any merge conflicts.
+          commit-message: 'chore: sync main into earlgrey hwe'
+          delete-branch: true
           labels: |
             automated-pr
             sync


### PR DESCRIPTION
Update the merge action to not commit or fast-forward.  This should give us the opportunity to resolve conflicts in the PR.