### PR TITLE
earlgrey/tests: Fix panic handler usage in SPI flash tests

### DIFF
--- a/target/earlgrey/tests/drivers/spi_flash/spi_flash.rs
+++ b/target/earlgrey/tests/drivers/spi_flash/spi_flash.rs
@@ -15,6 +15,7 @@ use pw_status::{Error, Result};
 use spi_flash::SpiFlash;
 use spi_host::SpiHost0;
 use userspace::entry;
+use util_panic as _;
 
 fn run_test() -> Result<()> {
     // 1. Initialize SPI Host.
@@ -114,5 +115,3 @@ fn entry() -> Result<()> {
 
     ret
 }
-
-util_panic::make_panic_handler!();

--- a/target/earlgrey/tests/spi_flash/combined_flash_server.rs
+++ b/target/earlgrey/tests/spi_flash/combined_flash_server.rs
@@ -17,6 +17,7 @@ use userspace::time::Instant;
 use userspace::{entry, syscall};
 use util_error::ErrorCode;
 use util_ipc::IpcHandle;
+use util_panic as _;
 use util_types::Blocking;
 
 // EFlash Interrupt Blocker
@@ -141,5 +142,3 @@ fn entry() -> Result<(), Error> {
     };
     ret
 }
-
-util_panic::make_panic_handler!();

--- a/target/earlgrey/tests/spi_flash/spi_flash_test.rs
+++ b/target/earlgrey/tests/spi_flash/spi_flash_test.rs
@@ -13,6 +13,7 @@ use hal_flash::{Flash, FlashAddress};
 use services_flash_client::FlashIpcClient;
 use util_error::{ErrorCode, KERNEL_ERROR_INTERNAL};
 use util_ipc::IpcHandle;
+use util_panic as _;
 
 fn erase_program_test(
     flash: &mut FlashIpcClient,
@@ -106,5 +107,3 @@ fn entry() -> Result<(), Error> {
 
     ret
 }
-
-util_panic::make_panic_handler!();


### PR DESCRIPTION
Commit 990349b8 ("util_panic: clean up panic handlers") removed the `make_panic_handler!` macro and unified panic handler definitions across earlgrey apps and tests. Update the SPI flash test binaries added in parallel to use `use util_panic as _;` instead of calling the removed macro.