### PR TITLE
earlgrey/drivers: Port SPI Host driver and add smoke test

### DIFF
--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -86,3 +86,18 @@ rust_library(
         "@ureg",
     ],
 )
+
+rust_library(
+    name = "spi_host",
+    srcs = ["spi_host.rs"],
+    crate_name = "earlgrey_spi_host",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//target/earlgrey/registers:spi_host",
+        "//util/error",
+        "//util/regcpy",
+        "@rust_crates//:embedded-hal",
+        "@ureg",
+    ],
+)

--- a/target/earlgrey/drivers/spi_host.rs
+++ b/target/earlgrey/drivers/spi_host.rs
@@ -1,0 +1,272 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPI Host driver for Earlgrey.
+//!
+//! This driver implements the `embedded-hal` 1.0 SPI traits for the Earlgrey SPI Host controller.
+
+#![no_std]
+
+use util_error::{
+    ErrorCode, SPI_GENERIC_FIFO_OVERFLOW, SPI_GENERIC_FIFO_UNDERFLOW, SPI_GENERIC_HARDWARE_ERROR,
+    SPI_GENERIC_INVALID_TRANSACTION, SPI_GENERIC_TIMEOUT,
+};
+
+/// SPI Host driver error wrapping an [`ErrorCode`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SpiError(pub ErrorCode);
+
+impl SpiError {
+    /// Invalid transaction parameters or state.
+    pub const INVALID_TRANSACTION: Self = Self(SPI_GENERIC_INVALID_TRANSACTION);
+    /// TX FIFO overflow.
+    pub const FIFO_OVERFLOW: Self = Self(SPI_GENERIC_FIFO_OVERFLOW);
+    /// RX FIFO underflow.
+    pub const FIFO_UNDERFLOW: Self = Self(SPI_GENERIC_FIFO_UNDERFLOW);
+    /// Operation timed out.
+    pub const TIMEOUT: Self = Self(SPI_GENERIC_TIMEOUT);
+    /// Hardware error reported by the controller.
+    pub const HARDWARE_ERROR: Self = Self(SPI_GENERIC_HARDWARE_ERROR);
+}
+
+impl embedded_hal::spi::Error for SpiError {
+    fn kind(&self) -> embedded_hal::spi::ErrorKind {
+        // Map all errors to Other for now.
+        embedded_hal::spi::ErrorKind::Other
+    }
+}
+
+impl From<ErrorCode> for SpiError {
+    fn from(err: ErrorCode) -> Self {
+        SpiError(err)
+    }
+}
+
+impl From<SpiError> for ErrorCode {
+    fn from(err: SpiError) -> Self {
+        err.0
+    }
+}
+
+/// Configuration for the SPI Host driver.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SpiConfig {
+    /// Clock divider to adjust transfer speed.
+    /// Formula: f_sck = f_core / (2 * (clkdiv + 1))
+    pub clkdiv: u32,
+    /// SPI clock polarity (false for low when idle, true for high when idle).
+    pub cpol: bool,
+    /// SPI clock phase (false to sample on first edge, true on second edge).
+    pub cpha: bool,
+    /// Chip Select ID line (0 for CS0, 1 for CS1, etc.)
+    pub csid: u32,
+}
+
+impl SpiConfig {
+    /// Default configuration for SPI Host 0 (SPI0).
+    /// SPI0 clock domain is 96MHz. clkdiv 1 provides 24MHz SCK.
+    pub const DEFAULT_SPI0: Self = Self {
+        clkdiv: 1,
+        cpol: false,
+        cpha: false,
+        csid: 0,
+    };
+
+    /// Default configuration for SPI Host 1 (SPI1).
+    /// SPI1 clock domain is 48MHz. clkdiv 0 provides 24MHz SCK.
+    pub const DEFAULT_SPI1: Self = Self {
+        clkdiv: 0,
+        cpol: false,
+        cpha: false,
+        csid: 0,
+    };
+}
+
+/// Earlgrey SPI Host driver.
+pub struct SpiHost {
+    mmio: spi_host::RegisterBlock<ureg::RealMmioMut<'static>>,
+}
+
+impl SpiHost {
+    /// Create a new SpiHost instance using the raw register block.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure they have exclusive access to the SpiHost peripheral registers
+    /// represented by the MMIO block.
+    pub unsafe fn new(mmio: spi_host::RegisterBlock<ureg::RealMmioMut<'static>>) -> Self {
+        Self { mmio }
+    }
+
+    /// Dynamically reconfigure the SPI Host speed, mode, and chip select.
+    pub fn configure(&mut self, config: &SpiConfig) -> Result<(), SpiError> {
+        self.mmio.configopts().write(|w| {
+            w.clkdiv(config.clkdiv)
+                .cpol(config.cpol)
+                .cpha(config.cpha)
+                .fullcyc(true)
+                .csnlead(0)
+                .csnidle(2)
+                .csntrail(1)
+        });
+        self.mmio.csid().write(|_| config.csid);
+        Ok(())
+    }
+
+    /// Initialize the SPI Host peripheral.
+    ///
+    /// Configures the clock, SPI mode (0), CS timings, performs a reset,
+    /// and enables the peripheral.
+    pub fn init(&mut self, config: &SpiConfig) -> Result<(), SpiError> {
+        self.configure(config)?;
+        self.mmio.control().write(|w| w.sw_rst(true));
+        loop {
+            let status = self.mmio.status().read();
+            if status.txempty() && status.rxempty() {
+                break;
+            }
+        }
+        self.mmio.control().write(|w| w.sw_rst(false).spien(true));
+        self.mmio.csid().write(|_| config.csid);
+
+        Ok(())
+    }
+
+    fn is_active(&self) -> bool {
+        self.mmio.status().read().active()
+    }
+
+    fn is_ready(&self) -> bool {
+        let status = self.mmio.status().read();
+        status.ready() && !status.active()
+    }
+
+    /// Send a write command segment.
+    fn write_cmd(
+        &mut self,
+        mut data: &[u8],
+        speed: u32,
+        final_csaat: bool,
+    ) -> Result<(), SpiError> {
+        self.mmio.control().modify(|w| w.output_en(true));
+
+        while !data.is_empty() {
+            while !self.is_ready() {
+                // TODO: we should block here for an interrupt that would signal the hardware is ready.
+            }
+
+            let chunk_len = core::cmp::min(data.len(), MAX_TX_CHUNK_LEN);
+            let (chunk, rest) = data.split_at(chunk_len);
+            data = rest;
+
+            util_regcpy::copy_to_reg_unaligned(&self.mmio.txdata(), chunk);
+
+            let chunk_csaat = !data.is_empty() || final_csaat;
+
+            self.mmio.command().write(|w| {
+                w.speed(speed)
+                    .csaat(chunk_csaat)
+                    .direction(DIR_TXONLY)
+                    .len(chunk_len.saturating_sub(1) as u32)
+            });
+        }
+        Ok(())
+    }
+
+    /// Send a read command segment and receive data into `dest`.
+    fn read_cmd(
+        &mut self,
+        mut len: usize,
+        speed: u32,
+        final_csaat: bool,
+        mut dest: &mut [u8],
+    ) -> Result<(), SpiError> {
+        self.mmio.control().modify(|w| w.output_en(true));
+
+        while len > 0 {
+            while !self.is_ready() {
+                // TODO: we should block here for an interrupt that would signal the hardware is ready.
+            }
+
+            let chunk_len = core::cmp::min(len, MAX_RX_CHUNK_LEN);
+            len -= chunk_len;
+
+            let chunk_csaat = len > 0 || final_csaat;
+
+            self.mmio.command().write(|w| {
+                w.speed(speed)
+                    .csaat(chunk_csaat)
+                    .direction(DIR_RXONLY)
+                    .len(chunk_len.saturating_sub(1) as u32)
+            });
+
+            if chunk_len > dest.len() {
+                return Err(SpiError::INVALID_TRANSACTION);
+            }
+            // Split dest into the chunk we want to read now, and the rest for later.
+            let (mut chunk_dest, rest) = dest.split_at_mut(chunk_len);
+            dest = rest;
+
+            while !chunk_dest.is_empty() {
+                let status = self.mmio.status().read();
+                let rxqd = status.rxqd() as usize; // rxqd is in 32-bit words
+                let bytes_in_fifo = rxqd * 4;
+
+                if bytes_in_fifo > 0 {
+                    let drain_len = core::cmp::min(bytes_in_fifo, chunk_dest.len());
+                    let (drain_chunk, remaining) = chunk_dest.split_at_mut(drain_len);
+                    util_regcpy::copy_from_reg_unaligned(drain_chunk, &self.mmio.rxdata());
+                    chunk_dest = remaining;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+const MAX_RX_CHUNK_LEN: usize = 256;
+const MAX_TX_CHUNK_LEN: usize = 288;
+const DIR_RXONLY: u32 = 1;
+const DIR_TXONLY: u32 = 2;
+
+impl embedded_hal::spi::ErrorType for SpiHost {
+    type Error = SpiError;
+}
+
+impl embedded_hal::spi::SpiDevice for SpiHost {
+    fn transaction(
+        &mut self,
+        operations: &mut [embedded_hal::spi::Operation<'_, u8>],
+    ) -> Result<(), Self::Error> {
+        let op_count = operations.len();
+        for (i, op) in operations.iter_mut().enumerate() {
+            let is_last = i == op_count - 1;
+            let csaat = !is_last;
+
+            match op {
+                embedded_hal::spi::Operation::Read(buf) => {
+                    self.read_cmd(buf.len(), 0, csaat, buf)?;
+                }
+                embedded_hal::spi::Operation::Write(buf) => {
+                    self.write_cmd(buf, 0, csaat)?;
+                }
+                embedded_hal::spi::Operation::Transfer(_, _)
+                | embedded_hal::spi::Operation::TransferInPlace(_) => {
+                    // Full-duplex SPI transfer is not supported by this simple driver yet.
+                    return Err(SpiError::INVALID_TRANSACTION);
+                }
+                embedded_hal::spi::Operation::DelayNs(_) => {
+                    // Delay operation is not supported.
+                    return Err(SpiError::INVALID_TRANSACTION);
+                }
+            }
+        }
+
+        // Wait for the controller to finish the last command segment.
+        while self.is_active() {}
+        // Disable output buffers to release the bus.
+        self.mmio.control().modify(|w| w.output_en(false));
+
+        Ok(())
+    }
+}

--- a/target/earlgrey/tests/drivers/spi_host/BUILD.bazel
+++ b/target/earlgrey/tests/drivers/spi_host/BUILD.bazel
@@ -1,0 +1,103 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:rust_app.bzl", "rust_app")
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+
+rust_app(
+    name = "spi_host",
+    srcs = [
+        "spi_host.rs",
+    ],
+    codegen_crate_name = "spi_host_codegen",
+    edition = "2024",
+    system_config = "@pigweed//pw_kernel/target:system_config_file",
+    tags = ["kernel"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//target/earlgrey/drivers:spi_host",
+        "//target/earlgrey/registers:spi_host",
+        "//util/panic",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+        "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:embedded-hal",
+    ],
+)
+
+system_image(
+    name = "spi_host_image",
+    apps = [
+        ":spi_host",
+    ],
+    kernel = ":target",
+    platform = "//target/earlgrey",
+    system_config = ":system_config",
+    tags = ["kernel"],
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    template = "//target/earlgrey:linker_script_template",
+)
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+    system_config = ":system_config",
+)
+
+rust_binary(
+    name = "target",
+    srcs = [
+        "target.rs",
+    ],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/earlgrey:entry",
+        "@pigweed//pw_kernel/arch/riscv:arch_riscv",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_kernel/userspace",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+opentitan_test(
+    name = "spi_host_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper340",
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
+    ],
+    target = ":spi_host_image",
+)
+
+opentitan_test(
+    name = "spi_host_qemu_test",
+    timeout = "moderate",
+    environment = "//target/earlgrey/env:qemu",
+    interface = "qemu",
+    tags = ["qemu"],
+    target = ":spi_host_image",
+)

--- a/target/earlgrey/tests/drivers/spi_host/spi_host.rs
+++ b/target/earlgrey/tests/drivers/spi_host/spi_host.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Smoke test for Earlgrey SPI Host driver.
+//!
+//! Initializes the SPI Host, reads the JEDEC SFDP signature of the
+//! external Flash, and verifies it matches the standard "SFDP" string.
+
+#![no_std]
+#![no_main]
+
+use earlgrey_spi_host::{SpiConfig, SpiHost};
+use embedded_hal::spi::SpiDevice;
+use pw_status::{Error, Result};
+use spi_host::{SpiHost0, SpiHost1};
+use userspace::entry;
+
+fn run_test() -> Result<()> {
+    // SAFETY: We have exclusive access to SPI_HOST0 in this test process.
+    let mmio0 = unsafe { spi_host::RegisterBlock::new(SpiHost0::PTR) };
+    let mut spi = unsafe { SpiHost::new(mmio0) };
+    spi.init(&SpiConfig::DEFAULT_SPI0).map_err(|_| {
+        pw_log::error!("SPI init failed");
+        Error::Internal
+    })?;
+
+    // 2. Read SFDP Signature (Command 0x5A, Address 0x000000, 8 Dummy Cycles -> 1 Dummy Byte).
+    // The TX buffer contains: [Opcode, Addr[23:16], Addr[15:8], Addr[7:0], Dummy]
+    let tx_buf = [0x5A, 0x00, 0x00, 0x00, 0x00];
+    let mut rx_buf = [0u8; 4];
+
+    let mut ops = [
+        embedded_hal::spi::Operation::Write(&tx_buf),
+        embedded_hal::spi::Operation::Read(&mut rx_buf),
+    ];
+
+    spi.transaction(&mut ops).map_err(|_| {
+        pw_log::error!("SPI transaction 1 failed");
+        Error::Internal
+    })?;
+
+    pw_log::info!(
+        "SFDP signature read 1: {:02x} {:02x} {:02x} {:02x}",
+        rx_buf[0],
+        rx_buf[1],
+        rx_buf[2],
+        rx_buf[3]
+    );
+
+    // Read SFDP Signature again to verify FIFO is not corrupted by padded write remainders.
+    let mut rx_buf2 = [0u8; 4];
+    let mut ops2 = [
+        embedded_hal::spi::Operation::Write(&tx_buf),
+        embedded_hal::spi::Operation::Read(&mut rx_buf2),
+    ];
+
+    spi.transaction(&mut ops2).map_err(|_| {
+        pw_log::error!("SPI transaction 2 failed");
+        Error::Internal
+    })?;
+
+    pw_log::info!(
+        "SFDP signature read 2: {:02x} {:02x} {:02x} {:02x}",
+        rx_buf2[0],
+        rx_buf2[1],
+        rx_buf2[2],
+        rx_buf2[3]
+    );
+
+    // 3. Verify SFDP Signature ("SFDP" -> [0x53, 0x46, 0x44, 0x50])
+    let expected_sig = [0x53, 0x46, 0x44, 0x50]; // "SFDP" in ASCII (little-endian bytes)
+    if rx_buf != expected_sig {
+        pw_log::error!(
+            "FAIL: Unexpected SFDP signature in read 1: [{:02x}, {:02x}, {:02x}, {:02x}] (expected [53, 46, 44, 50])",
+            rx_buf[0],
+            rx_buf[1],
+            rx_buf[2],
+            rx_buf[3]
+        );
+        return Err(Error::FailedPrecondition);
+    }
+    if rx_buf2 != expected_sig {
+        pw_log::error!(
+            "FAIL: Unexpected SFDP signature in read 2: [{:02x}, {:02x}, {:02x}, {:02x}] (expected [53, 46, 44, 50])",
+            rx_buf2[0],
+            rx_buf2[1],
+            rx_buf2[2],
+            rx_buf2[3]
+        );
+        return Err(Error::FailedPrecondition);
+    }
+
+    pw_log::info!("SFDP signature verified successfully!");
+
+    // SAFETY: We have exclusive access to SPI_HOST1 in this test process.
+    let mmio1 = unsafe { spi_host::RegisterBlock::new(SpiHost1::PTR) };
+    let mut spi1 = unsafe { SpiHost::new(mmio1) };
+    spi1.init(&SpiConfig::DEFAULT_SPI1).map_err(|_| {
+        pw_log::error!("SPI1 init failed");
+        Error::Internal
+    })?;
+
+    // Perform a dummy transaction. MISO is likely floating or unmapped, so we expect
+    // garbage bytes (usually 0x00 or 0xFF), but the transaction itself must succeed (no timeout/hang).
+    let mut rx_buf_dummy = [0u8; 4];
+    let mut ops_dummy = [
+        embedded_hal::spi::Operation::Write(&tx_buf),
+        embedded_hal::spi::Operation::Read(&mut rx_buf_dummy),
+    ];
+
+    spi1.transaction(&mut ops_dummy).map_err(|_| {
+        pw_log::error!("SPI1 transaction failed");
+        Error::Internal
+    })?;
+
+    pw_log::info!(
+        "SPI1 dummy transaction returned: {:02x} {:02x} {:02x} {:02x}",
+        rx_buf_dummy[0],
+        rx_buf_dummy[1],
+        rx_buf_dummy[2],
+        rx_buf_dummy[3]
+    );
+
+    Ok(())
+}
+
+#[entry]
+fn entry() -> Result<()> {
+    pw_log::info!("🔄 RUNNING SPI Host Smoke Test");
+    let ret = run_test();
+
+    if ret.is_err() {
+        pw_log::error!("FAIL: Smoke test execution failed");
+    } else {
+        pw_log::info!("✅ PASS");
+    }
+
+    ret
+}
+
+util_panic::make_panic_handler!();

--- a/target/earlgrey/tests/drivers/spi_host/system.json5
+++ b/target/earlgrey/tests/drivers/spi_host/system.json5
@@ -1,0 +1,47 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+{
+  arch: {
+    type: "riscv",
+  },
+  kernel: {
+    flash_start_address: 0xA0010000,
+    flash_size_bytes: 65536,
+    ram_start_address: 0x10000000,
+    ram_size_bytes: 32768,
+    interrupt_table: {
+      table: {}
+    },
+  },
+  apps: [
+    {
+      name: "spi_host",
+      flash_size_bytes: 16384,
+      processes: [{
+        name: "spi_host_process",
+        ram_size_bytes: 4096,
+        objects: [
+          {
+            type: "thread",
+            name: "spi_thread",
+            kernel_stack_size_bytes: 2048,
+          },
+        ],
+        memory_mappings: [
+          {
+            name: "spi_host0",
+            type: "device",
+            start_address: 0x40300000,
+            size_bytes: 0x1000,
+          },
+          {
+            name: "spi_host1",
+            type: "device",
+            start_address: 0x40310000,
+            size_bytes: 0x1000,
+          },
+        ],
+      }],
+    },
+  ],
+}

--- a/target/earlgrey/tests/drivers/spi_host/target.rs
+++ b/target/earlgrey/tests/drivers/spi_host/target.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+#![no_main]
+#![allow(clippy::empty_loop)]
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "Earlgrey Userspace UART";
+
+    fn main() -> ! {
+        codegen::start();
+        loop {}
+    }
+
+    fn shutdown(code: u32) -> ! {
+        pw_log::info!("Shutting down with code {}", code as u32);
+        match code {
+            0 => pw_log::info!("PASS"),
+            _ => pw_log::info!("FAIL: {}", code as u32),
+        };
+        loop {}
+    }
+}
+
+declare_target!(Target);

--- a/util/error/BUILD.bazel
+++ b/util/error/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
         "ipc.rs",
         "kernel.rs",
         "lib.rs",
+        "spi.rs",
     ],
     crate_name = "util_error",
     edition = "2024",

--- a/util/error/lib.rs
+++ b/util/error/lib.rs
@@ -11,10 +11,12 @@ use zerocopy::{Immutable, IntoBytes};
 mod flash;
 mod ipc;
 mod kernel;
+mod spi;
 
 pub use flash::*;
 pub use ipc::*;
 pub use kernel::*;
+pub use spi::*;
 
 /// Represents an error module.
 ///

--- a/util/error/spi.rs
+++ b/util/error/spi.rs
@@ -1,0 +1,22 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPI-specific error codes.
+
+use crate::{ErrorCode, ErrorModule};
+use pw_status::Error;
+
+/// The generic SPI error module.
+pub const SPI_GENERIC: ErrorModule = ErrorModule::new(0x5350); // ascii `SP`.
+
+/// Invalid transaction parameters or state.
+pub const SPI_GENERIC_INVALID_TRANSACTION: ErrorCode =
+    SPI_GENERIC.from_pw(1, Error::InvalidArgument);
+/// TX FIFO overflow.
+pub const SPI_GENERIC_FIFO_OVERFLOW: ErrorCode = SPI_GENERIC.from_pw(2, Error::ResourceExhausted);
+/// RX FIFO underflow.
+pub const SPI_GENERIC_FIFO_UNDERFLOW: ErrorCode = SPI_GENERIC.from_pw(3, Error::ResourceExhausted);
+/// Operation timed out.
+pub const SPI_GENERIC_TIMEOUT: ErrorCode = SPI_GENERIC.from_pw(4, Error::DeadlineExceeded);
+/// Hardware error reported by the controller.
+pub const SPI_GENERIC_HARDWARE_ERROR: ErrorCode = SPI_GENERIC.from_pw(5, Error::Internal);


### PR DESCRIPTION
Key modifications and fixes made during the port:
- Implements the `embedded-hal` `SpiDevice` trait, which includes:
  * Defines a related `SpiError` type.
  * Defines the `transaction` method in the struct, which accepts an array of operations, and `csaat` will be asserted during the entire operation series.
  * Marks the operations like `Transfer`, `TransferInPlace`, and `DelayNs` as unsupported explicitly, which is also originally unsupported.
  * Removes unsupported hardware optimization methods like `prefetch`, `drain_fifo`, and `aligned_drain_fifo` since they are not defined in `embedded_hal`. If we need the original optimization that only works on aligned words, we can branch on aligned/unaligned input and apply similar optimization when the input is aligned. However, we should stick with the input type defined in `embedded_hal`.
- Defines a dedicated `SpiConfig` struct and a dedicated `configure` method to make SPI Host configurable.

Also includes a smoke test validating SPI read transactions by checking the SFDP signature.