### PR TITLE
earlgrey: DFU updates in transport firmware

### DIFF
--- a/target/earlgrey/env/BUILD.bazel
+++ b/target/earlgrey/env/BUILD.bazel
@@ -21,14 +21,14 @@ fpga_environment(
     bitstream = "@opentitan_devbundle//:earlgrey/bitstreams/bitstream_fpga_hyper310.bit",
     interface = "hyper310",
     opentitantool_args = ["--cw-usb-port-workaround=3"],
-    rom_ext = "@opentitan_devbundle//:rom_ext/rom_ext_dice_x509_slot_virtual_fpga_cw310.prod_key_0.prod_key_0.signed.bin",
+    rom_ext = "@opentitan_devbundle//:rom_ext/rom_ext_usbdfu_anyversion_fpga_cw310.prod_key_0.signed.bin",
 )
 
 fpga_environment(
     name = "hyper340",
     bitstream = "@opentitan_devbundle//:earlgrey/bitstreams/bitstream_fpga_hyper340.bit",
     interface = "hyper340",
-    rom_ext = "@opentitan_devbundle//:rom_ext/rom_ext_dice_x509_slot_virtual_fpga_cw340.prod_key_0.prod_key_0.signed.bin",
+    rom_ext = "@opentitan_devbundle//:rom_ext/rom_ext_usbdfu_anyversion_fpga_cw340.prod_key_0.signed.bin",
 )
 
 silicon_environment(

--- a/target/earlgrey/firmware/transport/BUILD.bazel
+++ b/target/earlgrey/firmware/transport/BUILD.bazel
@@ -12,6 +12,8 @@ load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
 load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
 load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
 
+package(default_visibility = ["//visibility:public"])
+
 rust_process(
     name = "logmgr",
     srcs = [
@@ -40,6 +42,7 @@ rust_process(
 rust_process(
     name = "usbmgr",
     srcs = [
+        "dfu.rs",
         "usbmgr.rs",
     ],
     codegen_crate_name = "usbmgr_codegen",
@@ -48,6 +51,7 @@ rust_process(
     tags = ["kernel"],
     visibility = ["//visibility:public"],
     deps = [
+        "//hal/blocking/flash",
         "//hal/blocking/usb:hal_usb",
         "//protocol/usb/cdc_acm",
         "//protocol/usb/dfu",
@@ -59,7 +63,6 @@ rust_process(
         "//target/earlgrey/registers:usbdev",
         "//target/earlgrey/services/sysmgr:client",
         "//target/earlgrey/util",
-        "//target/earlgrey/util:dfu",
         "//util/error",
         "//util/ipc",
         "//util/zfmt",

--- a/target/earlgrey/firmware/transport/dfu.rs
+++ b/target/earlgrey/firmware/transport/dfu.rs
@@ -1,0 +1,523 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transport Firmware Device Firmware Upgrade (DFU) handler for Earlgrey.
+//!
+//! This module implements the USB DFU protocol for the Transport Firmware on Earlgrey, supporting firmware
+//! updates (ROM_EXT and Application) and reading device certificates (UDS, CDI0, CDI1).
+
+use earlgrey_sysmgr_client::{BootInfo, SysmgrClient};
+use earlgrey_util::manifest::{
+    Manifest, MANIFEST_EXT_ID_OWNER_TRANSFER_BLOB, MANIFEST_EXT_NAME_OWNER_TRANSFER_BLOB,
+};
+use earlgrey_util::tags::BootSlot;
+use earlgrey_util::tags::ManifestIdentifier;
+use earlgrey_util::EarlgreyFlashAddress;
+use earlgrey_util::PersoCertificate;
+use hal_flash::{Flash, FlashAddress};
+use services_flash_client::FlashIpcClient;
+use util_error::ErrorCode;
+use util_ipc::IpcChannel;
+use zerocopy::FromBytes;
+
+use protocol_usb_dfu::{DfuHandler, DfuStatus};
+use zfmt::Zfmt;
+
+const FLASH_BLOCK_SIZE: usize = 2048;
+
+#[derive(Zfmt)]
+#[zfmt(format = "Flashing {region} region at {start:x}-{end:x}")]
+struct FlashingRegion {
+    region: &'static str,
+    start: u32,
+    end: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Unknown manifest ID: {id:08x}")]
+struct UnknownManifestId {
+    id: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Invalid Application Manifest! Error code: 0x{code:08x}")]
+struct InvalidAppManifest {
+    code: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Found Owner Transfer Blob at offset 0x{offset:x}")]
+struct FoundOwnerTransferBlob {
+    offset: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Owner Transfer Blob offset 0x{offset:x} out of image bounds! length={length:x}")]
+struct OwnerTransferBlobOutOfBounds {
+    offset: u32,
+    length: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Reprogrammed OWNER_PAGE_1 with Owner Transfer Blob")]
+struct ReprogrammedOwnerPage1;
+
+#[derive(Zfmt)]
+#[zfmt(format = "Reprogramming OWNER_PAGE_1 failed! Code: 0x{code:08x}")]
+struct ReprogramOwnerPage1Failed {
+    code: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "Verified Owner Transfer Blob header in flash")]
+struct VerifiedOwnerTransferHeader;
+
+#[derive(Zfmt)]
+#[zfmt(
+    format = "Owner Transfer Blob header in flash MISMATCH! Expected 0x{expected:x}, got 0x{got:x}"
+)]
+struct OwnerTransferHeaderMismatch {
+    expected: u32,
+    got: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "{dir}: alt={alt}, block={block}, len={len}")]
+struct DfuTransfer {
+    dir: &'static str,
+    alt: u8,
+    block: u16,
+    len: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "DFU Manifestation")]
+struct DfuManifest;
+
+#[derive(Zfmt)]
+#[zfmt(format = "DFU Abort")]
+struct DfuAbort;
+
+/// USB string descriptor for the Firmware DFU interface (Alt 0).
+pub const DFU_FIRMWARE: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("Firmware").as_ref();
+/// USB string descriptor for the UDS Certificate DFU interface (Alt 1).
+pub const DFU_UDS_CERT: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("UDS Certificate").as_ref();
+/// USB string descriptor for the CDI0 Certificate DFU interface (Alt 2).
+pub const DFU_CDI0_CERT: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("CDI0 Certificate").as_ref();
+/// USB string descriptor for the CDI1 Certificate DFU interface (Alt 3).
+pub const DFU_CDI1_CERT: hal_usb::StringDescriptorRef =
+    hal_usb::string_descriptor!("CDI1 Certificate").as_ref();
+
+/// Retrieves a certificate from the info partition in flash.
+///
+/// # Arguments
+///
+/// * `flash` - The flash IPC client used to read from flash.
+/// * `n` - The certificate index: 0 for UDS, 1 for CDI0, 2 for CDI1.
+/// * `data` - The buffer to write the certificate into.
+///
+/// # Returns
+///
+/// The size of the certificate in bytes, or a DFU error status.
+fn get_certificate(flash: &mut FlashIpcClient, n: u8, data: &mut [u8]) -> Result<usize, DfuStatus> {
+    util_zfmt::debug!("Reading certificate {n}");
+    let (partition, mut n) = match n {
+        0 => (0, 0), // The UDS (dice) cert is located in bank=0, page=9.
+        1 => (1, 0), // The CDI (dice) certs are located in bank=1, page=9.
+        2 => (1, 1), // CDI1 is the second cert in bank=1, page=9.
+        _ => return Err(DfuStatus::ErrFile),
+    };
+    let mut offset = 0usize;
+    let mut buf = [0u8; 1024];
+    while offset < FLASH_BLOCK_SIZE {
+        let sz = core::cmp::min(FLASH_BLOCK_SIZE - offset, buf.len());
+        flash
+            .read(
+                FlashAddress::info(partition, 9, offset as u32),
+                &mut buf[..sz],
+            )
+            .map_err(|_| DfuStatus::ErrUnknown)?;
+        match PersoCertificate::from_bytes(&buf[..sz]) {
+            Ok((cert, _)) => {
+                if n == 0 {
+                    let len = cert.certificate.len();
+                    let l = len as u32;
+                    util_zfmt::debug!("Found cert: {l} bytes");
+                    let dest = data.get_mut(..len).ok_or(DfuStatus::ErrUnknown)?;
+                    dest.copy_from_slice(cert.certificate);
+                    return Ok(len);
+                }
+                offset += (cert.obj_size + 7) & !7;
+                n -= 1;
+            }
+            Err(_) => break,
+        }
+    }
+    Err(DfuStatus::ErrUnknown)
+}
+
+/// State of the firmware update process.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FwUpdateState {
+    /// Idle, waiting for the first block of firmware.
+    Idle,
+    /// Flashing ROM_EXT.
+    RomExt,
+    /// Flashing Application.
+    Application,
+    /// Firmware download complete.
+    Done,
+}
+
+/// Helper struct to track the progress and target partitions for a firmware update.
+///
+/// It uses an A/B partitioning scheme, targeting the inactive slot.
+struct FwUpdate {
+    /// Current state of the update process.
+    state: FwUpdateState,
+    /// Next expected block number that triggers a partition erase.
+    next_erase: u32,
+    /// The block number where the current image (ROM_EXT or App) download started.
+    start_block: u32,
+    /// Target boot slot for ROM_EXT.
+    _rom_ext: BootSlot,
+    /// Start address of target ROM_EXT partition in flash.
+    rom_ext_start: u32,
+    /// End address of target ROM_EXT partition in flash.
+    rom_ext_end: u32,
+    /// Target boot slot for Application.
+    app: BootSlot,
+    /// Start address of target Application partition in flash.
+    app_start: u32,
+    /// End address of target Application partition in flash.
+    app_end: u32,
+    /// The byte offset of the Owner Transfer Blob relative to the start of the image, if found.
+    owner_transfer_offset: Option<u32>,
+    /// Whether a VALID application manifest was detected during download.
+    is_valid_app: bool,
+}
+
+impl FwUpdate {
+    /// Creates a new `FwUpdate` tracker.
+    ///
+    /// It queries the current boot info to determine the active slots,
+    /// and targets the *opposite* (inactive) slots for the update.
+    fn new(info: &BootInfo) -> Result<Self, ErrorCode> {
+        let rom_ext = info
+            .rom_ext
+            .boot_slot
+            .opposite()
+            .ok_or(earlgrey_util::error::EG_ERROR_BOOT_SLOT_UNKNOWN)?;
+        let rom_ext_start = FwUpdate::addr(rom_ext);
+        let app = info
+            .app
+            .boot_slot
+            .opposite()
+            .ok_or(earlgrey_util::error::EG_ERROR_BOOT_SLOT_UNKNOWN)?;
+        let app_start = FwUpdate::addr(app) + info.rom_ext.size;
+
+        Ok(FwUpdate {
+            state: FwUpdateState::Idle,
+            next_erase: 0,
+            start_block: 0,
+            _rom_ext: rom_ext,
+            rom_ext_start,
+            rom_ext_end: rom_ext_start + info.rom_ext.size,
+            app,
+            app_start,
+            app_end: app_start + info.app.size,
+            owner_transfer_offset: None,
+            is_valid_app: false,
+        })
+    }
+
+    /// Returns the physical flash address offset for a given boot slot.
+    fn addr(slot: BootSlot) -> u32 {
+        match slot {
+            BootSlot::SlotA => 0,
+            BootSlot::SlotB => 0x80000,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// DFU handler for Earlgrey, managing firmware updates and certificate uploads.
+pub struct EarlgreyDfuHandler<IPC: IpcChannel> {
+    flash: FlashIpcClient,
+    sysmgr: SysmgrClient<IPC>,
+    update: FwUpdate,
+}
+
+impl<IPC: IpcChannel> EarlgreyDfuHandler<IPC> {
+    /// Creates a new DFU handler.
+    pub fn new(
+        flash: FlashIpcClient,
+        sysmgr: SysmgrClient<IPC>,
+        info: &BootInfo,
+    ) -> Result<Self, ErrorCode> {
+        Ok(EarlgreyDfuHandler {
+            flash,
+            sysmgr,
+            update: FwUpdate::new(info)?,
+        })
+    }
+
+    /// Erases the flash partition from `start` to `end` address (exclusive).
+    ///
+    /// The erase is performed page-by-page.
+    fn flash_erase(&mut self, mut start: u32, end: u32) -> Result<(), ErrorCode> {
+        let (_, page_size, _) = self.flash.geometry()?;
+        while start < end {
+            self.flash.erase(FlashAddress::data(start), page_size)?;
+            start += page_size.get() as u32;
+        }
+        Ok(())
+    }
+
+    /// Erases a single flash page (data or info).
+    fn flash_erase_page(&mut self, addr: FlashAddress) -> Result<(), ErrorCode> {
+        let (_, page_size, _) = self.flash.geometry()?;
+        self.flash.erase(addr, page_size)
+    }
+
+    /// Handles writing a block of firmware to flash.
+    ///
+    /// This function handles:
+    /// 1. Detecting the type of image (ROM_EXT or Application) from the manifest in the first block.
+    /// 2. Erasing the target partition upon receiving the first block.
+    /// 3. Programming subsequent blocks into the target partition.
+    /// 4. Transitioning the state to `Done` when a short block (less than 2048 bytes) is received.
+    fn flash_fw_block(&mut self, block_num: u32, data: &[u8]) -> Result<(), DfuStatus> {
+        if block_num == self.update.next_erase {
+            // Sized appropriately by transfer_size Functional Descriptor (2048 bytes).
+            // Use read_from_prefix to safely parse unaligned DFU buffer into naturally aligned stack variable.
+            let (manifest, _) =
+                Manifest::read_from_prefix(data).map_err(|_| DfuStatus::ErrFirmware)?;
+
+            if let Err(e) = manifest.check() {
+                util_zfmt::error!(InvalidAppManifest { code: e.0 });
+                return Err(DfuStatus::ErrFirmware);
+            }
+
+            match manifest.identifier {
+                ManifestIdentifier::ROM_EXT => {
+                    util_zfmt::info!(FlashingRegion {
+                        region: "ROM_EXT",
+                        start: self.update.rom_ext_start,
+                        end: self.update.rom_ext_end,
+                    });
+                    self.flash_erase(self.update.rom_ext_start, self.update.rom_ext_end)
+                        .map_err(|_| DfuStatus::ErrErase)?;
+                    self.update.state = FwUpdateState::RomExt;
+                    self.update.next_erase = (self.update.rom_ext_end - self.update.rom_ext_start)
+                        / (FLASH_BLOCK_SIZE as u32);
+                    self.update.start_block = block_num;
+                    self.update.is_valid_app = false;
+                    self.update.owner_transfer_offset = None;
+                }
+                ManifestIdentifier::APPLICATION => {
+                    util_zfmt::info!(FlashingRegion {
+                        region: "Application",
+                        start: self.update.app_start,
+                        end: self.update.app_end,
+                    });
+                    self.flash_erase(self.update.app_start, self.update.app_end)
+                        .map_err(|_| DfuStatus::ErrErase)?;
+                    self.update.state = FwUpdateState::Application;
+                    self.update.start_block = block_num;
+                    self.update.is_valid_app = true;
+
+                    // Scan extension table for Owner Transfer Blob
+                    let mut owner_transfer_offset = None;
+                    for entry in &manifest.extensions.entries {
+                        if entry.identifier == MANIFEST_EXT_ID_OWNER_TRANSFER_BLOB {
+                            let offset = entry.offset;
+                            // Ensure the entire fixed part of the extension (Header + 2048 byte blob)
+                            // fits within the reported image length.
+                            const EXT_FIXED_SIZE: usize = 8 + 2048;
+                            if offset >= 1024
+                                && (offset as usize + EXT_FIXED_SIZE) <= (manifest.length as usize)
+                            {
+                                owner_transfer_offset = Some(offset);
+                                util_zfmt::info!(FoundOwnerTransferBlob { offset });
+                            } else {
+                                util_zfmt::error!(OwnerTransferBlobOutOfBounds {
+                                    offset,
+                                    length: manifest.length
+                                });
+                                return Err(DfuStatus::ErrFirmware);
+                            }
+                            break;
+                        }
+                    }
+                    self.update.owner_transfer_offset = owner_transfer_offset;
+                }
+                _ => {
+                    util_zfmt::error!(UnknownManifestId {
+                        id: manifest.identifier.0 as u32
+                    });
+                    return Err(DfuStatus::ErrUnknown);
+                }
+            }
+        }
+
+        let block = block_num - self.update.start_block;
+        match self.update.state {
+            FwUpdateState::RomExt => {
+                let address = self.update.rom_ext_start + block * (FLASH_BLOCK_SIZE as u32);
+                if address + data.len() as u32 > self.update.rom_ext_end {
+                    return Err(DfuStatus::ErrAddress);
+                }
+                self.flash
+                    .program(FlashAddress::data(address), data)
+                    .map_err(|_| DfuStatus::ErrProg)?;
+            }
+            FwUpdateState::Application => {
+                let address = self.update.app_start + block * (FLASH_BLOCK_SIZE as u32);
+                if address + data.len() as u32 > self.update.app_end {
+                    return Err(DfuStatus::ErrAddress);
+                }
+                self.flash
+                    .program(FlashAddress::data(address), data)
+                    .map_err(|_| DfuStatus::ErrProg)?;
+            }
+            _ => {
+                return Err(DfuStatus::ErrUnknown);
+            }
+        }
+
+        if data.len() < FLASH_BLOCK_SIZE {
+            self.update.state = FwUpdateState::Done;
+        }
+        Ok(())
+    }
+}
+
+impl<IPC: IpcChannel> DfuHandler for EarlgreyDfuHandler<IPC> {
+    /// Handles a DFU download (DNLOAD) request.
+    ///
+    /// Accepts firmware blocks on Alt setting 0.
+    fn dnload(&mut self, alt: u8, block_num: u16, data: &[u8]) -> Result<(), DfuStatus> {
+        util_zfmt::info!(DfuTransfer {
+            dir: "DNLOAD",
+            alt,
+            block: block_num,
+            len: data.len() as u32,
+        });
+        if alt == 0 {
+            self.flash_fw_block(block_num as u32, data)
+        } else {
+            Err(DfuStatus::ErrFile)
+        }
+    }
+
+    /// Handles a DFU upload (UPLOAD) request.
+    ///
+    /// Returns device certificates on Alt settings 1, 2, and 3.
+    fn upload(&mut self, alt: u8, block_num: u16, data: &mut [u8]) -> Result<usize, DfuStatus> {
+        util_zfmt::info!(DfuTransfer {
+            dir: "UPLOAD",
+            alt,
+            block: block_num,
+            len: data.len() as u32,
+        });
+        match alt {
+            1 | 2 | 3 => get_certificate(&mut self.flash, alt - 1, data),
+            _ => Err(DfuStatus::ErrFile),
+        }
+    }
+
+    /// Handles DFU manifestation.
+    ///
+    /// If the firmware update succeeded, updates the boot policy to prefer the new
+    /// slot and requests a reboot.
+    fn manifest(&mut self) -> Result<(), DfuStatus> {
+        util_zfmt::info!(DfuManifest);
+        if self.update.state == FwUpdateState::Done
+            || self.update.state == FwUpdateState::Application
+            || self.update.state == FwUpdateState::RomExt
+        {
+            // Specialized Transport DFU Logic: Reprogram OWNER_PAGE_1 with Ownership Config
+            if self.update.is_valid_app {
+                if let Some(offset) = self.update.owner_transfer_offset {
+                    // 1. Read header from programmed flash to verify it's indeed the 'OWTB' extension
+                    let header_addr = FlashAddress::data(self.update.app_start + offset);
+                    let mut header_buf = [0u8; 8];
+                    self.flash
+                        .read(header_addr, &mut header_buf)
+                        .map_err(|_| DfuStatus::ErrUnknown)?;
+                    let id = u32::read_from_prefix(&header_buf[0..4])
+                        .map(|(id, _)| id)
+                        .map_err(|_| DfuStatus::ErrFirmware)?;
+                    if id != MANIFEST_EXT_ID_OWNER_TRANSFER_BLOB {
+                        util_zfmt::error!(OwnerTransferHeaderMismatch {
+                            expected: MANIFEST_EXT_ID_OWNER_TRANSFER_BLOB,
+                            got: id,
+                        });
+                        return Err(DfuStatus::ErrFirmware);
+                    }
+                    let name = u32::read_from_prefix(&header_buf[4..8])
+                        .map(|(n, _)| n)
+                        .map_err(|_| DfuStatus::ErrFirmware)?;
+                    if name != MANIFEST_EXT_NAME_OWNER_TRANSFER_BLOB {
+                        util_zfmt::error!(OwnerTransferHeaderMismatch {
+                            expected: MANIFEST_EXT_NAME_OWNER_TRANSFER_BLOB,
+                            got: name,
+                        });
+                        return Err(DfuStatus::ErrFirmware);
+                    }
+                    util_zfmt::info!(VerifiedOwnerTransferHeader);
+
+                    // 2. Erase OWNER_PAGE_1 (Bank 1, Page 3)
+                    // Permissions were pre-configured by ROM_EXT per user request guidelines.
+                    let owner_page_1 = FlashAddress::info(1, 3, 0);
+                    self.flash_erase_page(owner_page_1).map_err(|e| {
+                        util_zfmt::error!(ReprogramOwnerPage1Failed {
+                            code: u32::from(e) as u32
+                        });
+                        DfuStatus::ErrErase
+                    })?;
+
+                    // 3. Program OWNER_PAGE_1 in 32 iterations of 64 bytes
+                    const CHUNK_SIZE: usize = 64;
+                    let mut chunk_buf = [0u8; CHUNK_SIZE];
+                    for chunk_idx in 0..(FLASH_BLOCK_SIZE / CHUNK_SIZE) {
+                        let chunk_offset = (chunk_idx * CHUNK_SIZE) as u32;
+                        let src_addr =
+                            FlashAddress::data(self.update.app_start + offset + 8 + chunk_offset);
+                        self.flash
+                            .read(src_addr, &mut chunk_buf)
+                            .map_err(|_| DfuStatus::ErrUnknown)?;
+
+                        let dest_addr = FlashAddress::info(1, 3, chunk_offset);
+                        self.flash.program(dest_addr, &chunk_buf).map_err(|e| {
+                            util_zfmt::error!(ReprogramOwnerPage1Failed {
+                                code: u32::from(e) as u32
+                            });
+                            DfuStatus::ErrProg
+                        })?;
+                    }
+                    util_zfmt::info!(ReprogrammedOwnerPage1);
+                }
+            }
+
+            // TODO: check for errors.
+            let _ = self
+                .sysmgr
+                .set_boot_policy(earlgrey_sysmgr_client::BootPolicy {
+                    pref_slot: self.update.app,
+                    next_slot: BootSlot::Unspecified,
+                });
+            let _ = self.sysmgr.request_reboot();
+        }
+        Ok(())
+    }
+
+    /// Handles DFU abort.
+    fn abort(&mut self) {
+        util_zfmt::info!(DfuAbort);
+    }
+}

--- a/target/earlgrey/firmware/transport/tests/dfu/BUILD.bazel
+++ b/target/earlgrey/firmware/transport/tests/dfu/BUILD.bazel
@@ -1,0 +1,103 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY")
+load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+load("//target/earlgrey/tooling/signing:defs.bzl", "manifest", "sign_bin")
+load("//third_party/lowrisc_opentitan:defs.bzl", "opentitan_rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+manifest(
+    name = "owner_transfer_manifest",
+    identifier = "0x3042544f",  # "OTB0"
+    owner_transfer_block = "//target/earlgrey/signing/keys/dummy:dummy_owner_bin",
+    owner_transfer_detached_signature = "//target/earlgrey/signing/keys/dummy:dummy_owner_sig",
+    visibility = ["//visibility:public"],
+)
+
+sign_bin(
+    name = "bootinfo_signed_transfer",
+    basename = "bootinfo_transfer",
+    bin = "//target/earlgrey/tests/bootinfo:bootinfo_image",
+    #ecdsa_key = FPGA_ECDSA_KEY,
+    ecdsa_key = {
+        "//target/earlgrey/signing/keys/dummy:ecdsa_keyset": "app_prod_0",
+    },
+    manifest = ":owner_transfer_manifest",
+)
+
+sign_bin(
+    name = "bootinfo_signed_simple",
+    basename = "bootinfo_simple",
+    bin = "//target/earlgrey/tests/bootinfo:bootinfo_image",
+    ecdsa_key = FPGA_ECDSA_KEY,
+)
+
+opentitan_rust_binary(
+    name = "host_usb_dfu_owner_transfer",
+    srcs = ["host_usb_dfu_owner_transfer.rs"],
+    data = [
+        #    ":bootinfo_signed_transfer",
+        #    ":bootinfo_signed_simple",
+    ],
+    edition = "2024",
+    rustc_flags = [
+        "-C",
+        "link-arg=-Wl,--allow-shlib-undefined",
+    ],
+    deps = [
+        "//target/earlgrey/testutil",
+        "//third_party/lowrisc_opentitan:opentitanlib",
+        "//third_party/lowrisc_opentitan:usb_test_helper",
+        "@ot_crate_index//:anyhow",
+        "@ot_crate_index//:clap",
+        "@ot_crate_index//:log",
+        "@ot_crate_index//:zerocopy",
+    ],
+)
+
+manifest(
+    name = "transport_app_manifest",
+    address_translation = "0x739",
+)
+
+opentitan_test(
+    name = "dfu_owner_transfer_hyper310_test",
+    timeout = "eternal",
+    clear_bitstream = True,
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper310",
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = "//target/earlgrey/firmware/transport:transport_firmware",
+    target_data = [
+        ":bootinfo_signed_transfer",
+        ":bootinfo_signed_simple",
+    ],
+    test_cmd = "--logging=info --expect-reboot --expect-app --expect-owner-transfer --firmware=target/earlgrey/firmware/transport/tests/dfu/bootinfo_transfer.app_prod_0.signed.bin",
+    test_harness = ":host_usb_dfu_owner_transfer",
+)
+
+opentitan_test(
+    name = "dfu_firmware_update_hyper310_test",
+    timeout = "eternal",
+    clear_bitstream = True,
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper310",
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = "//target/earlgrey/firmware/transport:transport_firmware",
+    target_data = [
+        ":bootinfo_signed_transfer",
+        ":bootinfo_signed_simple",
+    ],
+    test_cmd = "--logging=info --expect-reboot --expect-app --firmware=target/earlgrey/firmware/transport/tests/dfu/bootinfo_simple.app_prod_0.signed.bin",
+    test_harness = ":host_usb_dfu_owner_transfer",
+)

--- a/target/earlgrey/firmware/transport/tests/dfu/host_usb_dfu_owner_transfer.rs
+++ b/target/earlgrey/firmware/transport/tests/dfu/host_usb_dfu_owner_transfer.rs
@@ -1,0 +1,184 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use std::time::Duration;
+
+use earlgrey_testutil::{get_dfu_transfer_size, print_uart, sequence_dfu_download, DfuClient};
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+use usb::UsbOpts;
+
+#[derive(Parser, Debug)]
+struct CmdArgs {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    #[command(flatten)]
+    usb: UsbOpts,
+
+    #[arg(
+        long,
+        default_value = "target/earlgrey/firmware/transport/tests/dfu/bootinfo_transfer.app_prod_0.signed.bin"
+    )]
+    firmware: String,
+
+    #[arg(long, default_value = "false")]
+    expect_reboot: bool,
+
+    #[arg(long, default_value = "false")]
+    expect_app: bool,
+
+    #[arg(long, default_value = "false")]
+    expect_owner_transfer: bool,
+}
+
+fn run_dfu_owner_transfer_test(
+    transport: &TransportWrapper,
+    usb: &UsbOpts,
+    firmware_path: &str,
+    expect_reboot: bool,
+    expect_app: bool,
+    expect_owner_transfer: bool,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+
+    log::info!("Resetting target...");
+    transport.reset(opentitanlib::app::UartRx::Clear)?;
+
+    log::info!("waiting for Maize Welcome on console...");
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Welcome to Maize on Earlgrey Transport Firmware!",
+        Duration::from_secs(10),
+    )?;
+
+    usb.apply_strappings(transport, true)?;
+    if usb.vbus_control_available() {
+        usb.enable_vbus(transport, true)?;
+    }
+    if usb.vbus_sense_available() {
+        if !usb.vbus_present(transport)? {
+            bail!("OT USB does not appear to be connected to a host (VBUS not detected)");
+        }
+    }
+
+    let usb_vid = usb.vid;
+    let usb_pid = usb.pid;
+
+    log::info!(
+        "waiting for DFU device (VID={:04x}, PID={:04x})...",
+        usb_vid,
+        usb_pid
+    );
+    let device = transport
+        .usb()?
+        .device_by_id_with_timeout(usb_vid, usb_pid, None, Duration::from_secs(10))
+        .context("DFU device not found")?;
+
+    log::info!("Claiming DFU interface...");
+    let interface_num = 2;
+    device.claim_interface(interface_num)?;
+
+    let transfer_size = get_dfu_transfer_size(&*device, interface_num)?;
+    log::info!("DFU Transfer Size (Block Size): {} bytes", transfer_size);
+
+    let dfu = DfuClient::new(&*device, interface_num);
+
+    log::info!(
+        "Reading Application firmware payload from '{}'...",
+        firmware_path
+    );
+    let test_data = std::fs::read(firmware_path)?;
+
+    log::info!(
+        "Sequencing DFU Download (expect_reboot = {})...",
+        expect_reboot
+    );
+    // Pass the actual expect_reboot variable to the test utility.
+    sequence_dfu_download(&dfu, &*uart, &test_data, transfer_size, expect_reboot)?;
+
+    if expect_reboot {
+        if expect_app {
+            log::info!("Waiting for Application Execution telemetry on UART...");
+            if expect_owner_transfer {
+                let _ = UartConsole::wait_for(
+                    &*uart,
+                    r"ownership_transfers: 1",
+                    Duration::from_secs(20),
+                )
+                .context("Failed to detect ownership_transfers: 1 in UART telemetry!")?;
+                log::info!("✅ Detected ownership_transfers: 1");
+
+                let _ = UartConsole::wait_for(&*uart, r"config_version: 1", Duration::from_secs(5))
+                    .context("Failed to detect config_version: 1 in UART telemetry!")?;
+                log::info!("✅ Detected config_version: 1");
+
+                let _ = UartConsole::wait_for(
+                    &*uart,
+                    r"update_mode: SELV \(0x564c4553\)",
+                    Duration::from_secs(5),
+                )
+                .context("Failed to detect update_mode: SELV in UART telemetry!")?;
+                log::info!("✅ Detected update_mode: SELV (0x564c4553)");
+            } else {
+                let _ = UartConsole::wait_for(
+                    &*uart,
+                    r"ownership_transfers: 0",
+                    Duration::from_secs(20),
+                )
+                .context("Failed to detect ownership_transfers: 0 in UART telemetry!")?;
+                log::info!("✅ Detected ownership_transfers: 0");
+
+                let _ = UartConsole::wait_for(&*uart, r"config_version: 1", Duration::from_secs(5))
+                    .context("Failed to detect config_version: 1 in UART telemetry!")?;
+                log::info!("✅ Detected config_version: 1");
+
+                let _ = UartConsole::wait_for(
+                    &*uart,
+                    r"update_mode: ANYV \(0x56594e41\)",
+                    Duration::from_secs(5),
+                )
+                .context("Failed to detect update_mode: ANYV in UART telemetry!")?;
+                log::info!("✅ Detected update_mode: ANYV (0x56594e41)");
+            }
+
+            let _ =
+                UartConsole::wait_for(&*uart, r"✅ PASSED bootinfo test", Duration::from_secs(5))
+                    .context("Failed to detect ✅ PASSED bootinfo test in UART telemetry!")?;
+            log::info!("✅ Detected 'PASSED bootinfo test'!");
+        } else {
+            log::info!("Waiting for Transport firmware reboot (no ownership transfer)...");
+            // Because no ownership transfer occurs, manifestation just reboots back into our Transport Firmware DFU server!
+            let _ = UartConsole::wait_for(
+                &*uart,
+                r"Welcome to Maize on Earlgrey Transport Firmware!",
+                Duration::from_secs(10),
+            )?;
+            log::info!("✅ Transport DFU Server rebooted successfully!");
+        }
+    }
+
+    print_uart(&*uart);
+    let _ = device.release_interface(interface_num);
+    log::info!("Test Execution Finished Successfully!");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = CmdArgs::parse();
+    args.init.init_logging();
+
+    let transport = args.init.init_target()?;
+    run_dfu_owner_transfer_test(
+        &transport,
+        &args.usb,
+        &args.firmware,
+        args.expect_reboot,
+        args.expect_app,
+        args.expect_owner_transfer,
+    )?;
+    Ok(())
+}

--- a/target/earlgrey/firmware/transport/tests/dfu/spec.md
+++ b/target/earlgrey/firmware/transport/tests/dfu/spec.md
@@ -1,0 +1,29 @@
+# Transport firmware tests
+
+The first tests we'll implement are DFU firmware-update and ownership transfer
+tests.  These tests will use DFU to upload a signed version of our own
+`//target/earlgrey/tests/bootinfo` binary signed with a dummy key.  There will
+be two versions of this test:
+- One version will contain an ownership transfer configuration and we'll expect
+  the boot the boot_test after DFU manifestation.
+- One version will not contain an ownership transfer configuration and we'll
+  expect to reboot and restart the transport firmware.
+
+We will need to update our signing rules.  Examine the changes
+to rules/signing.bzl and rules/manifest.bzl in opentitan repo
+commit 43dd42d68d52ea8a6d930b66ccf3db491a64ac88.  We'll want to
+modify our signing rules (or write new rule) to accomplish the same type of
+manifest header manipulation in this code base.
+
+We will need to create keys for the `dummy` owner.  We can copy the keys
+from the opentitan repo in `sw/device/silicon_creator/lib/ownership/keys/dummy`.
+We'll place a local copy in //target/earlgrey/signing/keys/dummy.
+
+This is a complex test that involves sequencing firmware updates to the device
+under test.  As such, we should write a test harness.
+We'll examine our own DFU test in //target/earlgrey/tests/usbdfu/host_usb_dfu_check.rs.
+The test should load the transport firmware (probably via the bazel
+opentitan_test rule), then use the test harness to sequence the DFU update and
+examine console output to look for pass/fail criterial.  Consider refactoring
+host_usb_dfu_check.rs to refactor out reusable components (like the DFU
+implementation) into target/earlgrey/testutil.

--- a/target/earlgrey/firmware/transport/usbmgr.rs
+++ b/target/earlgrey/firmware/transport/usbmgr.rs
@@ -28,7 +28,8 @@ use hal_usb::{ConfigDescriptor, DeviceDescriptor, SetupPacket, StringDescriptorR
 use usb_driver::UsbConfig;
 use usb_stack::{DescriptorSource, UsbAction, UsbClass};
 
-use earlgrey_dfu::{EarlgreyDfuHandler, DFU_CDI0_CERT, DFU_CDI1_CERT, DFU_FIRMWARE, DFU_UDS_CERT};
+mod dfu;
+use dfu::{EarlgreyDfuHandler, DFU_CDI0_CERT, DFU_CDI1_CERT, DFU_FIRMWARE, DFU_UDS_CERT};
 use earlgrey_sysmgr_client::SysmgrClient;
 use protocol_usb_cdc_acm::{CdcAcm, CdcAcmBuilder};
 use protocol_usb_dfu::{DfuBuilder, DfuClass};

--- a/target/earlgrey/testutil/BUILD.bazel
+++ b/target/earlgrey/testutil/BUILD.bazel
@@ -1,0 +1,21 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("//third_party/lowrisc_opentitan:defs.bzl", "opentitan_rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+opentitan_rust_library(
+    name = "testutil",
+    srcs = [
+        "lib.rs",
+    ],
+    crate_name = "earlgrey_testutil",
+    edition = "2024",
+    deps = [
+        "//third_party/lowrisc_opentitan:opentitanlib",
+        "@ot_crate_index//:anyhow",
+        "@ot_crate_index//:log",
+        "@ot_crate_index//:zerocopy",
+    ],
+)

--- a/target/earlgrey/testutil/lib.rs
+++ b/target/earlgrey/testutil/lib.rs
@@ -1,0 +1,167 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, bail, Result};
+use std::time::Duration;
+use zerocopy::FromBytes;
+
+use opentitanlib::io::console::ConsoleExt;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::io::usb::UsbDevice;
+use opentitanlib::rescue::dfu::{DfuRequest, DfuRequestType, DfuState, DfuStatus};
+
+const DFU_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct DfuClient<'a> {
+    pub device: &'a dyn UsbDevice,
+    pub interface: u8,
+}
+
+impl<'a> DfuClient<'a> {
+    pub fn new(device: &'a dyn UsbDevice, interface: u8) -> Self {
+        Self { device, interface }
+    }
+
+    pub fn write_control(&self, request: DfuRequest, value: u16, data: &[u8]) -> Result<usize> {
+        self.device.write_control_timeout(
+            DfuRequestType::Out.into(),
+            request.into(),
+            value,
+            self.interface as u16,
+            data,
+            DFU_TIMEOUT,
+        )
+    }
+
+    pub fn read_control(&self, request: DfuRequest, value: u16, data: &mut [u8]) -> Result<usize> {
+        self.device.read_control_timeout(
+            DfuRequestType::In.into(),
+            request.into(),
+            value,
+            self.interface as u16,
+            data,
+            DFU_TIMEOUT,
+        )
+    }
+
+    pub fn download(&self, block_num: u16, data: &[u8]) -> Result<usize> {
+        self.write_control(DfuRequest::DnLoad, block_num, data)
+    }
+
+    pub fn upload(&self, block_num: u16, data: &mut [u8]) -> Result<usize> {
+        self.read_control(DfuRequest::UpLoad, block_num, data)
+    }
+
+    pub fn get_status(&self) -> Result<DfuStatus> {
+        let mut buf = [0u8; 6];
+        self.read_control(DfuRequest::GetStatus, 0, &mut buf)?;
+        DfuStatus::read_from_bytes(&buf).map_err(|e| anyhow!("Failed to parse DfuStatus: {:?}", e))
+    }
+
+    pub fn clear_status(&self) -> Result<()> {
+        self.write_control(DfuRequest::ClrStatus, 0, &[])?;
+        Ok(())
+    }
+
+    pub fn abort(&self) -> Result<()> {
+        self.write_control(DfuRequest::Abort, 0, &[])?;
+        Ok(())
+    }
+
+    pub fn wait_state(&self, expected: DfuState, uart: &dyn Uart) -> Result<DfuStatus> {
+        loop {
+            print_uart(uart);
+            let status = self.get_status()?;
+            log::debug!(
+                "DFU State: {:?}, Status: {:?}",
+                status.state(),
+                status.status()
+            );
+            if status.state() == expected {
+                return Ok(status);
+            }
+            if status.state() == DfuState::Error {
+                bail!("DFU entered Error state: {:?}", status.status());
+            }
+            let delay = Duration::from_millis(status.poll_timeout() as u64);
+            std::thread::sleep(delay);
+        }
+    }
+}
+
+pub fn print_uart(uart: &dyn Uart) {
+    if !log::log_enabled!(log::Level::Info) {
+        return;
+    }
+    let mut buf = [0u8; 256];
+    while let Ok(n) = uart.read_timeout(&mut buf, Duration::ZERO) {
+        if n == 0 {
+            break;
+        }
+        use std::io::Write;
+        let _ = std::io::stdout().write_all(&buf[..n]);
+        let _ = std::io::stdout().flush();
+    }
+}
+
+pub fn get_dfu_transfer_size(device: &dyn UsbDevice, interface_num: u8) -> Result<u16> {
+    let config = device.active_configuration()?;
+    for intf in config.interface_alt_settings() {
+        let desc = intf.descriptor()?;
+        if desc.intf_num == interface_num {
+            for subdesc in intf.subdescriptors() {
+                if subdesc.len() >= 7 && subdesc[1] == 0x21 {
+                    let transfer_size = u16::from_le_bytes([subdesc[5], subdesc[6]]);
+                    return Ok(transfer_size);
+                }
+            }
+        }
+    }
+    bail!("DFU functional descriptor not found");
+}
+
+pub fn sequence_dfu_download(
+    dfu: &DfuClient,
+    uart: &dyn Uart,
+    data: &[u8],
+    transfer_size: u16,
+    expect_reboot: bool,
+) -> Result<()> {
+    // Ensure we start from a clean state
+    let status = dfu.get_status()?;
+    if status.state() == DfuState::Error {
+        log::info!("Clearing DFU error status...");
+        dfu.clear_status()?;
+    }
+
+    log::info!("Starting DFU download...");
+    let mut block_num = 0;
+    for chunk in data.chunks(transfer_size as usize) {
+        log::debug!("Sending block {}, size {}...", block_num, chunk.len());
+        dfu.download(block_num, chunk)?;
+        dfu.wait_state(DfuState::DnLoadIdle, uart)?;
+        block_num += 1;
+    }
+
+    log::info!("Signaling end of download (ZLP)...");
+    dfu.download(block_num, &[])?;
+
+    log::info!("Triggering Manifestation (GET_STATUS)...");
+    let manifest_res = dfu.get_status();
+
+    if expect_reboot {
+        log::info!(
+            "Waiting for manifestation-induced reboot (USB status OK: {})...",
+            manifest_res.is_ok()
+        );
+        std::thread::sleep(Duration::from_secs(4));
+        log::info!("Manifestation complete (Device Rebooted)!");
+    } else {
+        manifest_res?;
+        log::info!("Waiting for manifestation to complete...");
+        dfu.wait_state(DfuState::Idle, uart)?;
+        log::info!("Download complete!");
+    }
+    // Removed print_uart(uart) to preserve telemetry for the test harness.
+    Ok(())
+}

--- a/target/earlgrey/tooling/BUILD.bazel
+++ b/target/earlgrey/tooling/BUILD.bazel
@@ -10,7 +10,7 @@ package(default_visibility = ["//target/earlgrey:__subpackages__"])
 
 pw_py_importable_runfile(
     name = "opentitantool-runfiles",
-    src = "//third_party/lowrisc_opentitan:opentitantool",
+    src = "@opentitan_devbundle//:opentitantool/opentitantool",
     executable = True,
     import_location = "opentitan.opentitantool",
 )
@@ -36,13 +36,13 @@ pw_py_importable_runfile(
 
 pw_py_importable_runfile(
     name = "rom_ext_cw310-runfiles",
-    src = "@opentitan_devbundle//:rom_ext/rom_ext_dice_x509_slot_virtual_fpga_cw310.prod_key_0.prod_key_0.signed.bin",
+    src = "@opentitan_devbundle//:rom_ext/rom_ext_usbdfu_anyversion_fpga_cw310.prod_key_0.signed.bin",
     import_location = "opentitan.rom_ext_cw310",
 )
 
 pw_py_importable_runfile(
     name = "rom_ext_cw340-runfiles",
-    src = "@opentitan_devbundle//:rom_ext/rom_ext_dice_x509_slot_virtual_fpga_cw340.prod_key_0.prod_key_0.signed.bin",
+    src = "@opentitan_devbundle//:rom_ext/rom_ext_usbdfu_anyversion_fpga_cw340.prod_key_0.signed.bin",
     import_location = "opentitan.rom_ext_cw340",
 )
 

--- a/target/earlgrey/tooling/opentitan_runner.bzl
+++ b/target/earlgrey/tooling/opentitan_runner.bzl
@@ -270,7 +270,8 @@ _BASE_ATTRS = {
         executable = True,
         allow_single_file = True,
         cfg = "exec",
-        default = "//third_party/lowrisc_opentitan:opentitantool",
+        # TODO: update to opentitantool on master when everything is merged over.
+        default = "@opentitan_devbundle//:opentitantool/opentitantool",
         doc = "opentitantool",
     ),
 }


### PR DESCRIPTION
- Move the DFU module into the transport firmware and customize is for the transport firmware use case.
- Detect an ownership transfer blob in the firmware payload.
- Sequence an ownership transfer if the ownership blob is present.
- Add tests.