### PR TITLE
Smc Hardening

### DIFF
--- a/target/ast10x0/board/src/lib.rs
+++ b/target/ast10x0/board/src/lib.rs
@@ -13,6 +13,7 @@
 
 use ast10x0_peripherals::scu::{ClockRegisterHalf, ScuRegisterHalf};
 use ast10x0_peripherals::scu::{PinctrlPin, ScuRegisters};
+use ast10x0_peripherals::smc::{CalibrationScratch, SmcConfig, SmcError, UninitSmc, SPI_CALIB_LEN};
 
 /// Board descriptor metadata for AST10x0 board initialization.
 #[derive(Clone, Debug)]
@@ -20,6 +21,10 @@ pub struct Ast10x0BoardDescriptor {
     /// Pin control groups to apply during board init.
     /// Applied in order via `ScuRegisters::apply_pinctrl_group()`.
     pub pinctrl_groups: &'static [&'static [PinctrlPin]],
+    /// SMC controllers to calibrate during pre-kernel bring-up.
+    ///
+    /// Keep this empty when a board does not use SMC bring-up.
+    pub smc_configs: &'static [SmcConfig],
 }
 
 /// Runtime board object that executes hardware initialization steps.
@@ -70,6 +75,33 @@ impl Ast10x0Board {
 
         // Configure I2C global registers (clock dividers, etc.)
         unsafe { ast10x0_peripherals::i2c::init_i2c_global() };
+    }
+
+    /// Calibrate SMC controllers during pre-kernel bring-up.
+    ///
+    /// Controllers are initialized and calibrated sequentially using a shared
+    /// static scratch buffer, avoiding large stack allocations.
+    ///
+    /// # Safety
+    /// - Must be called only in single-threaded bring-up before concurrent SMC access.
+    /// - Each listed controller must be uniquely owned by this initialization flow.
+    pub unsafe fn calibrate_smc_controllers(&self) -> Result<(), SmcError> {
+        static mut SMC_CALIBRATION_SCRATCH: CalibrationScratch = [0u8; SPI_CALIB_LEN];
+
+        for config in self.descriptor.smc_configs {
+            // SAFETY: Board init is single-threaded and called once. This code
+            // borrows the static scratch buffer for one calibration at a time.
+            #[expect(static_mut_refs)]
+            let scratch = unsafe { &mut SMC_CALIBRATION_SCRATCH };
+
+            // SAFETY: Board init runs before concurrent users exist and owns
+            // early hardware bring-up for listed controllers.
+            let uninit = unsafe { UninitSmc::new(*config)? };
+            let ready = uninit.init()?;
+            let _calibrated = ready.calibrate(scratch)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/target/ast10x0/peripherals/i2c/controller.rs
+++ b/target/ast10x0/peripherals/i2c/controller.rs
@@ -79,7 +79,7 @@ impl<'a, Y: FnMut(u32)> Ast1060I2c<'a, Y> {
         yield_ns: Y,
     ) -> Result<Self, I2cError> {
         let mut i2c = unsafe { Self::from_initialized(regs, buff_regs, config, yield_ns) };
-        i2c.init_hardware(&config)?;
+        i2c.init_hardware(config)?;
         Ok(i2c)
     }
 
@@ -143,7 +143,7 @@ impl<'a, Y: FnMut(u32)> Ast1060I2c<'a, Y> {
     ) -> Result<Self, I2cError> {
         let mut i2c = unsafe { Self::from_initialized(regs, buff_regs, config, yield_ns) };
         i2c.dma_buf = Some(dma_buf);
-        i2c.init_hardware(&config)?;
+        i2c.init_hardware(config)?;
         Ok(i2c)
     }
 

--- a/target/ast10x0/peripherals/lib.rs
+++ b/target/ast10x0/peripherals/lib.rs
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
+#![deny(
+	clippy::unwrap_used,
+	clippy::expect_used,
+	clippy::panic,
+	clippy::unreachable,
+	clippy::todo,
+	clippy::unimplemented
+)]
 
 pub mod i2c;
 pub mod scu;

--- a/target/ast10x0/peripherals/smc/controller.rs
+++ b/target/ast10x0/peripherals/smc/controller.rs
@@ -9,9 +9,8 @@ use core::marker::PhantomData;
 use crate::smc::helpers::{
     encode_fmc_segment, encode_spi_segment, flash_capacity_bytes, get_mid_point_of_longest_one,
     spi_calibration_enable, spi_freq_div, total_capacity_bytes, validate_dma_read,
-    validate_mapped_range,
-    SPI_CTRL_FREQ_MASK, SPI_DMA_CALC_CKSUM, SPI_DMA_CALIB_MODE, SPI_DMA_ENABLE,
-    SPI_DMA_RAM_MAP_BASE,
+    validate_mapped_range, SPI_CTRL_FREQ_MASK, SPI_DMA_CALC_CKSUM, SPI_DMA_CALIB_MODE,
+    SPI_DMA_ENABLE, SPI_DMA_RAM_MAP_BASE,
 };
 use crate::smc::interrupts::{SmcInterrupt, SmcInterruptDecoder};
 use crate::smc::registers::SmcRegisters;

--- a/target/ast10x0/peripherals/smc/controller.rs
+++ b/target/ast10x0/peripherals/smc/controller.rs
@@ -7,8 +7,9 @@ use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 
 use crate::smc::helpers::{
-    encode_segment, flash_capacity_bytes, get_mid_point_of_longest_one, spi_calibration_enable,
-    spi_freq_div, total_capacity_bytes, validate_dma_read, validate_mapped_range,
+    encode_fmc_segment, encode_spi_segment, flash_capacity_bytes, get_mid_point_of_longest_one,
+    spi_calibration_enable, spi_freq_div, total_capacity_bytes, validate_dma_read,
+    validate_mapped_range,
     SPI_CTRL_FREQ_MASK, SPI_DMA_CALC_CKSUM, SPI_DMA_CALIB_MODE, SPI_DMA_ENABLE,
     SPI_DMA_RAM_MAP_BASE,
 };
@@ -179,6 +180,13 @@ impl Smc<Uninitialized> {
             _mode: PhantomData,
         })
     }
+    fn encode_segment(&self, start: usize, end: usize) -> Result<u32, SmcError> {
+        match self.config.controller_id {
+            SmcController::Fmc => encode_fmc_segment(start, end),
+            SmcController::Spi1 | SmcController::Spi2 => encode_spi_segment(start, end),
+        }
+    }
+
     fn setup_segments(&self) -> Result<(), SmcError> {
         // Decode-range sizing is topology-aware.
         //
@@ -198,12 +206,12 @@ impl Smc<Uninitialized> {
         total_capacity_bytes(self.config.cs0, self.config.cs1)?;
 
         if cs0_size > 0 {
-            let seg = encode_segment(0, cs0_size)?;
+            let seg = self.encode_segment(0, cs0_size)?;
             self.regs.write_cs0_segment(seg);
         }
 
         if cs1_size > 0 {
-            let seg = encode_segment(cs0_size, cs0_size + cs1_size)?;
+            let seg = self.encode_segment(cs0_size, cs0_size + cs1_size)?;
             self.regs.write_cs1_segment(seg);
         }
 
@@ -506,7 +514,7 @@ impl Smc<Ready> {
         let cs_idx = cs as usize;
         // Derive user-mode base from the stored normal-read value: preserve
         // frequency bits and replace mode type with ASPEED_SPI_USER.
-        let user_base = (self.normal_read_ctrl[cs_idx] & SPI_CTRL_FREQ_MASK) | ASPEED_SPI_USER;
+        let user_base = (self.normal_read_ctrl[cs_idx] & !0x7) | ASPEED_SPI_USER;
         let window = self.flash_window_base[cs_idx] as *mut u32;
 
         // Assert CS: inactive first, then active (matches aspeed-rust activate_user).

--- a/target/ast10x0/peripherals/smc/controller.rs
+++ b/target/ast10x0/peripherals/smc/controller.rs
@@ -3,7 +3,6 @@
 
 //! Generic SMC controller implementation
 
-use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 
 use crate::smc::helpers::{
@@ -38,16 +37,21 @@ const DMA_STATUS_RELEVANT_BITS: u32 = (1 << 11) | (1 << 10) | (1 << 9);
 /// Mask for bits that are not IO mode or mode-type fields — preserves
 /// frequency divisor and other config bits across per-phase ctrl writes.
 const SPI_CTRL_IO_MODE_MASK: u32 = !0x7000_0000;
-const SPI_CALIB_LEN: usize = 0x400;
 
-struct CalibrationScratch(UnsafeCell<[u8; SPI_CALIB_LEN]>);
+/// Length in bytes of the SPI read-timing calibration training buffer.
+///
+/// The calibration sweep reads this many bytes of real flash content as a
+/// reference sample (see [`CalibrationScratch`]).
+pub const SPI_CALIB_LEN: usize = 0x400;
 
-// Calibration runs during controller initialization with exclusive controller
-// ownership, so this scratch buffer is not accessed concurrently.
-unsafe impl Sync for CalibrationScratch {}
-
-static CALIBRATION_SCRATCH: CalibrationScratch =
-    CalibrationScratch(UnsafeCell::new([0; SPI_CALIB_LEN]));
+/// Caller-owned scratch buffer required by [`Smc::calibrate`].
+///
+/// Calibration is a one-time bring-up step. The buffer must live **off** the
+/// (often small) user-mode driver stack — e.g. on the board bring-up stack or
+/// in a caller-owned `static` — otherwise the 1 KiB frame can overflow a
+/// constrained thread stack. The driver path ([`Smc::open_calibrated`]) does
+/// not need this buffer.
+pub type CalibrationScratch = [u8; SPI_CALIB_LEN];
 
 const fn spi_nor_qread_cmd_for_capacity(capacity_bytes: usize) -> u32 {
     if capacity_bytes > SPI_NOR_4B_READ_THRESHOLD_BYTES {
@@ -77,12 +81,20 @@ const fn spi_nor_addr_width_reg(current: u32, cs: ChipSelect, use_4b: bool) -> u
 /// Type-state marker: controller is constructed but not initialized.
 pub struct Uninitialized;
 
-/// Type-state marker: controller has completed hardware initialization.
+/// Type-state marker: controller has completed hardware initialization
+/// (segments mapped) but read timing is not yet calibrated. No I/O is allowed.
 pub struct Ready;
+
+/// Type-state marker: controller is calibrated and operational.
+///
+/// Reached from [`Ready`] via [`Smc::calibrate`] (bring-up) or
+/// [`Smc::open_calibrated`] (driver). All I/O methods live in this state.
+pub struct Calibrated;
 
 /// Generic Static Memory Controller (SMC)
 ///
-/// The `Mode` type parameter enforces init ordering at compile time.
+/// The `Mode` type parameter enforces the
+/// `Uninitialized -> Ready -> Calibrated` lifecycle at compile time.
 pub struct Smc<Mode> {
     regs: SmcRegisters,
     controller_id: SmcController,
@@ -102,8 +114,11 @@ pub struct Smc<Mode> {
 /// Ergonomic alias for the uninitialized controller handle.
 pub type UninitSmc = Smc<Uninitialized>;
 
-/// Ergonomic alias for the initialized controller handle.
+/// Ergonomic alias for the initialized-but-uncalibrated controller handle.
 pub type ReadySmc = Smc<Ready>;
+
+/// Ergonomic alias for the calibrated, operational controller handle.
+pub type CalibratedSmc = Smc<Calibrated>;
 
 impl Smc<Uninitialized> {
     /// Create a new SMC controller instance.
@@ -218,7 +233,338 @@ impl Smc<Uninitialized> {
     }
 }
 
+// Mode-independent queries. These only read configuration (and, for
+// `is_calibrated`, a status register), so they are valid in any lifecycle state.
+impl<Mode> Smc<Mode> {
+    /// Get the controller identifier.
+    pub fn controller_id(&self) -> SmcController {
+        self.controller_id
+    }
+
+    /// Return configured total flash capacity for this controller in bytes.
+    pub fn capacity_bytes(&self) -> Result<usize, SmcError> {
+        total_capacity_bytes(self.config.cs0, self.config.cs1)
+    }
+
+    /// Return configured flash capacity in bytes for the given chip select.
+    ///
+    /// Returns `SmcError::InvalidChipSelect` if the slot was not populated
+    /// at construction time. Used by the device facade to bounds-check
+    /// per-CS reads and to compute per-CS controller-window offsets.
+    pub fn cs_capacity_bytes(&self, cs: ChipSelect) -> Result<usize, SmcError> {
+        crate::smc::helpers::cs_capacity_bytes(&self.config, cs)
+    }
+
+    /// Return the configured `FlashConfig` for the requested chip select.
+    ///
+    /// Returns `SmcError::InvalidChipSelect` if the slot was not populated at
+    /// construction time. Used by device-facade constructors to validate the
+    /// caller-supplied `FlashConfig` against the per-CS configuration the
+    /// controller was actually initialized with.
+    pub fn cs_config(&self, cs: ChipSelect) -> Result<FlashConfig, SmcError> {
+        let slot = match cs {
+            ChipSelect::Cs0 => self.config.cs0,
+            ChipSelect::Cs1 => self.config.cs1,
+        };
+        slot.ok_or(SmcError::InvalidChipSelect)
+    }
+
+    /// Report whether the controller's read timing has been calibrated in
+    /// hardware for `cs` (per-CS timing-compensation register is non-zero).
+    ///
+    /// This reflects silicon state, so it stays true across a `Ready` handle
+    /// constructed after an earlier [`Smc::calibrate`] (e.g. in board bring-up).
+    pub fn is_calibrated(&self, cs: ChipSelect) -> bool {
+        self.regs.already_calibrated(cs)
+    }
+}
+
 impl Smc<Ready> {
+    /// Calibrate read timing and configure read mode for all configured chip
+    /// selects, transitioning to the operational [`Calibrated`] state.
+    ///
+    /// This is the **bring-up** path (e.g. `board_init`): it runs the timing
+    /// sweep for CS0 using the caller-owned `scratch` buffer, which must live
+    /// off the small driver stack (see [`CalibrationScratch`]). If the hardware
+    /// is already calibrated, the sweep is skipped.
+    ///
+    /// # Errors
+    /// Propagates `SmcError` from capacity validation or the calibration DMA
+    /// path.
+    pub fn calibrate(
+        mut self,
+        scratch: &mut CalibrationScratch,
+    ) -> Result<Smc<Calibrated>, SmcError> {
+        if self.config.cs0.is_some() {
+            self.calibrate_cs(ChipSelect::Cs0, scratch)?;
+        }
+        if self.config.cs1.is_some() {
+            self.calibrate_cs(ChipSelect::Cs1, scratch)?;
+        }
+        Ok(self.into_calibrated())
+    }
+
+    /// Prepare for I/O on hardware that was calibrated earlier (e.g. in
+    /// `board_init`), transitioning to the operational [`Calibrated`] state.
+    ///
+    /// This is the **driver** path. It configures read mode and the clock
+    /// divisor but never runs the timing sweep, so it needs no scratch buffer
+    /// and is safe to call from a small, possibly-concurrent driver stack.
+    ///
+    /// # Errors
+    /// Returns `SmcError::NotCalibrated` if CS0 timing has not been calibrated
+    /// in hardware. Also propagates capacity-validation errors.
+    pub fn open_calibrated(mut self) -> Result<Smc<Calibrated>, SmcError> {
+        if self.config.cs0.is_some() {
+            self.open_cs(ChipSelect::Cs0)?;
+        }
+        if self.config.cs1.is_some() {
+            self.open_cs(ChipSelect::Cs1)?;
+        }
+        Ok(self.into_calibrated())
+    }
+
+    fn into_calibrated(self) -> Smc<Calibrated> {
+        Smc {
+            regs: self.regs,
+            controller_id: self.controller_id,
+            config: self.config,
+            state: self.state,
+            normal_read_ctrl: self.normal_read_ctrl,
+            flash_window_base: self.flash_window_base,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Program the memory-mapped SPI NOR read command and address width for
+    /// `cs`, and snapshot the resulting normal-read control value.
+    ///
+    /// Shared by both the calibrate and open paths; performs no timing setup.
+    fn prepare_cs(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
+        let mode: TransferMode = TransferMode::Mode114;
+        let dummy: u32 = 0x1;
+        let cs_idx = cs as usize;
+        let cs_capacity = self.cs_capacity_bytes(cs)?;
+        let use_4b_addr = spi_nor_uses_4b_addr(cs_capacity);
+        let read_opcode = spi_nor_qread_cmd_for_capacity(cs_capacity);
+        let read_cmd =
+            mode.data_io_bits() | (read_opcode << 16) | (dummy << 6) | ASPEED_SPI_NORMAL_READ;
+
+        self.regs.write_cs_ctrl(cs, read_cmd);
+        let addr_width = spi_nor_addr_width_reg(self.regs.read_addr_width(), cs, use_4b_addr);
+        self.regs.write_addr_width(addr_width);
+        self.normal_read_ctrl[cs_idx] = read_cmd;
+        Ok(())
+    }
+
+    /// Bring-up per-CS calibration: set read mode, then run the sweep (CS0) or
+    /// just configure the divisor (CS1).
+    fn calibrate_cs(
+        &mut self,
+        cs: ChipSelect,
+        scratch: &mut CalibrationScratch,
+    ) -> Result<(), SmcError> {
+        self.prepare_cs(cs)?;
+        if cs != ChipSelect::Cs0 {
+            // CS1 calibration can fault on boards where the secondary FMC flash
+            // is not ready for the calibration sweep. Keep CS1 on the same
+            // fixed timing path used after calibration and still program its
+            // normal-read command/address width above.
+            return self.configure_timing(cs, self.cs_config(cs)?.spi_clock_mhz);
+        }
+        self.timing_calibration(cs, scratch)
+    }
+
+    /// Driver per-CS open: set read mode and divisor; require that CS0 was
+    /// already calibrated in hardware (never runs the sweep).
+    fn open_cs(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
+        self.prepare_cs(cs)?;
+        let spi_clock_mhz = self.cs_config(cs)?.spi_clock_mhz;
+        // Only CS0 is timing-swept (see `calibrate_cs`), so it is the chip
+        // select whose calibration must already be present in hardware.
+        if cs == ChipSelect::Cs0 && !self.regs.already_calibrated(cs) {
+            return Err(SmcError::NotCalibrated);
+        }
+        self.configure_timing(cs, spi_clock_mhz)
+    }
+
+    fn configure_timing(&mut self, cs: ChipSelect, spi_clock_mhz: u32) -> Result<(), SmcError> {
+        // Timing calibration is topology-aware.
+        //
+        // For BootSpi (FMC, master_idx=0): Full calibration sweep recommended.
+        //   Boot firmware has exclusive access; full timing margin is priority.
+        //
+        // For HostSpi / NormalSpi when master_idx != 0: Shared-bus topology.
+        //   When a secondary master shares the flash bus, calibration on CS1 may need
+        //   to be skipped to avoid interfering with the primary master's calibration.
+        //   Phase 3+: gate calibration logic on config.topology.master_idx().
+        //
+        // For now, all topologies use a single divider lookup; no HCLK sweep.
+        // Phase 3+: add conditional calibration logic per topology and master_idx.
+        // pw_log::info!("=== configure_timing()===");
+        //TODO: need to get this from scu register
+        let sysclk_mhz = 200u32;
+        let encoded_div = spi_freq_div(sysclk_mhz, spi_clock_mhz)?;
+
+        let cs_idx = cs as usize;
+        let reg = self.regs.read_cs_ctrl(cs);
+        self.regs
+            .write_cs_ctrl(cs, (reg & !SPI_CTRL_FREQ_MASK) | encoded_div);
+        self.normal_read_ctrl[cs_idx] =
+            (self.normal_read_ctrl[cs_idx] & !SPI_CTRL_FREQ_MASK) | encoded_div;
+
+        Ok(())
+    }
+
+    fn timing_calibration(
+        &mut self,
+        cs: ChipSelect,
+        scratch: &mut CalibrationScratch,
+    ) -> Result<(), SmcError> {
+        let cs_cfg = self.cs_config(cs)?;
+        let cs_idx = cs as usize;
+
+        if self.regs.already_calibrated(cs) {
+            pw_log::info!("already calibrated");
+            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
+        }
+
+        //SPI2 work around
+        if self.config.topology.master_idx() != 0 && cs_idx != 0 {
+            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
+        }
+        // TODO: add SPIM config
+        /*
+         * use the related low frequency to get check calibration data
+         * and get golden data.
+         */
+        let ctrl_val = self.regs.read_cs_ctrl(cs) & (!SPI_CTRL_FREQ_MASK);
+        self.regs.write_cs_ctrl(cs, ctrl_val);
+
+        let window = self.flash_window_base[cs_idx] as *const u8;
+        // TODO: configure timing_calibration_start_offset beside be???
+        let timing_offset = 0x0;
+        let flash_ptr = window.wrapping_add(timing_offset);
+        // SAFETY: `flash_ptr` points into this controller's fixed MMIO flash
+        // aperture (mapped by `setup_segments`); `[0, SPI_CALIB_LEN)` is within
+        // every supported flash. `scratch` is a caller-owned, writable buffer of
+        // exactly `SPI_CALIB_LEN` bytes that does not overlap the MMIO window.
+        unsafe {
+            core::ptr::copy_nonoverlapping(flash_ptr, scratch.as_mut_ptr(), SPI_CALIB_LEN);
+        }
+
+        if !spi_calibration_enable(&scratch[..])? {
+            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
+        }
+
+        let gold_checksum = self.spi_dma_checksum(cs, 0, 0);
+        self.run_timing_sweep(cs, gold_checksum);
+
+        self.configure_timing(cs, cs_cfg.spi_clock_mhz)
+    }
+
+    fn spi_dma_checksum(&mut self, cs: ChipSelect, div: u32, delay: u32) -> u32 {
+        let timing_offset = 0x0;
+
+        // Request DMA access
+        self.regs.acquire_dma_arbiter();
+
+        // Set DMA flash start address
+        let cs_idx = cs as usize;
+        let flash_addr = self.flash_window_base[cs_idx] + timing_offset;
+        self.regs.write_dma_flash_addr(flash_addr as u32);
+        // Set DMA length
+        self.regs.write_dma_len(SPI_CALIB_LEN as u32);
+
+        // Configure DMA control register
+        let ctrl_val = SPI_DMA_ENABLE
+            | SPI_DMA_CALC_CKSUM
+            | SPI_DMA_CALIB_MODE
+            | (delay << 0x8)
+            | ((div & 0xf) << 16);
+        self.regs.write_dma_ctrl(ctrl_val);
+
+        // Wait until DMA done
+        if self.poll_blocking_dma_completion(0x1000) == 0 {
+            pw_log::info!("dma timeout!");
+        }
+
+        // Read checksum result
+        // disable dma will clear the checksum
+        let checksum = self.regs.read_dma_checksum();
+        // Clear DMA control and discard request
+        self.regs.disable_dma();
+
+        checksum
+    }
+
+    fn poll_blocking_dma_completion(&self, timeout: u32) -> u32 {
+        let mut to = timeout;
+
+        while (self.regs.read_dma_status() & DMA_STATUS_RELEVANT_BITS) == 0 {
+            to -= 1;
+
+            if to == 0 {
+                return 0;
+            }
+        }
+        to
+    }
+
+    fn run_timing_sweep(&mut self, cs: ChipSelect, gold_checksum: u32) {
+        let hclk_masks = [7u32, 14, 6, 13];
+        let mut calib_res = [0u8; 6 * 17];
+        let cs_cfg = self.cs_config(cs);
+        let mut freq_to_use = cs_cfg.unwrap().spi_clock_mhz;
+        let sysclk_mhz = 200u32;
+
+        for (i, &mask) in hclk_masks.iter().enumerate() {
+            let div = u32::try_from(i).unwrap() + 2;
+            if freq_to_use < sysclk_mhz / div {
+                continue;
+            }
+
+            freq_to_use = sysclk_mhz / div;
+
+            self.spi_dma_checksum(cs, mask, 0);
+
+            calib_res.fill(0);
+
+            for hcycle in 0..=5 {
+                for delay_ns in 0..=0xf {
+                    let reg_val = (1 << 3) | hcycle | (delay_ns << 4);
+
+                    let checksum = self.spi_dma_checksum(cs, mask, reg_val);
+
+                    let pass = checksum == gold_checksum;
+                    let index = (hcycle * 17 + delay_ns) as usize;
+                    calib_res[index] = u8::from(pass);
+                }
+            } //hcycle
+
+            let calib_point = get_mid_point_of_longest_one(&calib_res);
+            if calib_point >= 0 {
+                let hcycle = (calib_point as u32 / 17) as u32;
+                let delay_ns = (calib_point as u32 % 17) as u32;
+                let final_delay = ((1 << 3) | hcycle | (delay_ns << 4)) << (i * 8);
+
+                pw_log::info!(
+                    "Final hcycle: {}, delay_ns: {} final_delay0x{:08x}",
+                    hcycle as u32,
+                    delay_ns as u32,
+                    final_delay as u32
+                );
+
+                self.regs.write_cs_timing_compensation(cs, final_delay);
+                return;
+            } else {
+                pw_log::info!("Cannot get good calibration point.");
+            }
+        }
+    } // run_timing_sweep
+}
+
+impl Smc<Calibrated> {
     /// Perform a programmed I/O read via memory window.
     ///
     /// Reads directly from the flash memory window. Hardware automatically
@@ -248,12 +594,7 @@ impl Smc<Ready> {
 
         Ok(buf.len())
     }
-    #[inline(never)]
-    pub fn loop_delay(spin_cnt: u32) {
-        for _ in 0..spin_cnt {
-            core::hint::spin_loop();
-        }
-    }
+
     /// Initiate a DMA read operation (non-blocking).
     pub fn dma_read(
         &mut self,
@@ -272,7 +613,7 @@ impl Smc<Ready> {
             return Err(SmcError::InvalidChipSelect);
         }
         self.regs.disable_dma();
-        Self::loop_delay(0x1000);
+        loop_delay(0x1000);
 
         let cs_config = self.cs_config(cs)?;
         let cs_capacity = flash_capacity_bytes(Some(cs_config))?;
@@ -434,19 +775,7 @@ impl Smc<Ready> {
         core::task::Poll::Ready(self.complete_dma(status).map(|_| ()))
     }
 
-    pub fn poll_blocking_dma_completion(&self, timeout: u32) -> u32 {
-        let mut to = timeout;
-
-        while (self.regs.read_dma_status() & DMA_STATUS_RELEVANT_BITS) == 0 {
-            to -= 1;
-
-            if to == 0 {
-                return 0;
-            }
-        }
-        return to;
-    }
-    /// Check if controller is ready for operations.
+    /// Check if controller is idle and ready for a new operation.
     pub fn is_ready(&self) -> bool {
         self.state == SmcState::Idle
     }
@@ -456,40 +785,7 @@ impl Smc<Ready> {
         self.state = SmcState::DmaInFlight;
     }
 
-    /// Get the controller identifier.
-    pub fn controller_id(&self) -> SmcController {
-        self.controller_id
-    }
-
-    /// Return configured total flash capacity for this controller in bytes.
-    pub fn capacity_bytes(&self) -> Result<usize, SmcError> {
-        total_capacity_bytes(self.config.cs0, self.config.cs1)
-    }
-
-    /// Return configured flash capacity in bytes for the given chip select.
-    ///
-    /// Returns `SmcError::InvalidChipSelect` if the slot was not populated
-    /// at construction time. Used by the device facade to bounds-check
-    /// per-CS reads and to compute per-CS controller-window offsets.
-    pub fn cs_capacity_bytes(&self, cs: ChipSelect) -> Result<usize, SmcError> {
-        crate::smc::helpers::cs_capacity_bytes(&self.config, cs)
-    }
-
-    /// Return the configured `FlashConfig` for the requested chip select.
-    ///
-    /// Returns `SmcError::InvalidChipSelect` if the slot was not populated at
-    /// construction time. Used by device-facade constructors to validate the
-    /// caller-supplied `FlashConfig` against the per-CS configuration the
-    /// controller was actually initialized with.
-    pub fn cs_config(&self, cs: ChipSelect) -> Result<FlashConfig, SmcError> {
-        let slot = match cs {
-            ChipSelect::Cs0 => self.config.cs0,
-            ChipSelect::Cs1 => self.config.cs1,
-        };
-        slot.ok_or(SmcError::InvalidChipSelect)
-    }
-
-    /// Execute a raw user-mode SPI transfer on CS0 for this controller.
+    /// Execute a raw user-mode SPI transfer on the selected chip select.
     ///
     /// The `mode` parameter controls the IO width written to the CS control
     /// register for each phase (cmd / addr+payload / rx), matching the
@@ -547,192 +843,22 @@ impl Smc<Ready> {
         self.regs.write_cs_ctrl(cs, self.normal_read_ctrl[cs_idx]);
         Ok(())
     }
-
-    //
-    // MMIO access:: nor read init
-    //
-    //TODO: call from nordevice layer instead
-    pub fn spi_nor_read_init(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
-        let mode: TransferMode = TransferMode::Mode114;
-        let dummy: u32 = 0x1;
-        let cs_idx = cs as usize;
-        let cs_capacity = self.cs_capacity_bytes(cs)?;
-        let use_4b_addr = spi_nor_uses_4b_addr(cs_capacity);
-        let read_opcode = spi_nor_qread_cmd_for_capacity(cs_capacity);
-        //pw_log::info!("=== spi_read_init()===");
-        let read_cmd =
-            mode.data_io_bits() | (read_opcode << 16) | (dummy << 6) | ASPEED_SPI_NORMAL_READ;
-
-        self.regs.write_cs_ctrl(cs, read_cmd);
-        let addr_width = spi_nor_addr_width_reg(self.regs.read_addr_width(), cs, use_4b_addr);
-        self.regs.write_addr_width(addr_width);
-        self.normal_read_ctrl[cs_idx] = read_cmd;
-        if cs != ChipSelect::Cs0 {
-            // CS1 calibration can fault on boards where the secondary FMC flash
-            // is not ready for the calibration sweep. Keep CS1 on the same
-            // fixed timing path used after calibration and still program its
-            // normal-read command/address width above.
-            return self.configure_timing(cs, self.cs_config(cs)?.spi_clock_mhz);
-        }
-        self.timing_calibration(cs)
-    }
-
-    fn configure_timing(&mut self, cs: ChipSelect, spi_clock_mhz: u32) -> Result<(), SmcError> {
-        // Timing calibration is topology-aware.
-        //
-        // For BootSpi (FMC, master_idx=0): Full calibration sweep recommended.
-        //   Boot firmware has exclusive access; full timing margin is priority.
-        //
-        // For HostSpi / NormalSpi when master_idx != 0: Shared-bus topology.
-        //   When a secondary master shares the flash bus, calibration on CS1 may need
-        //   to be skipped to avoid interfering with the primary master's calibration.
-        //   Phase 3+: gate calibration logic on config.topology.master_idx().
-        //
-        // For now, all topologies use a single divider lookup; no HCLK sweep.
-        // Phase 3+: add conditional calibration logic per topology and master_idx.
-        // pw_log::info!("=== configure_timing()===");
-        //TODO: need to get this from scu register
-        let sysclk_mhz = 200u32;
-        let encoded_div = spi_freq_div(sysclk_mhz, spi_clock_mhz)?;
-
-        let cs_idx = cs as usize;
-        let reg = self.regs.read_cs_ctrl(cs);
-        self.regs
-            .write_cs_ctrl(cs, (reg & !SPI_CTRL_FREQ_MASK) | encoded_div);
-        self.normal_read_ctrl[cs_idx] =
-            (self.normal_read_ctrl[cs_idx] & !SPI_CTRL_FREQ_MASK) | encoded_div;
-
-        Ok(())
-    }
-
-    fn timing_calibration(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
-        let cs_cfg = self.cs_config(cs)?;
-        let cs_idx = cs as usize;
-
-        if self.regs.already_calibrated(cs) {
-            pw_log::info!("already calibrated");
-            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
-        }
-
-        //SPI2 work around
-        if self.config.topology.master_idx() != 0 && cs_idx != 0 {
-            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
-        }
-        // TODO: add SPIM config
-        /*
-         * use the related low frequency to get check calibration data
-         * and get golden data.
-         */
-        let ctrl_val = self.regs.read_cs_ctrl(cs) & (!SPI_CTRL_FREQ_MASK);
-        self.regs.write_cs_ctrl(cs, ctrl_val);
-
-        let check_buf = unsafe { &mut *CALIBRATION_SCRATCH.0.get() };
-        let window = self.flash_window_base[cs_idx] as *const u8;
-        // TODO: configure timing_calibration_start_offset beside be???
-        let timing_offset = 0x0;
-        let flash_ptr = window.wrapping_add(timing_offset);
-        unsafe {
-            core::ptr::copy_nonoverlapping(flash_ptr, check_buf.as_mut_ptr(), SPI_CALIB_LEN);
-        }
-
-        if !spi_calibration_enable(&check_buf[..])? {
-            return self.configure_timing(cs, cs_cfg.spi_clock_mhz);
-        }
-
-        let gold_checksum = self.spi_dma_checksum(cs, 0, 0);
-        self.run_timing_sweep(cs, gold_checksum);
-
-        self.configure_timing(cs, cs_cfg.spi_clock_mhz)
-    }
-
-    fn spi_dma_checksum(&mut self, cs: ChipSelect, div: u32, delay: u32) -> u32 {
-        let timing_offset = 0x0;
-
-        // Request DMA access
-        self.regs.acquire_dma_arbiter();
-
-        // Set DMA flash start address
-        let cs_idx = cs as usize;
-        let flash_addr = self.flash_window_base[cs_idx] + timing_offset;
-        self.regs.write_dma_flash_addr(flash_addr as u32);
-        // Set DMA length
-        self.regs.write_dma_len(SPI_CALIB_LEN as u32);
-
-        // Configure DMA control register
-        let ctrl_val = SPI_DMA_ENABLE
-            | SPI_DMA_CALC_CKSUM
-            | SPI_DMA_CALIB_MODE
-            | (delay << 0x8)
-            | ((div & 0xf) << 16);
-        self.regs.write_dma_ctrl(ctrl_val);
-
-        // Wait until DMA done
-        if self.poll_blocking_dma_completion(0x1000) == 0 {
-            pw_log::info!("dma timeout!");
-        }
-
-        // Read checksum result
-        // disable dma will clear the checksum
-        let checksum = self.regs.read_dma_checksum();
-        // Clear DMA control and discard request
-        self.regs.disable_dma();
-
-        return checksum;
-    }
-
-    fn run_timing_sweep(&mut self, cs: ChipSelect, gold_checksum: u32) {
-        let hclk_masks = [7u32, 14, 6, 13];
-        let mut calib_res = [0u8; 6 * 17];
-        let cs_cfg = self.cs_config(cs);
-        let mut freq_to_use = cs_cfg.unwrap().spi_clock_mhz;
-        let sysclk_mhz = 200u32;
-
-        for (i, &mask) in hclk_masks.iter().enumerate() {
-            let div = u32::try_from(i).unwrap() + 2;
-            if freq_to_use < sysclk_mhz / div {
-                continue;
-            }
-
-            freq_to_use = sysclk_mhz / div;
-
-            self.spi_dma_checksum(cs, mask, 0);
-
-            calib_res.fill(0);
-
-            for hcycle in 0..=5 {
-                for delay_ns in 0..=0xf {
-                    let reg_val = (1 << 3) | hcycle | (delay_ns << 4);
-
-                    let checksum = self.spi_dma_checksum(cs, mask, reg_val);
-
-                    let pass = checksum == gold_checksum;
-                    let index = (hcycle * 17 + delay_ns) as usize;
-                    calib_res[index] = u8::from(pass);
-                }
-            } //hcycle
-
-            let calib_point = get_mid_point_of_longest_one(&calib_res);
-            if calib_point >= 0 {
-                let hcycle = (calib_point as u32 / 17) as u32;
-                let delay_ns = (calib_point as u32 % 17) as u32;
-                let final_delay = ((1 << 3) | hcycle | (delay_ns << 4)) << (i * 8);
-
-                pw_log::info!(
-                    "Final hcycle: {}, delay_ns: {} final_delay0x{:08x}",
-                    hcycle as u32,
-                    delay_ns as u32,
-                    final_delay as u32
-                );
-
-                self.regs.write_cs_timing_compensation(cs, final_delay);
-                return;
-            } else {
-                pw_log::info!("Cannot get good calibration point.");
-            }
-        }
-    } // run_timing_sweep
 }
 
+/// Busy-wait for roughly `spin_cnt` iterations.
+#[inline(never)]
+fn loop_delay(spin_cnt: u32) {
+    for _ in 0..spin_cnt {
+        core::hint::spin_loop();
+    }
+}
+
+/// Read a byte stream from the SPI user-mode data port at `ahb_addr`.
+///
+/// # Safety
+/// `ahb_addr` must point at this controller's flash aperture while user mode is
+/// asserted; each access is a side-effecting SPI read and must use volatile
+/// semantics. `read_arr` must be a valid writable slice.
 unsafe fn spi_read_data(ahb_addr: *const u32, read_arr: &mut [u8]) {
     let len = read_arr.len();
     let mut index = 0usize;
@@ -749,6 +875,12 @@ unsafe fn spi_read_data(ahb_addr: *const u32, read_arr: &mut [u8]) {
     }
 }
 
+/// Write a byte stream to the SPI user-mode data port at `ahb_addr`.
+///
+/// # Safety
+/// `ahb_addr` must point at this controller's flash aperture while user mode is
+/// asserted; each access is a side-effecting SPI write and must use volatile
+/// semantics. `write_arr` must be a valid readable slice.
 unsafe fn spi_write_data(ahb_addr: *mut u32, write_arr: &[u8]) {
     let len = write_arr.len();
     let mut index = 0usize;

--- a/target/ast10x0/peripherals/smc/controller.rs
+++ b/target/ast10x0/peripherals/smc/controller.rs
@@ -163,7 +163,7 @@ impl Smc<Uninitialized> {
         let mut conf = 0u32;
         if self.config.cs0.is_some() {
             conf |= 1 << 16; // CONF_ENABLE_W0
-            conf |= 0x2 << 0; // FLASH_TYPE_SPI
+            conf |= 0x2; // FLASH_TYPE_SPI
         }
         if self.config.cs1.is_some() {
             conf |= 1 << 17; // CONF_ENABLE_W1
@@ -514,12 +514,15 @@ impl Smc<Ready> {
     fn run_timing_sweep(&mut self, cs: ChipSelect, gold_checksum: u32) {
         let hclk_masks = [7u32, 14, 6, 13];
         let mut calib_res = [0u8; 6 * 17];
-        let cs_cfg = self.cs_config(cs);
-        let mut freq_to_use = cs_cfg.unwrap().spi_clock_mhz;
+        let cs_cfg = match self.cs_config(cs) {
+            Ok(cfg) => cfg,
+            Err(_) => return,
+        };
+        let mut freq_to_use = cs_cfg.spi_clock_mhz;
         let sysclk_mhz = 200u32;
 
         for (i, &mask) in hclk_masks.iter().enumerate() {
-            let div = u32::try_from(i).unwrap() + 2;
+            let div = (i as u32) + 2;
             if freq_to_use < sysclk_mhz / div {
                 continue;
             }

--- a/target/ast10x0/peripherals/smc/controller.rs
+++ b/target/ast10x0/peripherals/smc/controller.rs
@@ -599,7 +599,8 @@ impl Smc<Ready> {
         let reg = self.regs.read_cs_ctrl(cs);
         self.regs
             .write_cs_ctrl(cs, (reg & !SPI_CTRL_FREQ_MASK) | encoded_div);
-        self.normal_read_ctrl[cs_idx] &= (!SPI_CTRL_FREQ_MASK) | encoded_div;
+        self.normal_read_ctrl[cs_idx] =
+            (self.normal_read_ctrl[cs_idx] & !SPI_CTRL_FREQ_MASK) | encoded_div;
 
         Ok(())
     }

--- a/target/ast10x0/peripherals/smc/device/flash.rs
+++ b/target/ast10x0/peripherals/smc/device/flash.rs
@@ -508,6 +508,8 @@ impl SpiNorFlashDevice for SpiNorFlash<'_> {
         self.validate_range(offset, buf.len())?;
         let translated = self.device_to_controller_offset(offset)?;
         let cs = self.cs;
+        //TODO: need to add dma_read variant if buf.len() is above some threshold
+        // and dma is enabled
         match &self.backend {
             FlashBackend::Fmc(fmc) => fmc.read(cs, translated, buf),
             FlashBackend::Spi(spi) => spi.read(cs, translated, buf),

--- a/target/ast10x0/peripherals/smc/device/flash.rs
+++ b/target/ast10x0/peripherals/smc/device/flash.rs
@@ -82,6 +82,10 @@ pub mod commands {
     pub const READ_ID: u8 = 0x9F;
 }
 
+const STATUS_WIP: u8 = 0x01;
+const WRITE_COMPLETE_MAX_POLLS: u32 = 1_000_000;
+const STATUS_POLL_SPIN_DELAY: u32 = 64;
+
 /// Addressing policy for SPI NOR command transactions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FlashAddressingPolicy {
@@ -164,6 +168,12 @@ where
         cursor += n;
     }
     Ok(true)
+}
+
+fn poll_delay() {
+    for _ in 0..STATUS_POLL_SPIN_DELAY {
+        core::hint::spin_loop();
+    }
 }
 
 enum FlashBackend<'a> {
@@ -472,13 +482,19 @@ impl<'a> SpiNorFlash<'a> {
         Ok(id)
     }
 
+    fn write_enable(&mut self) -> Result<(), SmcError> {
+        let profile = self.command_profile();
+        self.issue_command(&[profile.write_enable], &[])
+    }
+
     fn wait_write_complete(&self, max_polls: u32) -> Result<(), SmcError> {
         let mut polls = 0u32;
         while polls < max_polls {
             let sr = self.read_status_impl()?;
-            if (sr & 0x01) == 0 {
+            if (sr & STATUS_WIP) == 0 {
                 return Ok(());
             }
+            poll_delay();
             polls += 1;
         }
         Err(SmcError::Timeout)
@@ -510,10 +526,10 @@ impl SpiNorFlashDevice for SpiNorFlash<'_> {
 
         let profile = self.command_profile();
         let width = self.addr_width();
-        self.issue_command(&[profile.write_enable], &[])?;
+        self.write_enable()?;
         let (cmd, len) = encode_addr_cmd(profile.erase_sector_4k, offset, width);
         self.issue_command(&cmd[..len], &[])?;
-        self.wait_write_complete(10_000)
+        self.wait_write_complete(WRITE_COMPLETE_MAX_POLLS)
     }
 
     fn program_page(&mut self, offset: u32, data: &[u8]) -> Result<usize, SmcError> {
@@ -521,10 +537,10 @@ impl SpiNorFlashDevice for SpiNorFlash<'_> {
 
         let profile = self.command_profile();
         let width = self.addr_width();
-        self.issue_command(&[profile.write_enable], &[])?;
+        self.write_enable()?;
         let (cmd, len) = encode_addr_cmd(profile.page_program, offset, width);
         self.issue_command(&cmd[..len], data)?;
-        self.wait_write_complete(10_000)?;
+        self.wait_write_complete(WRITE_COMPLETE_MAX_POLLS)?;
         Ok(data.len())
     }
 

--- a/target/ast10x0/peripherals/smc/device/flash.rs
+++ b/target/ast10x0/peripherals/smc/device/flash.rs
@@ -7,8 +7,8 @@ use core::ops::FnMut;
 use core::result::Result;
 use core::result::Result::{Err, Ok};
 
-use crate::smc::fmc::FmcReady;
-use crate::smc::spi::SpiReady;
+use crate::smc::fmc::FmcCalibrated;
+use crate::smc::spi::SpiCalibrated;
 use crate::smc::types::{AddressWidth, ChipSelect, FlashConfig, SmcError, TransferMode};
 
 /// Build a command byte array: opcode followed by address bytes selected by
@@ -177,8 +177,8 @@ fn poll_delay() {
 }
 
 enum FlashBackend<'a> {
-    Fmc(&'a FmcReady),
-    Spi(&'a SpiReady),
+    Fmc(&'a FmcCalibrated),
+    Spi(&'a SpiCalibrated),
 }
 
 /// Decoded JEDEC identifier returned by `READ_ID` (`0x9F`).
@@ -229,14 +229,14 @@ pub struct SpiNorFlash<'a> {
 }
 
 impl<'a> SpiNorFlash<'a> {
-    /// Build a flash facade from an initialized FMC controller wrapper.
-    pub fn from_fmc(fmc: &'a mut FmcReady, cfg: FlashConfig) -> Result<Self, SmcError> {
+    /// Build a flash facade from a calibrated FMC controller wrapper.
+    pub fn from_fmc(fmc: &'a mut FmcCalibrated, cfg: FlashConfig) -> Result<Self, SmcError> {
         Self::from_fmc_cs(fmc, cfg, ChipSelect::Cs0)
     }
 
-    /// Build a flash facade from an initialized FMC controller wrapper with explicit CS.
+    /// Build a flash facade from a calibrated FMC controller wrapper with explicit CS.
     pub fn from_fmc_cs(
-        fmc: &'a mut FmcReady,
+        fmc: &'a mut FmcCalibrated,
         cfg: FlashConfig,
         cs: ChipSelect,
     ) -> Result<Self, SmcError> {
@@ -252,14 +252,14 @@ impl<'a> SpiNorFlash<'a> {
         })
     }
 
-    /// Build a flash facade from an initialized SPI1/SPI2 controller wrapper.
-    pub fn from_spi(spi: &'a mut SpiReady, cfg: FlashConfig) -> Result<Self, SmcError> {
+    /// Build a flash facade from a calibrated SPI1/SPI2 controller wrapper.
+    pub fn from_spi(spi: &'a mut SpiCalibrated, cfg: FlashConfig) -> Result<Self, SmcError> {
         Self::from_spi_cs(spi, cfg, ChipSelect::Cs0)
     }
 
-    /// Build a flash facade from an initialized SPI1/SPI2 controller wrapper with explicit CS.
+    /// Build a flash facade from a calibrated SPI1/SPI2 controller wrapper with explicit CS.
     pub fn from_spi_cs(
-        spi: &'a mut SpiReady,
+        spi: &'a mut SpiCalibrated,
         cfg: FlashConfig,
         cs: ChipSelect,
     ) -> Result<Self, SmcError> {
@@ -408,7 +408,7 @@ impl<'a> SpiNorFlash<'a> {
 
     /// Validate a device-local offset before handing it to the controller.
     ///
-    /// `FmcReady::read` / `SpiReady::read` already select the per-CS AHB
+    /// `FmcCalibrated::read` / `SpiCalibrated::read` already select the per-CS AHB
     /// window from the chip-select argument, so offsets stay CS-local here.
     fn device_to_controller_offset(&self, device_offset: u32) -> Result<u32, SmcError> {
         let cs_cap = self.capacity_bytes()?;

--- a/target/ast10x0/peripherals/smc/fmc.rs
+++ b/target/ast10x0/peripherals/smc/fmc.rs
@@ -15,8 +15,14 @@
 //! - **SPI1/SPI2**: Multi-instance application controllers with optional SPIPF monitoring
 //!
 //! See [`crate::smc`] module-level documentation for the full taxonomy.
+//!
+//! # Lifecycle
+//!
+//! [`FmcUninit`] → `init()` → [`FmcReady`] → `calibrate()` / `open_calibrated()`
+//! → [`FmcCalibrated`]. I/O is only available on the calibrated handle. Run
+//! `calibrate()` once during bring-up; the driver path uses `open_calibrated()`.
 
-use crate::smc::controller::{ReadySmc, UninitSmc};
+use crate::smc::controller::{CalibratedSmc, CalibrationScratch, ReadySmc, UninitSmc};
 use crate::smc::interrupts::SmcInterrupt;
 use crate::smc::types::{
     ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, TransferMode,
@@ -27,9 +33,14 @@ pub struct FmcUninit {
     inner: UninitSmc,
 }
 
-/// FMC handle after hardware initialization.
+/// FMC handle after hardware initialization, before calibration.
 pub struct FmcReady {
     inner: ReadySmc,
+}
+
+/// FMC handle after calibration: the operational, I/O-capable state.
+pub struct FmcCalibrated {
+    inner: CalibratedSmc,
 }
 
 impl FmcUninit {
@@ -44,7 +55,7 @@ impl FmcUninit {
         Ok(Self { inner })
     }
 
-    /// Initialize FMC hardware and transition to ready state.
+    /// Initialize FMC hardware and transition to the ready (uncalibrated) state.
     pub fn init(self) -> Result<FmcReady, SmcError> {
         Ok(FmcReady {
             inner: self.inner.init()?,
@@ -53,6 +64,53 @@ impl FmcUninit {
 }
 
 impl FmcReady {
+    /// Bring-up path: calibrate read timing and transition to operational state.
+    ///
+    /// `scratch` must live off the small driver stack (see
+    /// [`CalibrationScratch`]). See [`crate::smc::Smc::calibrate`].
+    pub fn calibrate(self, scratch: &mut CalibrationScratch) -> Result<FmcCalibrated, SmcError> {
+        Ok(FmcCalibrated {
+            inner: self.inner.calibrate(scratch)?,
+        })
+    }
+
+    /// Driver path: open a controller calibrated earlier (e.g. in `board_init`).
+    ///
+    /// Returns `SmcError::NotCalibrated` if calibration has not been performed.
+    /// See [`crate::smc::Smc::open_calibrated`].
+    pub fn open_calibrated(self) -> Result<FmcCalibrated, SmcError> {
+        Ok(FmcCalibrated {
+            inner: self.inner.open_calibrated()?,
+        })
+    }
+
+    /// Report whether read timing is calibrated in hardware for `cs`.
+    pub fn is_calibrated(&self, cs: ChipSelect) -> bool {
+        self.inner.is_calibrated(cs)
+    }
+
+    /// Get the controller identifier.
+    pub fn controller_id(&self) -> SmcController {
+        self.inner.controller_id()
+    }
+
+    /// Return configured flash capacity in bytes.
+    pub fn capacity_bytes(&self) -> Result<usize, SmcError> {
+        self.inner.capacity_bytes()
+    }
+
+    /// Return configured flash capacity in bytes for the given chip select.
+    pub fn cs_capacity_bytes(&self, cs: ChipSelect) -> Result<usize, SmcError> {
+        self.inner.cs_capacity_bytes(cs)
+    }
+
+    /// Return the configured `FlashConfig` for the requested chip select.
+    pub fn cs_config(&self, cs: ChipSelect) -> Result<FlashConfig, SmcError> {
+        self.inner.cs_config(cs)
+    }
+}
+
+impl FmcCalibrated {
     /// Perform a programmed I/O read via the FMC flash window.
     pub fn read(&self, cs: ChipSelect, offset: u32, buf: &mut [u8]) -> Result<usize, SmcError> {
         self.inner.read(cs, offset, buf)
@@ -89,19 +147,19 @@ impl FmcReady {
         self.inner.poll_dma_completion()
     }
 
-    /// Check if FMC is ready for operations.
+    /// Check if FMC is idle and ready for a new operation.
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
-    }
-
-    /// Program memory-mapped SPI NOR read mode for the selected chip select.
-    pub fn spi_nor_read_init(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
-        self.inner.spi_nor_read_init(cs)
     }
 
     #[doc(hidden)]
     pub fn test_force_dma_in_flight(&mut self) {
         self.inner.test_force_dma_in_flight();
+    }
+
+    /// Get the controller identifier.
+    pub fn controller_id(&self) -> SmcController {
+        self.inner.controller_id()
     }
 
     /// Return configured flash capacity in bytes.
@@ -146,13 +204,13 @@ impl FmcReady {
             .transceive_user(ChipSelect::Cs0, cmd, tx_payload, rx, mode)
     }
 
-    /// Access the underlying generic ready controller.
-    pub fn as_inner(&self) -> &ReadySmc {
+    /// Access the underlying generic calibrated controller.
+    pub fn as_inner(&self) -> &CalibratedSmc {
         &self.inner
     }
 
-    /// Mutable access to the underlying generic ready controller.
-    pub fn as_inner_mut(&mut self) -> &mut ReadySmc {
+    /// Mutable access to the underlying generic calibrated controller.
+    pub fn as_inner_mut(&mut self) -> &mut CalibratedSmc {
         &mut self.inner
     }
 }

--- a/target/ast10x0/peripherals/smc/helpers.rs
+++ b/target/ast10x0/peripherals/smc/helpers.rs
@@ -174,8 +174,7 @@ pub(crate) fn encode_fmc_segment(start: usize, end: usize) -> Result<u32, SmcErr
 
     let start = start as u32;
     let inclusive_end = (end - 1) as u32;
-    Ok(((((start >> 19) << 19) >> 16) & 0x0ff8)
-        | (((inclusive_end >> 19) << 19) & 0x0ff8_0000))
+    Ok(((((start >> 19) << 19) >> 16) & 0x0ff8) | (((inclusive_end >> 19) << 19) & 0x0ff8_0000))
 }
 
 /// Encode an SPI1/SPI2 memory segment into hardware register format.
@@ -188,8 +187,7 @@ pub(crate) fn encode_spi_segment(start: usize, end: usize) -> Result<u32, SmcErr
 
     let start = start as u32;
     let inclusive_end = (end - 1) as u32;
-    Ok(((((start >> 20) << 20) >> 16) & 0xffff)
-        | (((inclusive_end >> 20) << 20) & 0xffff_0000))
+    Ok(((((start >> 20) << 20) >> 16) & 0xffff) | (((inclusive_end >> 20) << 20) & 0xffff_0000))
 }
 
 /// Calculate AST-compatible SPI clock divider field for CS control registers.

--- a/target/ast10x0/peripherals/smc/helpers.rs
+++ b/target/ast10x0/peripherals/smc/helpers.rs
@@ -164,18 +164,32 @@ pub(crate) fn validate_dma_read(
     })
 }
 
-/// Encode a memory segment into hardware register format.
+/// Encode an FMC memory segment into hardware register format.
 ///
-/// Hardware uses 512 KB units for addressing.
-pub(crate) fn encode_segment(start: usize, end: usize) -> Result<u32, SmcError> {
-    let start_512k = (start >> 19) as u32;
-    let end_512k = ((end >> 19) - 1) as u32;
-
-    if start_512k > 0xFFFF || end_512k > 0xFFFF {
+/// FMC decode fields use 512 KiB alignment. `end` is exclusive.
+pub(crate) fn encode_fmc_segment(start: usize, end: usize) -> Result<u32, SmcError> {
+    if end == 0 || end <= start {
         return Err(SmcError::InvalidCapacity);
     }
 
-    Ok((end_512k << 16) | start_512k)
+    let start = start as u32;
+    let inclusive_end = (end - 1) as u32;
+    Ok(((((start >> 19) << 19) >> 16) & 0x0ff8)
+        | (((inclusive_end >> 19) << 19) & 0x0ff8_0000))
+}
+
+/// Encode an SPI1/SPI2 memory segment into hardware register format.
+///
+/// SPI decode fields use 1 MiB alignment. `end` is exclusive.
+pub(crate) fn encode_spi_segment(start: usize, end: usize) -> Result<u32, SmcError> {
+    if end == 0 || end <= start {
+        return Err(SmcError::InvalidCapacity);
+    }
+
+    let start = start as u32;
+    let inclusive_end = (end - 1) as u32;
+    Ok(((((start >> 20) << 20) >> 16) & 0xffff)
+        | (((inclusive_end >> 20) << 20) & 0xffff_0000))
 }
 
 /// Calculate AST-compatible SPI clock divider field for CS control registers.
@@ -267,18 +281,18 @@ mod tests {
 
     #[test]
     fn test_encode_segment() {
-        let seg = encode_segment(0, 16 * 1024 * 1024).unwrap();
-        let start_512k = seg & 0xFFFF;
-        let end_512k = (seg >> 16) & 0xFFFF;
+        let seg = encode_fmc_segment(0, 16 * 1024 * 1024).unwrap();
+        let start_512k = ((seg & 0x0ff8) << 16) >> 19;
+        let end_512k = (((seg & 0x0ff8_0000) | 0x0007_ffff) >> 19);
         assert_eq!(start_512k, 0);
         assert_eq!(end_512k, 31);
     }
 
     #[test]
     fn test_encode_segment_8mb_cs0() {
-        let seg = encode_segment(0, 8 * 1024 * 1024).unwrap();
-        let start_512k = seg & 0xFFFF;
-        let end_512k = (seg >> 16) & 0xFFFF;
+        let seg = encode_fmc_segment(0, 8 * 1024 * 1024).unwrap();
+        let start_512k = ((seg & 0x0ff8) << 16) >> 19;
+        let end_512k = (((seg & 0x0ff8_0000) | 0x0007_ffff) >> 19);
         assert_eq!(start_512k, 0);
         assert_eq!(end_512k, 15);
     }
@@ -287,9 +301,9 @@ mod tests {
     fn test_encode_segment_64mb_cs1_after_8mb_cs0() {
         let start = 8 * 1024 * 1024;
         let end = start + 64 * 1024 * 1024;
-        let seg = encode_segment(start, end).unwrap();
-        let start_512k = seg & 0xFFFF;
-        let end_512k = (seg >> 16) & 0xFFFF;
+        let seg = encode_fmc_segment(start, end).unwrap();
+        let start_512k = ((seg & 0x0ff8) << 16) >> 19;
+        let end_512k = (((seg & 0x0ff8_0000) | 0x0007_ffff) >> 19);
         assert_eq!(start_512k, 16);
         assert_eq!(end_512k, 143);
     }
@@ -328,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_segment_overflow() {
-        let result = encode_segment(0, 512 * 1024 * 1024);
+        let result = encode_fmc_segment(0, 512 * 1024 * 1024);
         assert!(result.is_err());
     }
 

--- a/target/ast10x0/peripherals/smc/helpers.rs
+++ b/target/ast10x0/peripherals/smc/helpers.rs
@@ -244,9 +244,9 @@ pub(crate) fn get_mid_point_of_longest_one(buf: &[u8]) -> i32 {
     }
 
     if max_cnt < 4 {
-        return -1;
+        -1
     } else {
-        return i32::try_from(mid_point).unwrap();
+        i32::try_from(mid_point).unwrap_or(-1)
     }
 }
 

--- a/target/ast10x0/peripherals/smc/mod.rs
+++ b/target/ast10x0/peripherals/smc/mod.rs
@@ -15,14 +15,17 @@ pub mod registers;
 pub mod spi;
 pub mod types;
 
-pub use controller::{Ready, ReadySmc, Smc, UninitSmc, Uninitialized};
+pub use controller::{
+    Calibrated, CalibratedSmc, CalibrationScratch, Ready, ReadySmc, Smc, UninitSmc, Uninitialized,
+    SPI_CALIB_LEN,
+};
 pub use device::{
     BlockDeviceInfo, FlashAddressingPolicy, FlashCommandProfile, JedecId, SpiNorBlockDevice,
     SpiNorFlash, SpiNorFlashDevice,
 };
-pub use fmc::{FmcReady, FmcUninit};
+pub use fmc::{FmcCalibrated, FmcReady, FmcUninit};
 pub use interrupts::{SmcInterrupt, SmcInterruptDecoder};
-pub use spi::{SpiReady, SpiUninit};
+pub use spi::{SpiCalibrated, SpiReady, SpiUninit};
 pub use types::{
     AddressWidth, ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, SmcRetryable,
     SmcTopology, TransferMode,

--- a/target/ast10x0/peripherals/smc/registers.rs
+++ b/target/ast10x0/peripherals/smc/registers.rs
@@ -19,7 +19,6 @@
 //! The controller layer answers "what to do with the data based on the topology."
 
 use ast1060_pac as device;
-use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 
 use crate::smc::helpers::{
@@ -35,7 +34,11 @@ use crate::smc::helpers::{
 /// hex offsets (e.g., `fmc000()` for offset 0x00, `fmc080()` for offset 0x80).
 pub struct SmcRegisters {
     base: *const device::fmc::RegisterBlock,
-    _not_sync: PhantomData<UnsafeCell<()>>, // Prevent Sync, allow Send
+    // `*const ()` marker keeps the handle `!Send` and `!Sync`. An `SmcRegisters`
+    // represents exclusive ownership of one hardware controller; it must not be
+    // shared between threads or moved into another execution context (e.g. an
+    // ISR) where it could alias the controller it owns.
+    _not_send_sync: PhantomData<*const ()>,
 }
 
 impl SmcRegisters {
@@ -49,7 +52,7 @@ impl SmcRegisters {
     pub const unsafe fn new(base: *const device::fmc::RegisterBlock) -> Self {
         Self {
             base,
-            _not_sync: PhantomData,
+            _not_send_sync: PhantomData,
         }
     }
 

--- a/target/ast10x0/peripherals/smc/spi.rs
+++ b/target/ast10x0/peripherals/smc/spi.rs
@@ -12,12 +12,17 @@
 //!
 //! The wrapper's role is **construction and delegation only**:
 //! - `SpiUninit::new()`: Type-check that controller_id is SPI1 or SPI2 (not FMC)
-//! - `SpiReady` methods: Delegate to inner controller operations
+//! - `SpiReady` / `SpiCalibrated` methods: Delegate to inner controller operations
 //!
-//! For BootSpi (FMC), use `Smc<FmcRegisterBackend>` directly.
+//! For BootSpi (FMC), use the [`crate::smc::fmc`] facade.
 //! For HostSpi/NormalSpi (SPI1/SPI2), use this wrapper.
+//!
+//! # Lifecycle
+//!
+//! [`SpiUninit`] → `init()` → [`SpiReady`] → `calibrate()` / `open_calibrated()`
+//! → [`SpiCalibrated`]. I/O is only available on the calibrated handle.
 
-use crate::smc::controller::{ReadySmc, UninitSmc};
+use crate::smc::controller::{CalibratedSmc, CalibrationScratch, ReadySmc, UninitSmc};
 use crate::smc::interrupts::SmcInterrupt;
 use crate::smc::types::{
     ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, TransferMode,
@@ -28,7 +33,12 @@ pub struct SpiUninit {
     inner: UninitSmc,
 }
 
-/// SPI handle after hardware initialization.
+/// SPI handle after hardware initialization, before calibration.
+pub struct SpiReady {
+    inner: ReadySmc,
+}
+
+/// SPI handle after calibration: the operational, I/O-capable state.
 ///
 /// # Topology Gating
 ///
@@ -36,16 +46,8 @@ pub struct SpiUninit {
 /// behavior (decode-range sizing, calibration skip, role-dependent control register
 /// programming) is handled by the controller layer, not here. This keeps the wrapper
 /// thin and the topology logic centralized.
-///
-/// # Example
-///
-/// ```ignore
-/// let mut spi = unsafe { SpiUninit::new(SmcController::Spi1, config)? };
-/// let spi = spi.init()?;  // Topology-gated behaviors in controller.init()
-/// spi.read(0, &mut buf)?;
-/// ```
-pub struct SpiReady {
-    inner: ReadySmc,
+pub struct SpiCalibrated {
+    inner: CalibratedSmc,
 }
 
 impl SpiUninit {
@@ -54,7 +56,7 @@ impl SpiUninit {
     /// # Topology Requirements
     ///
     /// The SPI wrapper is for HostSpi and NormalSpi topologies only.
-    /// BootSpi (FMC) should use the generic Smc<FmcRegisterBackend> directly.
+    /// BootSpi (FMC) should use the [`crate::smc::fmc`] facade.
     ///
     /// # Safety
     /// Caller must ensure unique ownership of the selected SPI hardware block.
@@ -65,7 +67,7 @@ impl SpiUninit {
         // Phase 3: Topology-aware SPI construction check.
         //
         // The SPI wrapper is specialized for HostSpi and NormalSpi topologies.
-        // FMC (BootSpi topology) uses the generic controller with FmcRegisterBackend.
+        // FMC (BootSpi topology) uses the FMC facade.
         // This check enforces that constraint at construction time.
         match controller_id {
             SmcController::Fmc => return Err(SmcError::InvalidChipSelect),
@@ -78,7 +80,7 @@ impl SpiUninit {
         Ok(Self { inner })
     }
 
-    /// Initialize SPI hardware and transition to ready state.
+    /// Initialize SPI hardware and transition to the ready (uncalibrated) state.
     pub fn init(self) -> Result<SpiReady, SmcError> {
         Ok(SpiReady {
             inner: self.inner.init()?,
@@ -87,6 +89,53 @@ impl SpiUninit {
 }
 
 impl SpiReady {
+    /// Bring-up path: calibrate read timing and transition to operational state.
+    ///
+    /// `scratch` must live off the small driver stack (see
+    /// [`CalibrationScratch`]). See [`crate::smc::Smc::calibrate`].
+    pub fn calibrate(self, scratch: &mut CalibrationScratch) -> Result<SpiCalibrated, SmcError> {
+        Ok(SpiCalibrated {
+            inner: self.inner.calibrate(scratch)?,
+        })
+    }
+
+    /// Driver path: open a controller calibrated earlier (e.g. in `board_init`).
+    ///
+    /// Returns `SmcError::NotCalibrated` if calibration has not been performed.
+    /// See [`crate::smc::Smc::open_calibrated`].
+    pub fn open_calibrated(self) -> Result<SpiCalibrated, SmcError> {
+        Ok(SpiCalibrated {
+            inner: self.inner.open_calibrated()?,
+        })
+    }
+
+    /// Report whether read timing is calibrated in hardware for `cs`.
+    pub fn is_calibrated(&self, cs: ChipSelect) -> bool {
+        self.inner.is_calibrated(cs)
+    }
+
+    /// Get the controller identifier.
+    pub fn controller_id(&self) -> SmcController {
+        self.inner.controller_id()
+    }
+
+    /// Return configured flash capacity in bytes.
+    pub fn capacity_bytes(&self) -> Result<usize, SmcError> {
+        self.inner.capacity_bytes()
+    }
+
+    /// Return configured flash capacity in bytes for the given chip select.
+    pub fn cs_capacity_bytes(&self, cs: ChipSelect) -> Result<usize, SmcError> {
+        self.inner.cs_capacity_bytes(cs)
+    }
+
+    /// Return the configured `FlashConfig` for the requested chip select.
+    pub fn cs_config(&self, cs: ChipSelect) -> Result<FlashConfig, SmcError> {
+        self.inner.cs_config(cs)
+    }
+}
+
+impl SpiCalibrated {
     /// Perform a programmed I/O read via the SPI flash window.
     pub fn read(&self, cs: ChipSelect, offset: u32, buf: &mut [u8]) -> Result<usize, SmcError> {
         self.inner.read(cs, offset, buf)
@@ -123,14 +172,19 @@ impl SpiReady {
         self.inner.poll_dma_completion()
     }
 
-    /// Check if SPI controller is ready for operations.
+    /// Check if SPI controller is idle and ready for a new operation.
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
     }
 
-    /// Program memory-mapped SPI NOR read mode for the selected chip select.
-    pub fn spi_nor_read_init(&mut self, cs: ChipSelect) -> Result<(), SmcError> {
-        self.inner.spi_nor_read_init(cs)
+    #[doc(hidden)]
+    pub fn test_force_dma_in_flight(&mut self) {
+        self.inner.test_force_dma_in_flight();
+    }
+
+    /// Get the controller identifier.
+    pub fn controller_id(&self) -> SmcController {
+        self.inner.controller_id()
     }
 
     /// Return configured flash capacity in bytes.
@@ -175,13 +229,13 @@ impl SpiReady {
             .transceive_user(ChipSelect::Cs0, cmd, tx_payload, rx, mode)
     }
 
-    /// Access the underlying generic ready controller.
-    pub fn as_inner(&self) -> &ReadySmc {
+    /// Access the underlying generic calibrated controller.
+    pub fn as_inner(&self) -> &CalibratedSmc {
         &self.inner
     }
 
-    /// Mutable access to the underlying generic ready controller.
-    pub fn as_inner_mut(&mut self) -> &mut ReadySmc {
+    /// Mutable access to the underlying generic calibrated controller.
+    pub fn as_inner_mut(&mut self) -> &mut CalibratedSmc {
         &mut self.inner
     }
 }

--- a/target/ast10x0/peripherals/smc/types.rs
+++ b/target/ast10x0/peripherals/smc/types.rs
@@ -30,6 +30,11 @@ pub enum SmcError {
     ControllerNotReady,
     /// DMA was requested but `SmcConfig::dma_enabled` is false for this controller
     DmaNotEnabled,
+    /// Read timing has not been calibrated in hardware for this controller.
+    ///
+    /// Returned by the driver-facing open path when bring-up (e.g. `board_init`)
+    /// did not run calibration first.
+    NotCalibrated,
 }
 
 /// Chip select index for a controller that may have multiple attached devices.

--- a/target/ast10x0/peripherals/uart/mod.rs
+++ b/target/ast10x0/peripherals/uart/mod.rs
@@ -144,19 +144,17 @@ impl Write for Usart {
                     .uartthr()
                     .write(|w| unsafe { w.bits(*byte as u32) });
                 written += 1;
+            } else if written == 0 {
+                // spec demands to block until at least one byte has been written.
+                // `continue` would skip to the next byte rather than retrying
+                // this one, so we busy-wait inline instead.
+                while self.is_tx_full() {}
+                self.regs()
+                    .uartthr()
+                    .write(|w| unsafe { w.bits(*byte as u32) });
+                written += 1;
             } else {
-                if written == 0 {
-                    // spec demands to block until at least one byte has been written.
-                    // `continue` would skip to the next byte rather than retrying
-                    // this one, so we busy-wait inline instead.
-                    while self.is_tx_full() {}
-                    self.regs()
-                        .uartthr()
-                        .write(|w| unsafe { w.bits(*byte as u32) });
-                    written += 1;
-                } else {
-                    break;
-                }
+                break;
             }
         }
         // Two invariants hold that LLVM cannot prove through value range analysis

--- a/target/ast10x0/tests/peripherals/i2c/i2c_init/target.rs
+++ b/target/ast10x0/tests/peripherals/i2c/i2c_init/target.rs
@@ -314,6 +314,7 @@ fn run_i2c_init_smoke_test() -> Result<(), &'static str> {
 
     let board = Ast10x0Board::new(Ast10x0BoardDescriptor {
         pinctrl_groups: &[pinctrl::PINCTRL_I2C1],
+        smc_configs: &[],
     });
 
     // SAFETY: Test target runs once at boot with exclusive access to the board.

--- a/target/ast10x0/tests/peripherals/i2c/i2c_irq/slave_target.rs
+++ b/target/ast10x0/tests/peripherals/i2c/i2c_irq/slave_target.rs
@@ -60,6 +60,7 @@ fn run_slave() -> Result<(), &'static str> {
 
     let board = Ast10x0Board::new(Ast10x0BoardDescriptor {
         pinctrl_groups: &[pinctrl::PINCTRL_I2C2],
+        smc_configs: &[],
     });
     // SAFETY: single call at boot with exclusive access to SCU/I2C global regs.
     unsafe { board.init() };

--- a/target/ast10x0/tests/peripherals/i2c/i2c_irq/target.rs
+++ b/target/ast10x0/tests/peripherals/i2c/i2c_irq/target.rs
@@ -49,6 +49,7 @@ fn run_master() -> Result<(), &'static str> {
 
     let board = Ast10x0Board::new(Ast10x0BoardDescriptor {
         pinctrl_groups: &[pinctrl::PINCTRL_I2C2],
+        smc_configs: &[],
     });
     // SAFETY: single call at boot with exclusive access to SCU/I2C global regs.
     unsafe { board.init() };

--- a/target/ast10x0/tests/smc/BUILD.bazel
+++ b/target/ast10x0/tests/smc/BUILD.bazel
@@ -6,6 +6,7 @@ exports_files(
     visibility = [
         "//target/ast10x0/tests/smc/dma_irq:__pkg__",
         "//target/ast10x0/tests/smc/read:__pkg__",
+        "//target/ast10x0/tests/smc/write:__pkg__",
     ],
 )
 
@@ -27,4 +28,14 @@ alias(
 alias(
     name = "smc_irq_evb_test",
     actual = "//target/ast10x0/tests/smc/dma_irq:smc_irq_evb_test",
+)
+
+alias(
+    name = "smc_write_test",
+    actual = "//target/ast10x0/tests/smc/write:smc_write_test",
+)
+
+alias(
+    name = "smc_write_evb_test",
+    actual = "//target/ast10x0/tests/smc/write:smc_write_evb_test",
 )

--- a/target/ast10x0/tests/smc/dma_irq/target.rs
+++ b/target/ast10x0/tests/smc/dma_irq/target.rs
@@ -25,8 +25,8 @@ use arch_arm_cortex_m::Arch;
 use ast10x0_peripherals::scu::pinctrl::PINCTRL_FMC_QUAD;
 use ast10x0_peripherals::scu::ScuRegisters;
 use ast10x0_peripherals::smc::{
-    ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, SmcInterrupt, SmcTopology,
-    UninitSmc,
+    CalibrationScratch, ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, SmcInterrupt,
+    SmcTopology, UninitSmc, SPI_CALIB_LEN,
 };
 use codegen as _;
 use console_backend::console_backend_write_all;
@@ -91,7 +91,7 @@ pub fn fmc_dma_irq_handler<K: Kernel>(_kernel: K) {
 }
 
 fn poll_dma_irq_completion(
-    controller: &mut ast10x0_peripherals::smc::ReadySmc,
+    controller: &mut ast10x0_peripherals::smc::CalibratedSmc,
 ) -> Poll<Result<(), SmcError>> {
     if !FMC_DMA_IRQ_FIRED.swap(false, Ordering::AcqRel) {
         return Poll::Pending;
@@ -118,9 +118,11 @@ fn run_dma_read_irq_test() -> Result<(), SmcError> {
     };
 
     let uninit = unsafe { UninitSmc::new(config)? };
-    let mut controller = uninit.init()?;
+    let controller = uninit.init()?;
 
-    controller.spi_nor_read_init(ChipSelect::Cs0)?;
+    // Bring-up context (large test stack): calibrate, then operate.
+    let mut scratch: CalibrationScratch = [0u8; SPI_CALIB_LEN];
+    let mut controller = controller.calibrate(&mut scratch)?;
 
     if !controller.is_ready() || controller.controller_id() != SmcController::Fmc {
         return Err(SmcError::HardwareError);

--- a/target/ast10x0/tests/smc/read/target.rs
+++ b/target/ast10x0/tests/smc/read/target.rs
@@ -23,7 +23,8 @@
 use ast10x0_peripherals::scu::pinctrl::PINCTRL_FMC_QUAD;
 use ast10x0_peripherals::scu::ScuRegisters;
 use ast10x0_peripherals::smc::{
-    ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, SmcTopology, UninitSmc,
+    CalibrationScratch, ChipSelect, FlashConfig, SmcConfig, SmcController, SmcError, SmcTopology,
+    UninitSmc, SPI_CALIB_LEN,
 };
 use console_backend::console_backend_write_all;
 use target_common::{declare_target, TargetInterface};
@@ -65,19 +66,15 @@ fn run_smc_read_test() -> Result<(), SmcError> {
     };
     pw_log::info!("=== AST10x0 smc  read test  ===");
     let controller = unsafe { UninitSmc::new(config)? };
-    let mut controller = controller.init()?;
+    let controller = controller.init()?;
 
-    let _ = match controller.spi_nor_read_init(ChipSelect::Cs0) {
-        Ok(v) => v,
+    // Bring-up context (large test stack): calibrate all configured chip
+    // selects, transitioning the controller to its operational state.
+    let mut scratch: CalibrationScratch = [0u8; SPI_CALIB_LEN];
+    let mut controller = match controller.calibrate(&mut scratch) {
+        Ok(c) => c,
         Err(e) => {
-            pw_log::info!("Error:: spi_nor_read_init cs0");
-            return Err(e);
-        }
-    };
-    let _ = match controller.spi_nor_read_init(ChipSelect::Cs1) {
-        Ok(v) => v,
-        Err(e) => {
-            pw_log::info!("Error:: spi_nor_read_init cs1");
+            pw_log::info!("Error:: calibrate");
             return Err(e);
         }
     };

--- a/target/ast10x0/tests/smc/write/BUILD.bazel
+++ b/target/ast10x0/tests/smc/write/BUILD.bazel
@@ -1,0 +1,79 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image", "system_image_test")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@pigweed//pw_kernel/tooling/panic_detector:rust_binary_no_panics_test.bzl", "rust_binary_no_panics_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/ast10x0:defs.bzl", "TARGET_COMPATIBLE_WITH")
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+    system_config = ":system_config",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    template = "//target/ast10x0:linker_script_template",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+        "//target/ast10x0/tests/smc:target_debug.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/ast10x0:entry",
+        "//target/ast10x0/peripherals",
+        "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+system_image(
+    name = "smc_write_test",
+    kernel = ":target",
+    platform = "//target/ast10x0",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    userspace = False,
+    visibility = ["//visibility:public"],
+)
+
+system_image_test(
+    name = "smc_write_evb_test",
+    image = ":smc_write_test",
+    tags = ["hardware"],
+    target_compatible_with = select({
+        "//target/ast10x0:qemu_enabled": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+rust_binary_no_panics_test(
+    name = "no_panics_test",
+    binary = ":smc_write_test",
+    tags = ["kernel"],
+)

--- a/target/ast10x0/tests/smc/write/system.json5
+++ b/target/ast10x0/tests/smc/write/system.json5
@@ -1,0 +1,17 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+// AST10x0 kernel-only SMC FMC CS1 erase/write/read verify test configuration.
+{
+    arch: {
+        type: "armv7m",
+        vector_table_start_address: 0x00000000,
+        vector_table_size_bytes: 1280,
+    },
+    kernel: {
+        flash_start_address: 0x00000500,
+        flash_size_bytes: 262144,
+        ram_start_address: 0x00040500,
+        ram_size_bytes: 393216,
+    },
+}

--- a/target/ast10x0/tests/smc/write/target.rs
+++ b/target/ast10x0/tests/smc/write/target.rs
@@ -39,6 +39,7 @@ const CS1_CONFIG: FlashConfig = FlashConfig {
 
 const TEST_OFFSET: u32 = 0x10_0000;
 const TEST_LEN: usize = 256;
+const TEST_SECTOR_LEN: usize = 4096;
 
 pub struct Target {}
 
@@ -56,6 +57,22 @@ fn expect_erased(buf: &[u8]) -> Result<(), SmcError> {
             return Err(SmcError::HardwareError);
         }
     }
+    Ok(())
+}
+
+fn restore_sector(flash: &mut SpiNorFlash<'_>, original: &[u8]) -> Result<(), SmcError> {
+    pw_log::info!("=== restore CS1 sector ===");
+    flash.erase_sector(TEST_OFFSET)?;
+
+    let written = flash.program(TEST_OFFSET, original)?;
+    if written != TEST_SECTOR_LEN {
+        return Err(SmcError::HardwareError);
+    }
+
+    if !flash.verify(TEST_OFFSET, original)? {
+        return Err(SmcError::HardwareError);
+    }
+
     Ok(())
 }
 
@@ -81,14 +98,36 @@ fn run_smc_fmc_cs1_write_test() -> Result<(), SmcError> {
         return Err(SmcError::HardwareError);
     }
 
-    let mut flash = SpiNorFlash::from_fmc_cs(&mut fmc, CS1_CONFIG, ChipSelect::Cs1)?;
-    let jedec = flash.jedec_id()?;
+    let jedec = {
+        let flash = SpiNorFlash::from_fmc_cs(&mut fmc, CS1_CONFIG, ChipSelect::Cs1)?;
+        flash.jedec_id()?
+    };
     pw_log::info!(
         "CS1 JEDEC ID: {:02x} {:02x} {:02x}",
         jedec[0] as u32,
         jedec[1] as u32,
         jedec[2] as u32
     );
+
+    pw_log::info!("=== backup CS1 sector ===");
+    let original = unsafe { core::slice::from_raw_parts_mut(0x41000 as *mut u8, TEST_SECTOR_LEN) };
+    fmc.dma_read(
+        ChipSelect::Cs1,
+        TEST_OFFSET,
+        0x41000usize,
+        TEST_SECTOR_LEN as u32,
+    )?;
+    loop {
+        match fmc.poll_dma_completion() {
+            core::task::Poll::Pending => {}
+            core::task::Poll::Ready(result) => {
+                result?;
+                break;
+            }
+        }
+    }
+
+    let mut flash = SpiNorFlash::from_fmc_cs(&mut fmc, CS1_CONFIG, ChipSelect::Cs1)?;
 
     pw_log::info!("=== erase CS1 sector ===");
     flash.erase_sector(TEST_OFFSET)?;
@@ -121,6 +160,8 @@ fn run_smc_fmc_cs1_write_test() -> Result<(), SmcError> {
     if !flash.verify(TEST_OFFSET, &pattern)? {
         return Err(SmcError::HardwareError);
     }
+
+    restore_sector(&mut flash, original)?;
 
     dump_smc_register(0x7E62_0000, 16);
     Ok(())

--- a/target/ast10x0/tests/smc/write/target.rs
+++ b/target/ast10x0/tests/smc/write/target.rs
@@ -1,0 +1,145 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! AST10x0 SMC FMC CS1 erase/write/read verify test target.
+
+#![no_std]
+#![no_main]
+
+#[allow(unused_imports)]
+use ast10x0_peripherals::scu::pinctrl::PINCTRL_FMC_QUAD;
+use ast10x0_peripherals::scu::ScuRegisters;
+use ast10x0_peripherals::smc::{
+    ChipSelect, FlashConfig, FmcUninit, SmcConfig, SmcController, SmcError, SmcTopology,
+    SpiNorFlash, SpiNorFlashDevice,
+};
+use console_backend::console_backend_write_all;
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+#[path = "../target_debug.rs"]
+mod target_debug;
+use target_debug::{dump_smc_read, dump_smc_register};
+
+const CS0_CONFIG: FlashConfig = FlashConfig {
+    capacity_mb: 8,
+    page_size: 256,
+    sector_size: 4096,
+    block_size: 65536,
+    spi_clock_mhz: 50,
+};
+
+const CS1_CONFIG: FlashConfig = FlashConfig {
+    capacity_mb: 64,
+    page_size: 256,
+    sector_size: 4096,
+    block_size: 65536,
+    spi_clock_mhz: 50,
+};
+
+const TEST_OFFSET: u32 = 0x10_0000;
+const TEST_LEN: usize = 256;
+
+pub struct Target {}
+
+fn fill_test_pattern(out: &mut [u8; TEST_LEN]) {
+    let mut i = 0usize;
+    while i < out.len() {
+        out[i] = (i as u8).wrapping_mul(17).wrapping_add(0x5a);
+        i += 1;
+    }
+}
+
+fn expect_erased(buf: &[u8]) -> Result<(), SmcError> {
+    for &byte in buf {
+        if byte != 0xff {
+            return Err(SmcError::HardwareError);
+        }
+    }
+    Ok(())
+}
+
+fn run_smc_fmc_cs1_write_test() -> Result<(), SmcError> {
+    let scu = unsafe { ScuRegisters::new_global_unlocked() };
+    scu.apply_pinctrl_group(PINCTRL_FMC_QUAD);
+
+    let config = SmcConfig {
+        controller_id: SmcController::Fmc,
+        cs0: Some(CS0_CONFIG),
+        cs1: Some(CS1_CONFIG),
+        dma_enabled: true,
+        enable_interrupts: false,
+        topology: SmcTopology::BootSpi { master_idx: 0 },
+    };
+
+    pw_log::info!("=== AST10x0 SMC FMC CS1 write test ===");
+    let fmc = unsafe { FmcUninit::new(config)? };
+    let mut fmc = fmc.init()?;
+    fmc.spi_nor_read_init(ChipSelect::Cs1)?;
+
+    if !fmc.is_ready() {
+        return Err(SmcError::HardwareError);
+    }
+
+    let mut flash = SpiNorFlash::from_fmc_cs(&mut fmc, CS1_CONFIG, ChipSelect::Cs1)?;
+    let jedec = flash.jedec_id()?;
+    pw_log::info!(
+        "CS1 JEDEC ID: {:02x} {:02x} {:02x}",
+        jedec[0] as u32,
+        jedec[1] as u32,
+        jedec[2] as u32
+    );
+
+    pw_log::info!("=== erase CS1 sector ===");
+    flash.erase_sector(TEST_OFFSET)?;
+
+    let mut read_buf = [0u8; TEST_LEN];
+    let n = flash.read(TEST_OFFSET, &mut read_buf)?;
+    if n != TEST_LEN {
+        return Err(SmcError::HardwareError);
+    }
+    expect_erased(&read_buf)?;
+    dump_smc_read(&read_buf, TEST_LEN as u32);
+
+    pw_log::info!("=== program CS1 page ===");
+    let mut pattern = [0u8; TEST_LEN];
+    fill_test_pattern(&mut pattern);
+    let written = flash.program_page(TEST_OFFSET, &pattern)?;
+    if written != TEST_LEN {
+        return Err(SmcError::HardwareError);
+    }
+
+    pw_log::info!("=== read CS1 page ===");
+    read_buf.fill(0);
+    let n = flash.read(TEST_OFFSET, &mut read_buf)?;
+    if n != TEST_LEN || read_buf != pattern {
+        return Err(SmcError::HardwareError);
+    }
+    dump_smc_read(&read_buf, TEST_LEN as u32);
+
+    pw_log::info!("=== verify CS1 page ===");
+    if !flash.verify(TEST_OFFSET, &pattern)? {
+        return Err(SmcError::HardwareError);
+    }
+
+    dump_smc_register(0x7E62_0000, 16);
+    Ok(())
+}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "AST10x0 SMC FMC CS1 write Test";
+
+    fn main() -> ! {
+        let sentinel = if run_smc_fmc_cs1_write_test().is_ok() {
+            b"TEST_RESULT:PASS\n"
+        } else {
+            b"TEST_RESULT:FAIL\n"
+        };
+        let _ = console_backend_write_all(sentinel);
+
+        #[expect(clippy::empty_loop)]
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/target/ast10x0/tests/smc/write/target.rs
+++ b/target/ast10x0/tests/smc/write/target.rs
@@ -10,8 +10,8 @@
 use ast10x0_peripherals::scu::pinctrl::PINCTRL_FMC_QUAD;
 use ast10x0_peripherals::scu::ScuRegisters;
 use ast10x0_peripherals::smc::{
-    ChipSelect, FlashConfig, FmcUninit, SmcConfig, SmcController, SmcError, SmcTopology,
-    SpiNorFlash, SpiNorFlashDevice,
+    CalibrationScratch, ChipSelect, FlashConfig, FmcUninit, SmcConfig, SmcController, SmcError,
+    SmcTopology, SpiNorFlash, SpiNorFlashDevice, SPI_CALIB_LEN,
 };
 use console_backend::console_backend_write_all;
 use target_common::{declare_target, TargetInterface};
@@ -91,8 +91,10 @@ fn run_smc_fmc_cs1_write_test() -> Result<(), SmcError> {
 
     pw_log::info!("=== AST10x0 SMC FMC CS1 write test ===");
     let fmc = unsafe { FmcUninit::new(config)? };
-    let mut fmc = fmc.init()?;
-    fmc.spi_nor_read_init(ChipSelect::Cs1)?;
+    let fmc = fmc.init()?;
+    // Bring-up context (large test stack): calibrate, then operate.
+    let mut scratch: CalibrationScratch = [0u8; SPI_CALIB_LEN];
+    let mut fmc = fmc.calibrate(&mut scratch)?;
 
     if !fmc.is_ready() {
         return Err(SmcError::HardwareError);


### PR DESCRIPTION
Fixed test failures and created an extra typestate to prevent an uncalibrated smc controller from being used for I/O.