### PR TITLE
fix: ipc_user test signal race

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,9 @@ git_override(
         "//third_party/pigweed:integration_tests_armv7m.patch",
         # Stage .bin alongside .elf in system_image_test runfiles.
         "//third_party/pigweed:system_image_test_bin_runfiles.patch",
+        # Fix race in ipc_user_test: handler was lowering USER signal before
+        # the initiator's object_wait could observe it, causing a hang.
+        "//third_party/pigweed:ipc_user_test_signal_race.patch",
     ],
     remote = "https://pigweed.googlesource.com/pigweed/pigweed",
 )

--- a/third_party/pigweed/ipc_user_test_signal_race.patch
+++ b/third_party/pigweed/ipc_user_test_signal_race.patch
@@ -1,0 +1,9 @@
+--- a/pw_kernel/tests/ipc/user/handler.rs
++++ b/pw_kernel/tests/ipc/user/handler.rs
+@@ -32,6 +32,4 @@
+         if wait_return.pending_signals.contains(Signals::USER) {
+             syscall::object_set_peer_user_signal(handle::IPC, true).map_err(|_| Error::Internal)?;
+-            syscall::object_set_peer_user_signal(handle::IPC, false)
+-                .map_err(|_| Error::Internal)?;
+             return Ok(());
+         }


### PR DESCRIPTION
The test would fail very rarely, and highly dependent on the test invocation. Running `bazel test --config=virt_ast10x0 //target/ast10x0/tests/ipc/user:ipc_test --nocache_test_results` failed once out of 100 times, on the 9th invocation. However running `bazel test --config=virt_ast10x0 //target/ast10x0/tests/ipc/user:ipc_test --nocache_test_results --runs_per_test=1000` made every single invocation fail without this patch.

The change in this patch is not likely an adequate solution long term, but it serves to illustrate what is failing this test