### PR TITLE
ci: refactor self-hosted bazel setup into composite action

### DIFF
--- a/.github/actions/setup-bazel-self-hosted/action.yml
+++ b/.github/actions/setup-bazel-self-hosted/action.yml
@@ -1,0 +1,17 @@
+# Licensed under the Apache-2.0 license
+
+name: 'Setup Bazel (Self-Hosted)'
+description: 'Configure Bazel for self-hosted runners with local persistent caching'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: false
+        disk-cache: false
+        repository-cache: false
+        output-base: ${{ runner.workspace }}/.bazel
+        bazelrc: |
+          build --disk_cache=/home/github-runner/.cache/bazel-disk
+          common --repository_cache=/home/github-runner/.cache/bazel-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
+      uses: ./.github/actions/setup-bazel-self-hosted
 
     - name: Presubmit Checks
       # The presubmit workflow performs formatting checks, license checks
@@ -40,11 +36,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
+      uses: ./.github/actions/setup-bazel-self-hosted
 
     - name: Run tests
       # See workflows.json for the `ci` definition.
@@ -59,11 +51,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
+      uses: ./.github/actions/setup-bazel-self-hosted
 
     - name: Build
       # See workflows.json for the `default` definition.


### PR DESCRIPTION
Refactors the repeated setup-bazel steps in ci.yml into a local
composite action (.github/actions/setup-bazel-self-hosted).

This ensures a consistent configuration across all CI jobs, including:
- Disabling GitHub-backed caching to avoid redundancy and conflicts.
- Setting a unique output base per runner (${{ runner.workspace }}/.bazel)
  to avoid server trashing.
- Configuring local persistent cache paths in the runner's home directory.

Future updates to the self-hosted Bazel configuration can now be
managed in a single place.
