### PR TITLE
earlgrey: refactor gpio and pinmux drivers 

### DIFF
--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -30,6 +30,9 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "//target/earlgrey/registers",
+        "//target/earlgrey/registers:top_earlgrey",
+        "//target/earlgrey/util/error",
+        "//util/error",
         "@ureg",
     ],
 )

--- a/target/earlgrey/drivers/gpio.rs
+++ b/target/earlgrey/drivers/gpio.rs
@@ -4,7 +4,7 @@
 #![no_std]
 
 use core::fmt::Debug;
-use earlgrey_pinmux::{EarlGreyPinmux, Pad, PadConfig, Pull};
+use earlgrey_pinmux::{EarlGreyPinmux, Outsel, Pad, PadConfig, PeriphIn, Pull};
 use earlgrey_util_error::gpio::{EG_GPIO, EG_GPIO_INVALID_CONFIGURATION};
 use openprot_hal_blocking::gpio_port::{
     EdgeSensitivity, GpioError, GpioErrorKind, GpioErrorType, GpioInterrupt, GpioPort,
@@ -27,7 +27,7 @@ impl GpioError for EarlGreyGpioError {
 
 pub struct EarlGreyGpio {
     registers: gpio::RegisterBlock<ureg::RealMmioMut<'static>>,
-    pinmux: EarlGreyPinmux,
+    pub pinmux: EarlGreyPinmux,
 }
 
 impl EarlGreyGpio {
@@ -94,6 +94,8 @@ impl PinMask for GpioMask {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+#[rustfmt::skip]
 pub enum GpioPin {
     Pin0 = 0,
     Pin1 = 1,
@@ -127,6 +129,60 @@ pub enum GpioPin {
     Pin29 = 29,
     Pin30 = 30,
     Pin31 = 31,
+}
+
+impl GpioPin {
+    /// Convert a GpioPin to its PeriphIn value.
+    pub const fn as_periph(self) -> PeriphIn {
+        // This should really be a trait, but rust currently doesn't have const functions in traits.
+        // Gpios for PeriphIn are [0..31].
+        // nosemgrep
+        unsafe {
+            // SAFETY: The Gpio value range is [0..31] and is valid as PeriphIn.
+            // We should really use PeriphIn::try_from, but that isn't available in const context.
+            core::mem::transmute::<u32, PeriphIn>(self as u32)
+        }
+    }
+
+    /// Convert a GpioPin to its OutSel selector value.
+    pub const fn as_outsel(self) -> Outsel {
+        // This should really be a trait, but rust currently doesn't have const functions in traits.
+        // Gpios for Outsel are [3..34].
+        // nosemgrep
+        unsafe {
+            // SAFETY: The Gpio value range is [0..31] and is valid (plus 3) as Outsel.
+            // We should really use Outsel::try_from, but that isn't available in const context.
+            core::mem::transmute::<u32, Outsel>(self as u32 + 3)
+        }
+    }
+}
+
+impl From<GpioPin> for PeriphIn {
+    fn from(pin: GpioPin) -> PeriphIn {
+        pin.as_periph()
+    }
+}
+
+impl From<GpioPin> for Outsel {
+    fn from(pin: GpioPin) -> Outsel {
+        pin.as_outsel()
+    }
+}
+
+impl TryFrom<u32> for GpioPin {
+    type Error = ();
+    fn try_from(p: u32) -> Result<Self, Self::Error> {
+        if (0..32).contains(&p) {
+            Ok(unsafe { core::mem::transmute::<u32, GpioPin>(p) })
+        } else {
+            Err(())
+        }
+    }
+}
+impl From<GpioPin> for u32 {
+    fn from(pin: GpioPin) -> Self {
+        pin as u32
+    }
 }
 
 impl From<GpioPin> for GpioMask {
@@ -200,16 +256,18 @@ impl GpioPort for EarlGreyGpio {
 
         // Handle Pinmux and Pad attributes
         if let Some(pad) = config.pad {
-            let pin_idx = pins.0.trailing_zeros() as usize;
+            let pin_idx = pins.0.trailing_zeros();
+            let gpio_pin = GpioPin::try_from(pin_idx).map_err(|_| EG_GPIO_INVALID_CONFIGURATION)?;
 
             // DIO pads are dedicated and don't require routing,
             // only attribute configuration.
             if !pad.is_dio() {
                 if config.is_input {
-                    self.pinmux.connect_input(pin_idx, pad);
+                    self.pinmux.connect_input(gpio_pin.into(), pad)?;
                 }
                 if config.is_output {
-                    self.pinmux.connect_output(pad, pin_idx);
+                    // The output selector for GPIO pins starts at index 3.
+                    self.pinmux.connect_output(pad, gpio_pin.into())?;
                 }
             }
 
@@ -219,7 +277,7 @@ impl GpioPort for EarlGreyGpio {
                     pull: config.pull,
                     ..Default::default()
                 },
-            );
+            )?;
         }
 
         Ok(())

--- a/target/earlgrey/drivers/pinmux.rs
+++ b/target/earlgrey/drivers/pinmux.rs
@@ -3,11 +3,20 @@
 
 #![no_std]
 
+use earlgrey_util_error::pinmux::{
+    EG_PINMUX_INVALID_INPUT, EG_PINMUX_INVALID_OUTPUT, EG_PINMUX_INVALID_PAD,
+};
 use registers::pinmux;
+pub use top_earlgrey::{PinmuxOutsel as Outsel, PinmuxPeripheralIn as PeriphIn};
+use util_error::ErrorCode;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
+#[repr(i32)]
+#[rustfmt::skip]
 pub enum Pad {
+    // Constant Values
+    ConstantZero = -2,
+    ConstantOne = -1,
     // MIO Pads (0-46)
     IOA0 = 0,
     IOA1 = 1,
@@ -76,14 +85,39 @@ pub enum Pad {
 }
 
 impl Pad {
+    const NUM_MIO_PADS: i32 = top_earlgrey::NUM_MIO_PADS as i32;
+
+    /// Is this a direct IO pad?
     pub fn is_dio(&self) -> bool {
-        (*self as u32) >= 47
+        (*self as i32) >= Self::NUM_MIO_PADS
     }
 
+    /// Get the direct IO index of this pad.
     pub fn dio_index(self) -> Option<usize> {
-        let index = self as usize;
-        if index >= 47 {
-            Some(index - 47)
+        let index = self as i32;
+        if index >= Self::NUM_MIO_PADS {
+            Some((index - Self::NUM_MIO_PADS) as usize)
+        } else {
+            None
+        }
+    }
+
+    /// Get the muxed IO index of this pad.
+    pub fn mio_index(self) -> Option<usize> {
+        let index = self as i32;
+        if (0..Self::NUM_MIO_PADS).contains(&index) {
+            Some(index as usize)
+        } else {
+            None
+        }
+    }
+
+    /// Get the input selector index of this pad.
+    pub fn as_insel(self) -> Option<u32> {
+        let idx = self as i32;
+        if idx < Self::NUM_MIO_PADS {
+            // The InSel selector is the index + 2.
+            Some((idx + 2) as u32)
         } else {
             None
         }
@@ -130,26 +164,32 @@ impl EarlGreyPinmux {
     }
 
     /// Connects a peripheral input to an MIO pad.
-    pub fn connect_input(&mut self, periph_input_idx: usize, pad: Pad) {
-        // MIO pads start at index 2 in periph_insel (0=Low, 1=High)
-        let periph_source = 2 + (pad as u32);
-        self.registers
-            .mio_periph_insel()
-            .at(periph_input_idx)
-            .write(|w| w.in_(periph_source));
+    pub fn connect_input(&mut self, input: PeriphIn, pad: Pad) -> Result<(), ErrorCode> {
+        if let Some(sel) = pad.as_insel() {
+            self.registers
+                .mio_periph_insel()
+                .at(input as usize)
+                .write(|w| w.in_(sel));
+            Ok(())
+        } else {
+            Err(EG_PINMUX_INVALID_INPUT)
+        }
     }
 
     /// Connects an MIO pad to a peripheral output.
-    pub fn connect_output(&mut self, pad: Pad, periph_output_idx: usize) {
-        // Peripheral outputs start at index 3 in outsel (0=Low, 1=High, 2=HighZ)
-        let pad_source = 3 + (periph_output_idx as u32);
-        self.registers
-            .mio_outsel()
-            .at(pad as usize)
-            .write(|w| w.out(pad_source));
+    pub fn connect_output(&mut self, pad: Pad, output: Outsel) -> Result<(), ErrorCode> {
+        if let Some(idx) = pad.mio_index() {
+            self.registers
+                .mio_outsel()
+                .at(idx)
+                .write(|w| w.out(output as u32));
+            Ok(())
+        } else {
+            Err(EG_PINMUX_INVALID_OUTPUT)
+        }
     }
 
-    pub fn configure_pad(&mut self, pad: Pad, config: &PadConfig) {
+    pub fn configure_pad(&mut self, pad: Pad, config: &PadConfig) -> Result<(), ErrorCode> {
         if let Some(dio_idx) = pad.dio_index() {
             self.registers.dio_pad_attr().at(dio_idx).modify(|w| {
                 w.pull_en(config.pull != Pull::None)
@@ -163,8 +203,9 @@ impl EarlGreyPinmux {
                     .od_en(config.open_drain)
                     .invert(config.invert)
             });
-        } else {
-            self.registers.mio_pad_attr().at(pad as usize).modify(|w| {
+            Ok(())
+        } else if let Some(mio_idx) = pad.mio_index() {
+            self.registers.mio_pad_attr().at(mio_idx).modify(|w| {
                 w.pull_en(config.pull != Pull::None)
                     .pull_select(|w| {
                         if config.pull == Pull::Up {
@@ -176,6 +217,13 @@ impl EarlGreyPinmux {
                     .od_en(config.open_drain)
                     .invert(config.invert)
             });
+            Ok(())
+        } else if pad.as_insel().is_some() {
+            // Constant pads (ConstantZero, ConstantOne) have valid input selectors
+            // but no physical pad attributes to configure.
+            Ok(())
+        } else {
+            Err(EG_PINMUX_INVALID_PAD)
         }
     }
 }

--- a/target/earlgrey/tests/drivers/gpio/BUILD.bazel
+++ b/target/earlgrey/tests/drivers/gpio/BUILD.bazel
@@ -8,6 +8,7 @@ load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_scri
 load("@pigweed//pw_kernel/tooling/panic_detector:rust_binary_no_panics_test.bzl", "rust_binary_no_panics_test")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
+load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY")
 load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
 
 rust_app(
@@ -26,6 +27,7 @@ rust_app(
         "//target/earlgrey/drivers:gpio",
         "//target/earlgrey/drivers:pinmux",
         "//target/earlgrey/registers",
+        "//util/panic",
         "@pigweed//pw_kernel/userspace",
         "@pigweed//pw_log/rust:pw_log",
         "@pigweed//pw_status/rust:pw_status",
@@ -96,6 +98,32 @@ opentitan_test(
     interface = "verilator",
     tags = [
         "verilator",
+    ],
+    target = ":gpio",
+)
+
+opentitan_test(
+    name = "gpio_hyper310_test",
+    timeout = "moderate",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper310",
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = ":gpio",
+)
+
+opentitan_test(
+    name = "gpio_hyper340_test",
+    timeout = "moderate",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper340",
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
     ],
     target = ":gpio",
 )

--- a/target/earlgrey/tests/drivers/gpio/test_gpio.rs
+++ b/target/earlgrey/tests/drivers/gpio/test_gpio.rs
@@ -9,6 +9,7 @@ use earlgrey_pinmux::{Pad, Pull};
 use openprot_hal_blocking::gpio_port::{GpioPort, PinMask};
 use pw_status::Result;
 use userspace::entry;
+use util_panic as _;
 
 fn test_gpio_basic() -> Result<()> {
     let mut gpio = unsafe { EarlGreyGpio::new() };
@@ -70,22 +71,134 @@ fn test_gpio_basic() -> Result<()> {
     Ok(())
 }
 
+// TODO: remove after fixing QEMU to handle this test properly.
+#[allow(dead_code)]
+fn test_gpio_constants() -> Result<()> {
+    let mut gpio = unsafe { EarlGreyGpio::new() };
+
+    // Configure Pin 1 as input, connected to ConstantZero
+    pw_log::info!("Configuring Pin 1 as input connected to ConstantZero");
+    gpio.configure(
+        GpioPin::Pin1.into(),
+        EarlGreyPinConfig {
+            is_input: true,
+            is_output: false,
+            input_filter: false,
+            pad: Some(Pad::ConstantZero),
+            pull: Pull::None,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    // Read Pin 1, should be low (0)
+    let input = gpio.read_input().map_err(|_| pw_status::Error::Internal)?;
+    if input.contains(GpioPin::Pin1.into()) {
+        pw_log::error!("Pin 1 (ConstantZero) readback failed (expected Low)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    // Configure Pin 1 as input, connected to ConstantOne
+    pw_log::info!("Configuring Pin 1 as input connected to ConstantOne");
+    gpio.configure(
+        GpioPin::Pin1.into(),
+        EarlGreyPinConfig {
+            is_input: true,
+            is_output: false,
+            input_filter: false,
+            pad: Some(Pad::ConstantOne),
+            pull: Pull::None,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    // Read Pin 1, should be high (1)
+    let input = gpio.read_input().map_err(|_| pw_status::Error::Internal)?;
+    if !input.contains(GpioPin::Pin1.into()) {
+        pw_log::error!("Pin 1 (ConstantOne) readback failed (expected High)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    Ok(())
+}
+
+// TODO: remove after determining if this is a valid test.
+#[allow(dead_code)]
+fn test_gpio_mio_loopback() -> Result<()> {
+    let mut gpio = unsafe { EarlGreyGpio::new() };
+
+    // Configure Pin 2 as output, connected to Pad::IOA0
+    pw_log::info!("Configuring Pin 2 as output connected to IOA0");
+    gpio.configure(
+        GpioPin::Pin2.into(),
+        EarlGreyPinConfig {
+            is_input: false,
+            is_output: true,
+            input_filter: false,
+            pad: Some(Pad::IOA0),
+            pull: Pull::None,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    // Configure Pin 3 as input, connected to Pad::IOA0
+    pw_log::info!("Configuring Pin 3 as input connected to Pad::IOA0");
+    gpio.configure(
+        GpioPin::Pin3.into(),
+        EarlGreyPinConfig {
+            is_input: true,
+            is_output: false,
+            input_filter: false,
+            pad: Some(Pad::IOA0),
+            pull: Pull::None,
+        },
+    )
+    .map_err(|_| pw_status::Error::Internal)?;
+
+    // Set Pin 2 high
+    pw_log::info!("Setting Pin 2 high");
+    gpio.set_reset(GpioPin::Pin2.into(), GpioMask::empty())
+        .map_err(|_| pw_status::Error::Internal)?;
+
+    // Read Pin 3, should be high
+    let input = gpio.read_input().map_err(|_| pw_status::Error::Internal)?;
+    if !input.contains(GpioPin::Pin3.into()) {
+        pw_log::error!("MIO Loopback failed (expected High on Pin 3)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    // Set Pin 2 low
+    pw_log::info!("Setting Pin 2 low");
+    gpio.set_reset(GpioMask::empty(), GpioPin::Pin2.into())
+        .map_err(|_| pw_status::Error::Internal)?;
+
+    // Read Pin 3, should be low
+    let input = gpio.read_input().map_err(|_| pw_status::Error::Internal)?;
+    if input.contains(GpioPin::Pin3.into()) {
+        pw_log::error!("MIO Loopback failed (expected Low on Pin 3)");
+        return Err(pw_status::Error::Internal.into());
+    }
+
+    Ok(())
+}
+
 #[entry]
 fn entry() -> Result<()> {
     pw_log::info!("🔄 RUNNING GPIO SMOKE TEST");
     let ret = test_gpio_basic();
 
-    if ret.is_err() {
-        pw_log::error!("❌ FAIL");
-    } else {
-        pw_log::info!("✅ PASS");
+    if ret.is_ok() {
+        // TODO: it seems that qemu doesn't implement ConstantOne for GPIOs correctly.
+        // ret = test_gpio_constants();
+    }
+    if ret.is_ok() {
+        // TODO: it is unclear whether you can really configure the pinmux for loopback.
+        // This test fails on both qemu and fpga.
+        // ret = test_gpio_mio_loopback();
     }
 
+    match ret {
+        Ok(()) => pw_log::info!("✅ PASS"),
+        Err(e) => pw_log::error!("❌ FAIL: {}", e as u32),
+    }
     ret
-}
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    pw_log::error!("FAIL: panic in gpio test");
-    loop {}
 }

--- a/target/earlgrey/util/error/BUILD.bazel
+++ b/target/earlgrey/util/error/BUILD.bazel
@@ -9,6 +9,7 @@ rust_library(
     srcs = [
         "gpio.rs",
         "lib.rs",
+        "pinmux.rs",
     ],
     crate_name = "earlgrey_util_error",
     edition = "2024",

--- a/target/earlgrey/util/error/lib.rs
+++ b/target/earlgrey/util/error/lib.rs
@@ -10,6 +10,8 @@ pub use util_error::{AsStatus, ErrorCode, ErrorModule};
 
 pub mod gpio;
 pub use gpio::*;
+pub mod pinmux;
+pub use pinmux::*;
 
 /// The Earlgrey utility error module (ASCII `'EG'`).
 pub const EG_ERROR: ErrorModule = ErrorModule::new(0x4547);

--- a/target/earlgrey/util/error/pinmux.rs
+++ b/target/earlgrey/util/error/pinmux.rs
@@ -1,0 +1,19 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pinmux-specific error codes for Earlgrey.
+
+use pw_status::Error;
+use util_error::{ErrorCode, ErrorModule};
+
+/// The Earlgrey Pinmux error module (ASCII `'EP'`).
+pub const EG_PINMUX: ErrorModule = ErrorModule::new(0x4550);
+
+/// The requested input configuration is not supported.
+pub const EG_PINMUX_INVALID_INPUT: ErrorCode = EG_PINMUX.from_pw(1, Error::InvalidArgument);
+
+/// The requested output configuration is not supported.
+pub const EG_PINMUX_INVALID_OUTPUT: ErrorCode = EG_PINMUX.from_pw(2, Error::InvalidArgument);
+
+/// The requested pad is invalid or does not support configuration.
+pub const EG_PINMUX_INVALID_PAD: ErrorCode = EG_PINMUX.from_pw(3, Error::InvalidArgument);


### PR DESCRIPTION
Refactor the gpio and pinmux drivers to use pinmux peripheral and pad related constants from `top_earlgrey`.

This PR depends on #369.  You need only review the last commit.