### PR TITLE
[earlgrey] qemu: bump pin to v10.2.0-2026-06-14; enable UART + GPIO qemu tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -103,3 +103,8 @@ test:stress_k_ast1060_evb   --local_test_jobs=1
 test:stress_k_ast1060_evb   --run_under="//target/ast10x0/harness:test_runner \
   --timeout 0 "
 test:stress_k_ast1060_evb   --test_env=AST1060_EVB_PI_HOST
+
+# Site-local overrides. Kept last so developer machine-specific settings (e.g. a
+# local QEMU source override via --override_repository) take precedence. This
+# file is not checked in; see third_party/qemu/setup.md.
+try-import %workspace%/.bazelrc-site

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build
 rust-project.json
 user.bazelrc
+.bazelrc-site
 /bazel-*
 /out
 target/rust-analyzer/

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -555,7 +555,7 @@
     },
     "//third_party/qemu:extensions.bzl%qemu": {
       "general": {
-        "bzlTransitiveDigest": "vYbS6zbBSUEYrJr8ZFwTQQ36P+gfjwYHsC6c3Of1Mbw=",
+        "bzlTransitiveDigest": "Rd1333rjuzM1bQseVI6A3PGgXNZR96GehAsbuOML4F8=",
         "usagesDigest": "sd4NrZaNp1CVFJ9pAaTO/LvX7gn0a5KpGnmBklHnLK4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -564,9 +564,9 @@
           "qemu_opentitan_src": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/qemu/releases/download/v10.2.0-2026-01-15/qemu-ot-earlgrey-v10.2.0-2026-01-15-x86_64-unknown-linux-gnu.tar.gz",
+              "url": "https://github.com/lowRISC/qemu/releases/download/v10.2.0-2026-06-14/qemu-ot-earlgrey-v10.2.0-2026-06-14-x86_64-unknown-linux-gnu.tar.gz",
               "build_file": "@@//third_party/qemu:BUILD.qemu_opentitan.bazel",
-              "sha256": "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
+              "sha256": "0162acd6a5d262669910592304cd7771a4b4944889305357a22dcf10706dab36",
               "patch_cmds": [
                 "touch .this.is.the.archive"
               ]

--- a/target/earlgrey/tests/drivers/gpio/BUILD.bazel
+++ b/target/earlgrey/tests/drivers/gpio/BUILD.bazel
@@ -91,5 +91,10 @@ opentitan_test(
     target = ":gpio",
 )
 
-# TODO: QEMU ot-earlgrey machine has no ot_gpio device model — DIRECT_OUT reads
-# return 0. Re-enable when upstream lowRISC QEMU lands ot_gpio emulation.
+opentitan_test(
+    name = "gpio_qemu_test",
+    timeout = "moderate",
+    interface = "qemu",
+    tags = ["qemu"],
+    target = ":gpio",
+)

--- a/target/earlgrey/tests/uart/BUILD.bazel
+++ b/target/earlgrey/tests/uart/BUILD.bazel
@@ -142,6 +142,10 @@ opentitan_test(
     target = ":uart",
 )
 
-# TODO: QEMU ot-earlgrey machine doesn't fire UART1 RX-watermark interrupts —
-# the loopback test hangs waiting for an interrupt that never arrives.
-# Re-enable when lowRISC QEMU validates interrupt-driven UART under ot-earlgrey.
+opentitan_test(
+    name = "uart_qemu_test",
+    timeout = "moderate",
+    interface = "qemu",
+    tags = ["qemu"],
+    target = ":uart",
+)

--- a/third_party/qemu/extensions.bzl
+++ b/third_party/qemu/extensions.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Ported from opentitan/third_party/qemu/extensions.bzl.
-# Pinned to QEMU tag v10.2.0-2026-01-15.
+# Pinned to QEMU tag v10.2.0-2026-06-14.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -84,7 +84,7 @@ qemu_bazel_build_or_forward = repository_rule(
 )
 
 def _qemu_opentitan_repos():
-    QEMU_VERSION = "v10.2.0-2026-01-15"
+    QEMU_VERSION = "v10.2.0-2026-06-14"
 
     url = "/".join([
         "https://github.com/lowRISC/qemu/releases/download",
@@ -96,7 +96,7 @@ def _qemu_opentitan_repos():
         name = "qemu_opentitan_src",
         url = url,
         build_file = Label(":BUILD.qemu_opentitan.bazel"),
-        sha256 = "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
+        sha256 = "0162acd6a5d262669910592304cd7771a4b4944889305357a22dcf10706dab36",
         patch_cmds = ["touch {}".format(_ARCHIVE_MARKER_FILE)],
     )
 


### PR DESCRIPTION
Bump the pinned lowRISC QEMU release in third_party/qemu/extensions.bzl from v10.2.0-2026-01-15 to v10.2.0-2026-06-14.

Eenable previously stubbed-out earlgrey qemu tests:

  - //target/earlgrey/tests/uart:uart_qemu_test
  - //target/earlgrey/tests/drivers/gpio:gpio_qemu_test