### PR TITLE
Add attestation producer service (api + producer crates)

### DIFF
--- a/services/attest/BUILD.bazel
+++ b/services/attest/BUILD.bazel
@@ -17,7 +17,7 @@ test_suite(
     name = "attest_host_tests",
     tests = [
         "//services/attest/api:attest_api_test",
-        "//services/attest/producer:attest_producer_unit_test",
         "//services/attest/producer:attest_producer_integration_test",
+        "//services/attest/producer:attest_producer_unit_test",
     ],
 )

--- a/services/attest/BUILD.bazel
+++ b/services/attest/BUILD.bazel
@@ -1,0 +1,23 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+# All production crates (embedded-safe, no test stubs).
+filegroup(
+    name = "attest_embedded_all",
+    srcs = [
+        "//services/attest/api:attest_api",
+        "//services/attest/producer:attest_producer",
+    ],
+)
+
+# Host-side tests; run without embedded target config.
+test_suite(
+    name = "attest_host_tests",
+    tests = [
+        "//services/attest/api:attest_api_test",
+        "//services/attest/producer:attest_producer_unit_test",
+        "//services/attest/producer:attest_producer_integration_test",
+    ],
+)

--- a/services/attest/README.md
+++ b/services/attest/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # services/attest
 
 Attestation producer service for the OpenPRoT Platform Root of Trust.

--- a/services/attest/README.md
+++ b/services/attest/README.md
@@ -1,0 +1,66 @@
+# services/attest
+
+Attestation producer service for the OpenPRoT Platform Root of Trust.
+
+This directory contains two Cargo crates and the Bazel build targets that
+deliver OCP-EAT attestation token generation to the rest of the OpenPRoT
+firmware stack.
+
+## Crates
+
+| Crate | Path | Role |
+|---|---|---|
+| `openprot-attest-api` | `api/` | Platform-independent traits and types. Callers depend on this crate only. |
+| `openprot-attest-producer` | `producer/` | Concrete token producer backed by Caliptra hardware or a software stub. |
+
+Neither crate depends on the verifier module or `spdm-lib`. Evidence from the
+verifier is accepted as a raw CBOR byte slice (`&[u8]`), keeping the producer
+decoupled from verifier internals.
+
+## Bazel targets
+
+```
+//services/attest:attest_embedded_all   # production filegroup (api + producer)
+//services/attest:attest_host_tests     # test_suite for all host-side tests
+```
+
+## Cargo build
+
+```bash
+# From the workspace root (~/openprot_attestation/)
+
+# API crate only
+cargo build -p openprot-attest-api
+
+# Producer crate (pulls in API automatically)
+cargo build -p openprot-attest-producer
+
+# Producer with software stub enabled (no Caliptra hardware required)
+cargo build -p openprot-attest-producer --features test-support
+
+# Entire workspace
+cargo build
+```
+
+## Testing
+
+```bash
+cargo test -p openprot-attest-producer --features test-support
+cargo test --features test-support
+```
+
+## Relationship to the verifier
+
+The attester and verifier are deliberately decoupled. The verifier
+(`attestation/src/verifier/`) produces a CBOR-serialized `AttestEvidence`
+value that is passed to `AttestProducer::generate_token` as the `evidence`
+byte slice. The producer embeds it verbatim as the `concise-evidence` claim
+(key `-70001`) in the outgoing OCP-EAT token. The outer `COSE_Sign1`
+signature covers the embedded evidence.
+
+## Standards
+
+- OCP Entity Attestation Token — <https://opencomputeproject.github.io/Security/ietf-eat-profile/HEAD/>
+- IETF EAT (RFC 9711) — <https://www.rfc-editor.org/rfc/rfc9711>
+- CBOR Web Token (RFC 8392) — <https://www.rfc-editor.org/rfc/rfc8392>
+- COSE (RFC 9052) — <https://www.rfc-editor.org/rfc/rfc9052>

--- a/services/attest/api/BUILD.bazel
+++ b/services/attest/api/BUILD.bazel
@@ -1,0 +1,20 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "attest_api",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "openprot_attest_api",
+    edition = "2021",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rust_crates//:thiserror",
+    ],
+)
+
+rust_test(
+    name = "attest_api_test",
+    crate = ":attest_api",
+)

--- a/services/attest/api/Cargo.toml
+++ b/services/attest/api/Cargo.toml
@@ -1,3 +1,6 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "openprot-attest-api"
 version = "0.1.0"

--- a/services/attest/api/Cargo.toml
+++ b/services/attest/api/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "openprot-attest-api"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Platform-independent API for the OpenPRoT attestation producer service"
+
+[dependencies]
+thiserror = "1"

--- a/services/attest/api/README.md
+++ b/services/attest/api/README.md
@@ -1,0 +1,90 @@
+# openprot-attest-api
+
+Platform-independent trait and type definitions for the OpenPRoT attestation
+producer service.
+
+Callers and other OpenPRoT services depend **only** on this crate. It has no
+dependency on the producer implementation, the verifier module, or `spdm-lib`.
+
+## Purpose
+
+This crate defines the stable interface boundary for attestation token
+generation. By depending on `openprot-attest-api` rather than
+`openprot-attest-producer`, services can be tested with any `AttestProducer`
+implementation — including the `SoftwareAttestProducer` stub — without pulling
+in hardware dependencies.
+
+## Source files
+
+| File | Contents |
+|---|---|
+| `src/lib.rs` | Public re-exports. `#![forbid(unsafe_code)]`. |
+| `src/traits.rs` | `AttestProducer` trait. |
+| `src/types.rs` | `Measurement`, `DigestAlgorithm`, `MeasurementAuthority`, `CertChain`, `AttestConfig`, `OemId`, `CaliptraSigner` trait, `MeasurementProvider` trait. |
+| `src/error.rs` | `AttestError` — shared error type for both service crates. |
+
+## Key traits
+
+### `AttestProducer`
+
+The primary interface implemented by `HwAttestProducer` (and the
+`SoftwareAttestProducer` stub in the producer crate).
+
+```rust
+pub trait AttestProducer: Send + Sync {
+    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError>;
+    fn cert_chain(&self) -> Result<CertChain, AttestError>;
+}
+```
+
+`evidence` is the raw CBOR output of the verifier service. Pass an empty slice
+when no peer attestation has been performed. The bytes are embedded verbatim as
+the `concise-evidence` claim (key `-70001`) in the OCP-EAT token.
+
+### `CaliptraSigner`
+
+Abstracts signing operations that must execute inside the Caliptra hardware
+boundary.
+
+```rust
+pub trait CaliptraSigner: Send + Sync {
+    fn sign_es384(&self, payload: &[u8]) -> Result<[u8; 96], AttestError>;
+    fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError>;
+    fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError>;
+}
+```
+
+The private Alias Key never leaves Caliptra. Production code implements this
+trait via the Caliptra mailbox driver (`caliptra-sw`).
+
+### `MeasurementProvider`
+
+Plug in platform-specific firmware measurement sources (UEFI, BMC, etc.)
+beyond the Caliptra-internal measurements.
+
+```rust
+pub trait MeasurementProvider: Send + Sync {
+    fn component_name(&self) -> &str;
+    fn measurements(&self) -> Result<Vec<Measurement>, AttestError>;
+}
+```
+
+## Key types
+
+| Type | Description |
+|---|---|
+| `Measurement` | Single firmware measurement: component name, version, digest algorithm, digest bytes, measurement authority. |
+| `DigestAlgorithm` | `Sha384` or `Sha512`. |
+| `MeasurementAuthority` | `Caliptra` (hardware-measured) or `Platform` (software-registered). |
+| `CertChain` | DER-encoded certificate chain ordered leaf → root. |
+| `AttestConfig` | Producer configuration: `oemid`, `hw_model`, `hw_version`, `cert_cache_ttl`. |
+
+## Cargo
+
+```toml
+[dependencies]
+openprot-attest-api = { path = "services/attest/api" }
+```
+
+No additional features are required. The crate has a single dependency:
+`thiserror` for `AttestError` derivation.

--- a/services/attest/api/README.md
+++ b/services/attest/api/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # openprot-attest-api
 
 Platform-independent trait and type definitions for the OpenPRoT attestation

--- a/services/attest/api/src/error.rs
+++ b/services/attest/api/src/error.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Debug, thiserror::Error)]
+pub enum AttestError {
+    #[error("Caliptra mailbox error: {0}")]
+    Caliptra(String),
+    #[error("CBOR encoding error: {0}")]
+    Cbor(String),
+    #[error("COSE signing error: {0}")]
+    Cose(String),
+    #[error("Measurement provider error: {0}")]
+    Provider(String),
+}

--- a/services/attest/api/src/error.rs
+++ b/services/attest/api/src/error.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 #[derive(Debug, thiserror::Error)]

--- a/services/attest/api/src/lib.rs
+++ b/services/attest/api/src/lib.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! Platform-independent API for the OpenPRoT attestation producer service.

--- a/services/attest/api/src/lib.rs
+++ b/services/attest/api/src/lib.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Platform-independent API for the OpenPRoT attestation producer service.
+//!
+//! # Usage
+//!
+//! Applications depend only on this crate. Platform code provides a concrete
+//! [`AttestProducer`] implementation (hardware-backed via Caliptra, or the
+//! `test-support`-gated software stub in the `openprot-attest-producer` crate).
+//!
+//! ```text
+//! ┌───────────────────────────────────────────────┐
+//! │  application / verifier service               │
+//! │      depends on: openprot-attest-api          │
+//! │      calls:      AttestProducer::generate_token│
+//! └──────────────────┬────────────────────────────┘
+//!                    │ trait object / generic bound
+//! ┌──────────────────▼────────────────────────────┐
+//! │  openprot-attest-producer                     │
+//! │      HwAttestProducer  (production)           │
+//! │      SoftwareAttestProducer (test-support)    │
+//! └───────────────────────────────────────────────┘
+//! ```
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod traits;
+mod types;
+
+pub use error::AttestError;
+pub use traits::AttestProducer;
+pub use types::{
+    AttestConfig, CaliptraSigner, CertChain, DigestAlgorithm, Measurement,
+    MeasurementAuthority, MeasurementProvider, OemId,
+};

--- a/services/attest/api/src/traits.rs
+++ b/services/attest/api/src/traits.rs
@@ -20,7 +20,11 @@ pub trait AttestProducer: Send + Sync {
     /// available.
     ///
     /// Returns the complete COSE_Sign1 structure as a byte vector.
-    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError>;
+    fn generate_token(
+        &self,
+        nonce: &[u8],
+        evidence: &[u8],
+    ) -> Result<Vec<u8>, AttestError>;
 
     /// Return the current DICE certificate chain, ordered leaf → root.
     fn cert_chain(&self) -> Result<CertChain, AttestError>;

--- a/services/attest/api/src/traits.rs
+++ b/services/attest/api/src/traits.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{AttestError, CertChain};

--- a/services/attest/api/src/traits.rs
+++ b/services/attest/api/src/traits.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{AttestError, CertChain};
+
+/// Platform-independent attestation producer interface.
+///
+/// Implementors assemble and sign an OCP-EAT COSE_Sign1 token containing
+/// platform measurements, DICE identity claims, and optionally pre-serialized
+/// SPDM evidence from the verifier service.
+///
+/// The `evidence` parameter accepted by `generate_token` is a raw CBOR byte
+/// slice produced by the verifier service. Passing it as bytes rather than a
+/// typed struct keeps this crate free of any verifier or spdm-lib dependency.
+pub trait AttestProducer: Send + Sync {
+    /// Generate a signed OCP-EAT COSE_Sign1 token bound to `nonce`.
+    ///
+    /// `evidence` is a CBOR-encoded blob from the verifier service, embedded
+    /// verbatim as claim -70001. Pass an empty slice when no peer evidence is
+    /// available.
+    ///
+    /// Returns the complete COSE_Sign1 structure as a byte vector.
+    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError>;
+
+    /// Return the current DICE certificate chain, ordered leaf → root.
+    fn cert_chain(&self) -> Result<CertChain, AttestError>;
+}

--- a/services/attest/api/src/types.rs
+++ b/services/attest/api/src/types.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/services/attest/api/src/types.rs
+++ b/services/attest/api/src/types.rs
@@ -24,11 +24,11 @@ pub enum MeasurementAuthority {
 /// A single firmware measurement record to include in the EAT token.
 #[derive(Clone, Debug)]
 pub struct Measurement {
-    pub component:  String,
-    pub version:    String,
+    pub component: String,
+    pub version: String,
     pub digest_alg: DigestAlgorithm,
-    pub digest:     Vec<u8>,
-    pub authority:  MeasurementAuthority,
+    pub digest: Vec<u8>,
+    pub authority: MeasurementAuthority,
 }
 
 /// DER-encoded certificate chain ordered leaf → root.
@@ -36,9 +36,9 @@ pub struct CertChain(pub Vec<Vec<u8>>);
 
 /// Producer configuration, set once at platform initialisation.
 pub struct AttestConfig {
-    pub oemid:          OemId,
-    pub hw_model:       String,
-    pub hw_version:     String,
+    pub oemid: OemId,
+    pub hw_model: String,
+    pub hw_version: String,
     pub cert_cache_ttl: Duration,
 }
 

--- a/services/attest/api/src/types.rs
+++ b/services/attest/api/src/types.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use crate::error::AttestError;
+
+/// OEM identifier (IANA Private Enterprise Number or UUID form).
+#[derive(Clone, Debug)]
+pub struct OemId(pub Vec<u8>);
+
+#[derive(Clone, Copy, Debug)]
+pub enum DigestAlgorithm {
+    Sha384,
+    Sha512,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum MeasurementAuthority {
+    Caliptra,
+    Platform,
+}
+
+/// A single firmware measurement record to include in the EAT token.
+#[derive(Clone, Debug)]
+pub struct Measurement {
+    pub component:  String,
+    pub version:    String,
+    pub digest_alg: DigestAlgorithm,
+    pub digest:     Vec<u8>,
+    pub authority:  MeasurementAuthority,
+}
+
+/// DER-encoded certificate chain ordered leaf → root.
+pub struct CertChain(pub Vec<Vec<u8>>);
+
+/// Producer configuration, set once at platform initialisation.
+pub struct AttestConfig {
+    pub oemid:          OemId,
+    pub hw_model:       String,
+    pub hw_version:     String,
+    pub cert_cache_ttl: Duration,
+}
+
+/// Hardware-backed signing operations.
+///
+/// Production: implemented by a Caliptra mailbox driver.
+/// Testing: implement with a software key (`SoftwareAttestProducer` in the
+/// producer crate behind `test-support`).
+pub trait CaliptraSigner: Send + Sync {
+    /// Sign `payload` with the Alias Key (ES384). Returns raw (r‖s) bytes.
+    fn sign_es384(&self, payload: &[u8]) -> Result<[u8; 96], AttestError>;
+    /// Return the DER-encoded Alias (leaf) certificate.
+    fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError>;
+    /// Return the full DER-encoded certificate chain, leaf → root.
+    fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError>;
+}
+
+/// Platform-specific measurement source.
+///
+/// Implement for each firmware component (UEFI, BMC, etc.) the platform
+/// wants to measure beyond Caliptra-internal measurements.
+pub trait MeasurementProvider: Send + Sync {
+    fn component_name(&self) -> &str;
+    fn measurements(&self) -> Result<Vec<Measurement>, AttestError>;
+}

--- a/services/attest/producer/BUILD.bazel
+++ b/services/attest/producer/BUILD.bazel
@@ -1,0 +1,39 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "attest_producer",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "openprot_attest_producer",
+    edition = "2021",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//services/attest/api:attest_api",
+        "@rust_crates//:ciborium",
+        "@rust_crates//:thiserror",
+        "@rust_crates//:zeroize",
+    ],
+)
+
+rust_test(
+    name = "attest_producer_unit_test",
+    crate = ":attest_producer",
+    features = ["test-support"],
+    deps = [
+        "//services/attest/api:attest_api",
+        "@rust_crates//:ciborium",
+    ],
+)
+
+rust_test(
+    name = "attest_producer_integration_test",
+    srcs = ["tests/producer_integration.rs"],
+    features = ["test-support"],
+    deps = [
+        ":attest_producer",
+        "//services/attest/api:attest_api",
+        "@rust_crates//:ciborium",
+    ],
+)

--- a/services/attest/producer/BUILD.bazel
+++ b/services/attest/producer/BUILD.bazel
@@ -30,6 +30,7 @@ rust_test(
 rust_test(
     name = "attest_producer_integration_test",
     srcs = ["tests/producer_integration.rs"],
+    edition = "2021",
     features = ["test-support"],
     deps = [
         ":attest_producer",

--- a/services/attest/producer/Cargo.toml
+++ b/services/attest/producer/Cargo.toml
@@ -1,3 +1,6 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "openprot-attest-producer"
 version = "0.1.0"

--- a/services/attest/producer/Cargo.toml
+++ b/services/attest/producer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "openprot-attest-producer"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Concrete OCP-EAT attestation producer for OpenPRoT"
+
+[features]
+default = []
+test-support = []
+
+[dependencies]
+openprot-attest-api = { path = "../api" }
+ciborium  = { version = "0.2", default-features = false }
+thiserror = "1"
+zeroize   = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+ciborium = { version = "0.2", default-features = false }

--- a/services/attest/producer/README.md
+++ b/services/attest/producer/README.md
@@ -1,0 +1,100 @@
+# openprot-attest-producer
+
+Concrete OCP-EAT attestation token producer for OpenPRoT.
+
+Implements the `AttestProducer` trait from `openprot-attest-api` with two
+backends: a hardware-backed producer that calls the Caliptra mailbox driver,
+and a software stub for testing without physical hardware.
+
+## Source files
+
+| File | Contents |
+|---|---|
+| `src/lib.rs` | Public re-exports; feature gates. |
+| `src/signer.rs` | `HwAttestProducer` and `SoftwareAttestProducer` (feature = `test-support`). |
+| `src/builder.rs` | Assembles the CBOR claim map, embeds raw evidence bytes, constructs the `COSE_Sign1` envelope. No verifier dependency. |
+| `src/dice_identity.rs` | Wraps the Caliptra mailbox calls that return the DER-encoded DICE certificate chain. |
+| `src/measurements.rs` | Aggregates Caliptra-internal firmware measurements with platform-registered `MeasurementProvider` outputs. |
+
+## Implementations
+
+### `HwAttestProducer` (production)
+
+Backed by a `CaliptraSigner` implementation from the Caliptra mailbox driver.
+All ES384 signing operations occur inside the Caliptra hardware boundary; the
+private Alias Key is never exposed to host software.
+
+```rust
+let producer = HwAttestProducer::new(Arc::new(caliptra_driver), config);
+producer.add_provider(Box::new(UefiFirmwareMeasurements));
+
+let token: Vec<u8> = producer.generate_token(&nonce, &evidence_cbor)?;
+```
+
+### `SoftwareAttestProducer` (feature = `test-support`)
+
+Software-only stub for unit and integration tests. Uses a deterministic
+all-zero ES384 signature and placeholder DER certificates. No Caliptra
+hardware or driver is required.
+
+```rust
+#[cfg(feature = "test-support")]
+let producer = SoftwareAttestProducer::new(config);
+let token = producer.generate_token(&nonce, &[])?;
+```
+
+Enable the feature in `Cargo.toml`:
+
+```toml
+[dev-dependencies]
+openprot-attest-producer = { path = "services/attest/producer", features = ["test-support"] }
+```
+
+## Token structure
+
+`builder.rs` produces a `COSE_Sign1`-wrapped CWT conforming to the OCP-EAT
+profile. The protected header carries the algorithm identifier (`-35` = ES384)
+and the `x5chain` certificate chain. The CWT payload includes:
+
+| Claim | Key | Description |
+|---|---|---|
+| `iss` | 1 | Issuer derived from Caliptra device identity |
+| `iat` | 6 | Token creation timestamp |
+| `eat_nonce` | 10 | Caller-supplied freshness nonce (min 32 bytes) |
+| `ueid` | 256 | Unique Entity Identifier from Caliptra CDI |
+| `oemid` | 258 | OEM identifier (IANA PEN form) |
+| `hwmodel` | 259 | Hardware model string |
+| `hwversion` | 260 | Hardware version string |
+| `dbgstat` | 263 | Debug status |
+| `measurements` | -70000 | Per-component firmware measurement records |
+| `concise-evidence` | -70001 | CBOR-serialized verifier appraisal results (omitted if no peer attestation) |
+
+## Dependencies
+
+| Crate | Purpose |
+|---|---|
+| `openprot-attest-api` | Trait and type definitions (`AttestProducer`, `CaliptraSigner`, etc.) |
+| `ciborium` | CBOR encoding of token claims and evidence embedding |
+| `thiserror` | `AttestError` derivation |
+| `zeroize` | Zero-on-drop for intermediate key material and sensitive buffers |
+
+## Cargo build
+
+```bash
+# Production build
+cargo build -p openprot-attest-producer
+
+# With software stub
+cargo build -p openprot-attest-producer --features test-support
+
+# Tests (software stub required)
+cargo test -p openprot-attest-producer --features test-support
+```
+
+## Bazel targets
+
+```
+//services/attest/producer:attest_producer               # production library
+//services/attest/producer:attest_producer_unit_test     # unit tests
+//services/attest/producer:attest_producer_integration_test  # integration tests
+```

--- a/services/attest/producer/README.md
+++ b/services/attest/producer/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # openprot-attest-producer
 
 Concrete OCP-EAT attestation token producer for OpenPRoT.

--- a/services/attest/producer/src/builder.rs
+++ b/services/attest/producer/src/builder.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! OCP-EAT COSE_Sign1 token assembly.

--- a/services/attest/producer/src/builder.rs
+++ b/services/attest/producer/src/builder.rs
@@ -19,28 +19,30 @@
 //! Claim key numbers follow RFC 9711 and the OCP-EAT profile.
 
 use ciborium::value::Value;
-use openprot_attest_api::{AttestConfig, AttestError, CaliptraSigner, DigestAlgorithm, Measurement};
+use openprot_attest_api::{
+    AttestConfig, AttestError, CaliptraSigner, DigestAlgorithm, Measurement,
+};
 
 // Registered EAT claim keys (RFC 9711 / RFC 8392)
-const CLAIM_ISS:      i64 = 1;
-const CLAIM_IAT:      i64 = 6;
-const CLAIM_NONCE:    i64 = 10;
-const CLAIM_UEID:     i64 = 256;
-const CLAIM_OEMID:    i64 = 258;
-const CLAIM_HWMODEL:  i64 = 259;
-const CLAIM_HWVER:    i64 = 260;
-const CLAIM_DBGSTAT:  i64 = 263;
-const CLAIM_SWNAME:   i64 = 14;
-const CLAIM_SWVER:    i64 = 15;
+const CLAIM_ISS: i64 = 1;
+const CLAIM_IAT: i64 = 6;
+const CLAIM_NONCE: i64 = 10;
+const CLAIM_UEID: i64 = 256;
+const CLAIM_OEMID: i64 = 258;
+const CLAIM_HWMODEL: i64 = 259;
+const CLAIM_HWVER: i64 = 260;
+const CLAIM_DBGSTAT: i64 = 263;
+const CLAIM_SWNAME: i64 = 14;
+const CLAIM_SWVER: i64 = 15;
 
 // OCP-EAT private claim labels
 const CLAIM_MEASUREMENTS: i64 = -70000;
-const CLAIM_EVIDENCE:     i64 = -70001;
+const CLAIM_EVIDENCE: i64 = -70001;
 
 // COSE algorithm identifier for ES384
-const ALG_ES384:    i64 = -35;
+const ALG_ES384: i64 = -35;
 // COSE header key for x5chain
-const HDR_X5CHAIN:  i64 = 33;
+const HDR_X5CHAIN: i64 = 33;
 
 /// Build and sign a complete OCP-EAT token.
 ///
@@ -66,7 +68,10 @@ pub(crate) fn build(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    claims.push((Value::Integer(CLAIM_IAT.into()), Value::Integer((iat as i64).into())));
+    claims.push((
+        Value::Integer(CLAIM_IAT.into()),
+        Value::Integer((iat as i64).into()),
+    ));
 
     claims.push((
         Value::Integer(CLAIM_NONCE.into()),
@@ -96,15 +101,26 @@ pub(crate) fn build(
     ));
 
     // dbgstat = 3 (disabled)
-    claims.push((Value::Integer(CLAIM_DBGSTAT.into()), Value::Integer(3i64.into())));
+    claims.push((
+        Value::Integer(CLAIM_DBGSTAT.into()),
+        Value::Integer(3i64.into()),
+    ));
 
-    let sw_names: Vec<Value> = measurements.iter().map(|m| Value::Text(m.component.clone())).collect();
+    let sw_names: Vec<Value> = measurements
+        .iter()
+        .map(|m| Value::Text(m.component.clone()))
+        .collect();
     let sw_vers: Vec<Value> = measurements
         .iter()
-        .map(|m| Value::Array(vec![Value::Text(m.version.clone()), Value::Integer(1i64.into())]))
+        .map(|m| {
+            Value::Array(vec![
+                Value::Text(m.version.clone()),
+                Value::Integer(1i64.into()),
+            ])
+        })
         .collect();
     claims.push((Value::Integer(CLAIM_SWNAME.into()), Value::Array(sw_names)));
-    claims.push((Value::Integer(CLAIM_SWVER.into()),  Value::Array(sw_vers)));
+    claims.push((Value::Integer(CLAIM_SWVER.into()), Value::Array(sw_vers)));
 
     let meas_array: Vec<Value> = measurements
         .iter()
@@ -120,7 +136,10 @@ pub(crate) fn build(
             ])
         })
         .collect();
-    claims.push((Value::Integer(CLAIM_MEASUREMENTS.into()), Value::Array(meas_array)));
+    claims.push((
+        Value::Integer(CLAIM_MEASUREMENTS.into()),
+        Value::Array(meas_array),
+    ));
 
     // Embed pre-serialized verifier evidence verbatim
     if !evidence_cbor.is_empty() {
@@ -140,10 +159,14 @@ pub(crate) fn build(
 
     // Protected header: { alg: ES384, x5chain: [cert-chain] }
     let protected_header = Value::Map(vec![
-        (Value::Integer(1i64.into()),           Value::Integer(ALG_ES384.into())),
-        (Value::Integer(HDR_X5CHAIN.into()), Value::Array(
-            chain.into_iter().map(Value::Bytes).collect(),
-        )),
+        (
+            Value::Integer(1i64.into()),
+            Value::Integer(ALG_ES384.into()),
+        ),
+        (
+            Value::Integer(HDR_X5CHAIN.into()),
+            Value::Array(chain.into_iter().map(Value::Bytes).collect()),
+        ),
     ]);
     let mut protected_header_bytes = Vec::new();
     ciborium::ser::into_writer(&protected_header, &mut protected_header_bytes)
@@ -173,8 +196,12 @@ mod tests {
     struct TestSigner;
 
     impl CaliptraSigner for TestSigner {
-        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
-        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> {
+            Ok([0u8; 96])
+        }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> {
+            Ok(vec![0x30, 0x00])
+        }
         fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
             Ok(vec![vec![0x30, 0x00], vec![0x30, 0x00]])
         }
@@ -182,46 +209,52 @@ mod tests {
 
     fn config() -> AttestConfig {
         AttestConfig {
-            oemid:          OemId(vec![0x00, 0x01, 0x47, 0xae]),
-            hw_model:       "TestModel".into(),
-            hw_version:     "1.0.0".into(),
+            oemid: OemId(vec![0x00, 0x01, 0x47, 0xae]),
+            hw_model: "TestModel".into(),
+            hw_version: "1.0.0".into(),
             cert_cache_ttl: Duration::from_secs(3600),
         }
     }
 
     fn meas() -> Vec<Measurement> {
         vec![Measurement {
-            component:  "Test ROM".into(),
-            version:    "1.0.0".into(),
+            component: "Test ROM".into(),
+            version: "1.0.0".into(),
             digest_alg: DigestAlgorithm::Sha384,
-            digest:     vec![0xAAu8; 48],
-            authority:  MeasurementAuthority::Caliptra,
+            digest: vec![0xAAu8; 48],
+            authority: MeasurementAuthority::Caliptra,
         }]
     }
 
     fn decode_payload(token: &[u8]) -> Vec<(Value, Value)> {
         let outer: Value = ciborium::de::from_reader(token).unwrap();
-        let payload_bytes = outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
-        let payload: Value = ciborium::de::from_reader(payload_bytes.as_slice()).unwrap();
+        let payload_bytes =
+            outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
+        let payload: Value =
+            ciborium::de::from_reader(payload_bytes.as_slice()).unwrap();
         payload.as_map().unwrap().clone()
     }
 
     fn find_claim(map: &[(Value, Value)], key: i64) -> Option<&Value> {
         map.iter()
-            .find(|(k, _)| k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key))
+            .find(|(k, _)| {
+                k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key)
+            })
             .map(|(_, v)| v)
     }
 
     #[test]
     fn output_is_four_element_cbor_array() {
-        let token = build(&config(), &TestSigner, &meas(), b"nonce", &[]).unwrap();
+        let token =
+            build(&config(), &TestSigner, &meas(), b"nonce", &[]).unwrap();
         let value: Value = ciborium::de::from_reader(token.as_slice()).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 4);
     }
 
     #[test]
     fn nonce_appears_in_payload() {
-        let token = build(&config(), &TestSigner, &meas(), b"testnonce", &[]).unwrap();
+        let token =
+            build(&config(), &TestSigner, &meas(), b"testnonce", &[]).unwrap();
         let map = decode_payload(&token);
         let v = find_claim(&map, 10).unwrap(); // CLAIM_NONCE = 10
         assert_eq!(v.as_bytes().unwrap(), b"testnonce");
@@ -237,7 +270,8 @@ mod tests {
     #[test]
     fn non_empty_evidence_included_verbatim() {
         let evidence = vec![0xDE, 0xAD, 0xBE, 0xEF];
-        let token = build(&config(), &TestSigner, &meas(), b"n", &evidence).unwrap();
+        let token =
+            build(&config(), &TestSigner, &meas(), b"n", &evidence).unwrap();
         let map = decode_payload(&token);
         let v = find_claim(&map, -70001).unwrap();
         assert_eq!(v.as_bytes().unwrap(), &evidence);

--- a/services/attest/producer/src/builder.rs
+++ b/services/attest/producer/src/builder.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! OCP-EAT COSE_Sign1 token assembly.
+//!
+//! Token structure (CBOR diagnostic notation):
+//!
+//! ```text
+//! 18(                        ; COSE_Sign1
+//!   [
+//!     << { 1: -35, 33: [cert-chain...] } >>,   ; protected header
+//!     {},                                        ; unprotected header
+//!     << 61( { ...CWT claims... } ) >>,          ; payload (EAT CWT)
+//!     h'...'                                     ; ES384 signature
+//!   ]
+//! )
+//! ```
+//!
+//! Claim key numbers follow RFC 9711 and the OCP-EAT profile.
+
+use ciborium::value::Value;
+use openprot_attest_api::{AttestConfig, AttestError, CaliptraSigner, DigestAlgorithm, Measurement};
+
+// Registered EAT claim keys (RFC 9711 / RFC 8392)
+const CLAIM_ISS:      i64 = 1;
+const CLAIM_IAT:      i64 = 6;
+const CLAIM_NONCE:    i64 = 10;
+const CLAIM_UEID:     i64 = 256;
+const CLAIM_OEMID:    i64 = 258;
+const CLAIM_HWMODEL:  i64 = 259;
+const CLAIM_HWVER:    i64 = 260;
+const CLAIM_DBGSTAT:  i64 = 263;
+const CLAIM_SWNAME:   i64 = 14;
+const CLAIM_SWVER:    i64 = 15;
+
+// OCP-EAT private claim labels
+const CLAIM_MEASUREMENTS: i64 = -70000;
+const CLAIM_EVIDENCE:     i64 = -70001;
+
+// COSE algorithm identifier for ES384
+const ALG_ES384:    i64 = -35;
+// COSE header key for x5chain
+const HDR_X5CHAIN:  i64 = 33;
+
+/// Build and sign a complete OCP-EAT token.
+///
+/// `evidence_cbor` is a raw CBOR byte slice from the verifier service.
+/// Pass an empty slice when no peer evidence is available.
+pub(crate) fn build(
+    config: &AttestConfig,
+    signer: &dyn CaliptraSigner,
+    measurements: &[Measurement],
+    nonce: &[u8],
+    evidence_cbor: &[u8],
+) -> Result<Vec<u8>, AttestError> {
+    let chain = signer.cert_chain_der()?;
+
+    let mut claims: Vec<(Value, Value)> = Vec::new();
+
+    claims.push((
+        Value::Integer(CLAIM_ISS.into()),
+        Value::Text("https://openprot.example/caliptra/device".into()),
+    ));
+
+    let iat = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    claims.push((Value::Integer(CLAIM_IAT.into()), Value::Integer((iat as i64).into())));
+
+    claims.push((
+        Value::Integer(CLAIM_NONCE.into()),
+        Value::Bytes(nonce.to_vec()),
+    ));
+
+    // UEID: type RAND (0x01 prefix) + 28 placeholder bytes
+    let mut ueid = vec![0x01u8];
+    ueid.extend_from_slice(&[0u8; 28]);
+    claims.push((Value::Integer(CLAIM_UEID.into()), Value::Bytes(ueid)));
+
+    claims.push((
+        Value::Integer(CLAIM_OEMID.into()),
+        Value::Bytes(config.oemid.0.clone()),
+    ));
+
+    claims.push((
+        Value::Integer(CLAIM_HWMODEL.into()),
+        Value::Text(config.hw_model.clone()),
+    ));
+    claims.push((
+        Value::Integer(CLAIM_HWVER.into()),
+        Value::Array(vec![
+            Value::Text(config.hw_version.clone()),
+            Value::Integer(1i64.into()),
+        ]),
+    ));
+
+    // dbgstat = 3 (disabled)
+    claims.push((Value::Integer(CLAIM_DBGSTAT.into()), Value::Integer(3i64.into())));
+
+    let sw_names: Vec<Value> = measurements.iter().map(|m| Value::Text(m.component.clone())).collect();
+    let sw_vers: Vec<Value> = measurements
+        .iter()
+        .map(|m| Value::Array(vec![Value::Text(m.version.clone()), Value::Integer(1i64.into())]))
+        .collect();
+    claims.push((Value::Integer(CLAIM_SWNAME.into()), Value::Array(sw_names)));
+    claims.push((Value::Integer(CLAIM_SWVER.into()),  Value::Array(sw_vers)));
+
+    let meas_array: Vec<Value> = measurements
+        .iter()
+        .map(|m| {
+            let alg: i64 = match m.digest_alg {
+                DigestAlgorithm::Sha384 => -43,
+                DigestAlgorithm::Sha512 => -44,
+            };
+            Value::Array(vec![
+                Value::Text(m.component.clone()),
+                Value::Integer(alg.into()),
+                Value::Bytes(m.digest.clone()),
+            ])
+        })
+        .collect();
+    claims.push((Value::Integer(CLAIM_MEASUREMENTS.into()), Value::Array(meas_array)));
+
+    // Embed pre-serialized verifier evidence verbatim
+    if !evidence_cbor.is_empty() {
+        claims.push((
+            Value::Integer(CLAIM_EVIDENCE.into()),
+            Value::Bytes(evidence_cbor.to_vec()),
+        ));
+    }
+
+    // CBOR-encode CWT payload
+    let mut payload_bytes = Vec::new();
+    ciborium::ser::into_writer(&Value::Map(claims), &mut payload_bytes)
+        .map_err(|e| AttestError::Cbor(e.to_string()))?;
+
+    // Sign with Caliptra Alias Key
+    let sig = signer.sign_es384(&payload_bytes)?;
+
+    // Protected header: { alg: ES384, x5chain: [cert-chain] }
+    let protected_header = Value::Map(vec![
+        (Value::Integer(1i64.into()),           Value::Integer(ALG_ES384.into())),
+        (Value::Integer(HDR_X5CHAIN.into()), Value::Array(
+            chain.into_iter().map(Value::Bytes).collect(),
+        )),
+    ]);
+    let mut protected_header_bytes = Vec::new();
+    ciborium::ser::into_writer(&protected_header, &mut protected_header_bytes)
+        .map_err(|e| AttestError::Cbor(e.to_string()))?;
+
+    // COSE_Sign1 = [protected-bstr, unprotected-map, payload-bstr, sig-bstr]
+    let cose_sign1 = Value::Array(vec![
+        Value::Bytes(protected_header_bytes),
+        Value::Map(vec![]),
+        Value::Bytes(payload_bytes),
+        Value::Bytes(sig.to_vec()),
+    ]);
+
+    let mut out = Vec::new();
+    ciborium::ser::into_writer(&cose_sign1, &mut out)
+        .map_err(|e| AttestError::Cbor(e.to_string()))?;
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openprot_attest_api::{DigestAlgorithm, MeasurementAuthority, OemId};
+    use std::time::Duration;
+
+    struct TestSigner;
+
+    impl CaliptraSigner for TestSigner {
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
+            Ok(vec![vec![0x30, 0x00], vec![0x30, 0x00]])
+        }
+    }
+
+    fn config() -> AttestConfig {
+        AttestConfig {
+            oemid:          OemId(vec![0x00, 0x01, 0x47, 0xae]),
+            hw_model:       "TestModel".into(),
+            hw_version:     "1.0.0".into(),
+            cert_cache_ttl: Duration::from_secs(3600),
+        }
+    }
+
+    fn meas() -> Vec<Measurement> {
+        vec![Measurement {
+            component:  "Test ROM".into(),
+            version:    "1.0.0".into(),
+            digest_alg: DigestAlgorithm::Sha384,
+            digest:     vec![0xAAu8; 48],
+            authority:  MeasurementAuthority::Caliptra,
+        }]
+    }
+
+    fn decode_payload(token: &[u8]) -> Vec<(Value, Value)> {
+        let outer: Value = ciborium::de::from_reader(token).unwrap();
+        let payload_bytes = outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
+        let payload: Value = ciborium::de::from_reader(payload_bytes.as_slice()).unwrap();
+        payload.as_map().unwrap().clone()
+    }
+
+    fn find_claim(map: &[(Value, Value)], key: i64) -> Option<&Value> {
+        map.iter()
+            .find(|(k, _)| k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key))
+            .map(|(_, v)| v)
+    }
+
+    #[test]
+    fn output_is_four_element_cbor_array() {
+        let token = build(&config(), &TestSigner, &meas(), b"nonce", &[]).unwrap();
+        let value: Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn nonce_appears_in_payload() {
+        let token = build(&config(), &TestSigner, &meas(), b"testnonce", &[]).unwrap();
+        let map = decode_payload(&token);
+        let v = find_claim(&map, 10).unwrap(); // CLAIM_NONCE = 10
+        assert_eq!(v.as_bytes().unwrap(), b"testnonce");
+    }
+
+    #[test]
+    fn empty_evidence_omits_evidence_claim() {
+        let token = build(&config(), &TestSigner, &meas(), b"n", &[]).unwrap();
+        let map = decode_payload(&token);
+        assert!(find_claim(&map, -70001).is_none());
+    }
+
+    #[test]
+    fn non_empty_evidence_included_verbatim() {
+        let evidence = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let token = build(&config(), &TestSigner, &meas(), b"n", &evidence).unwrap();
+        let map = decode_payload(&token);
+        let v = find_claim(&map, -70001).unwrap();
+        assert_eq!(v.as_bytes().unwrap(), &evidence);
+    }
+
+    #[test]
+    fn hw_model_in_payload() {
+        let token = build(&config(), &TestSigner, &meas(), b"n", &[]).unwrap();
+        let map = decode_payload(&token);
+        let v = find_claim(&map, 259).unwrap(); // CLAIM_HWMODEL = 259
+        assert_eq!(v.as_text().unwrap(), "TestModel");
+    }
+}

--- a/services/attest/producer/src/dice_identity.rs
+++ b/services/attest/producer/src/dice_identity.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! Caliptra DICE certificate chain retrieval.

--- a/services/attest/producer/src/dice_identity.rs
+++ b/services/attest/producer/src/dice_identity.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Caliptra DICE certificate chain retrieval.
+//!
+//! The chain is assembled by Caliptra during boot:
+//!   Vendor CA → IDevID → LDevID → AliasFMC → AliasRT  (leaf)
+//!
+//! In production the `CaliptraSigner` implementation delegates to the
+//! `caliptra-sw` Rust driver.  Tests use a software-backed stub.
+
+use openprot_attest_api::{AttestError, CaliptraSigner, CertChain};
+
+/// Retrieve the full DICE certificate chain from Caliptra, ordered leaf → root.
+pub fn cert_chain(signer: &dyn CaliptraSigner) -> Result<CertChain, AttestError> {
+    let chain = signer.cert_chain_der()?;
+    if chain.len() < 2 {
+        return Err(AttestError::Caliptra(
+            "DICE certificate chain must have at least two certificates (leaf + one CA)".into(),
+        ));
+    }
+    Ok(CertChain(chain))
+}
+
+/// Return just the DER-encoded Alias (leaf) certificate.
+pub fn alias_cert(signer: &dyn CaliptraSigner) -> Result<Vec<u8>, AttestError> {
+    signer.alias_cert_der()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OneCert;
+    struct TwoCerts;
+
+    impl CaliptraSigner for OneCert {
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
+            Ok(vec![vec![0x30, 0x00]])
+        }
+    }
+
+    impl CaliptraSigner for TwoCerts {
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
+            Ok(vec![vec![0x30, 0x00], vec![0x30, 0x01]])
+        }
+    }
+
+    #[test]
+    fn rejects_chain_with_fewer_than_two_certs() {
+        assert!(cert_chain(&OneCert).is_err());
+    }
+
+    #[test]
+    fn accepts_chain_with_two_certs() {
+        let chain = cert_chain(&TwoCerts).unwrap();
+        assert_eq!(chain.0.len(), 2);
+    }
+
+    #[test]
+    fn alias_cert_returns_leaf() {
+        assert_eq!(alias_cert(&TwoCerts).unwrap(), vec![0x30, 0x00]);
+    }
+}

--- a/services/attest/producer/src/dice_identity.rs
+++ b/services/attest/producer/src/dice_identity.rs
@@ -12,7 +12,9 @@
 use openprot_attest_api::{AttestError, CaliptraSigner, CertChain};
 
 /// Retrieve the full DICE certificate chain from Caliptra, ordered leaf → root.
-pub fn cert_chain(signer: &dyn CaliptraSigner) -> Result<CertChain, AttestError> {
+pub fn cert_chain(
+    signer: &dyn CaliptraSigner,
+) -> Result<CertChain, AttestError> {
     let chain = signer.cert_chain_der()?;
     if chain.len() < 2 {
         return Err(AttestError::Caliptra(
@@ -35,16 +37,24 @@ mod tests {
     struct TwoCerts;
 
     impl CaliptraSigner for OneCert {
-        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
-        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> {
+            Ok([0u8; 96])
+        }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> {
+            Ok(vec![0x30, 0x00])
+        }
         fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
             Ok(vec![vec![0x30, 0x00]])
         }
     }
 
     impl CaliptraSigner for TwoCerts {
-        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> { Ok([0u8; 96]) }
-        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> { Ok(vec![0x30, 0x00]) }
+        fn sign_es384(&self, _: &[u8]) -> Result<[u8; 96], AttestError> {
+            Ok([0u8; 96])
+        }
+        fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> {
+            Ok(vec![0x30, 0x00])
+        }
         fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
             Ok(vec![vec![0x30, 0x00], vec![0x30, 0x01]])
         }

--- a/services/attest/producer/src/lib.rs
+++ b/services/attest/producer/src/lib.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Concrete attestation producer for OpenPRoT.
+//!
+//! Provides [`HwAttestProducer`], which implements [`openprot_attest_api::AttestProducer`]
+//! backed by a Caliptra hardware signer.  Under the `test-support` feature,
+//! [`SoftwareAttestProducer`] provides a fully software-backed substitute
+//! that requires no Caliptra hardware.
+
+#![forbid(unsafe_code)]
+
+pub mod builder;
+pub mod dice_identity;
+pub mod measurements;
+mod signer;
+
+pub use signer::HwAttestProducer;
+
+#[cfg(feature = "test-support")]
+pub use signer::SoftwareAttestProducer;

--- a/services/attest/producer/src/lib.rs
+++ b/services/attest/producer/src/lib.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! Concrete attestation producer for OpenPRoT.

--- a/services/attest/producer/src/measurements.rs
+++ b/services/attest/producer/src/measurements.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Firmware measurement collection.
+//!
+//! Aggregates Caliptra-internal measurements (ROM, FMC, RT digests) with any
+//! platform-registered [`MeasurementProvider`] instances.
+
+use openprot_attest_api::{AttestError, Measurement, MeasurementProvider};
+
+/// Collect all measurements: Caliptra-internal first, then registered providers.
+///
+/// `caliptra_measurements` is pre-fetched from the Caliptra driver.
+/// Platform providers are queried here and their results appended.
+pub fn collect(
+    caliptra_measurements: Vec<Measurement>,
+    providers: &[Box<dyn MeasurementProvider>],
+) -> Result<Vec<Measurement>, AttestError> {
+    let mut all = caliptra_measurements;
+    for provider in providers {
+        let entries = provider.measurements().map_err(|e| {
+            AttestError::Provider(format!("provider '{}' failed: {e}", provider.component_name()))
+        })?;
+        all.extend(entries);
+    }
+    Ok(all)
+}
+
+/// Stub Caliptra measurements for use in tests (requires `test-support` feature).
+#[cfg(feature = "test-support")]
+pub fn test_caliptra_measurements() -> Vec<Measurement> {
+    use openprot_attest_api::{DigestAlgorithm, MeasurementAuthority};
+
+    vec![
+        Measurement {
+            component:  "Caliptra ROM".into(),
+            version:    "1.0.0".into(),
+            digest_alg: DigestAlgorithm::Sha384,
+            digest:     vec![0xAAu8; 48],
+            authority:  MeasurementAuthority::Caliptra,
+        },
+        Measurement {
+            component:  "Caliptra FMC".into(),
+            version:    "2.3.1".into(),
+            digest_alg: DigestAlgorithm::Sha384,
+            digest:     vec![0xBBu8; 48],
+            authority:  MeasurementAuthority::Caliptra,
+        },
+        Measurement {
+            component:  "Caliptra RT".into(),
+            version:    "2.3.1".into(),
+            digest_alg: DigestAlgorithm::Sha384,
+            digest:     vec![0xCCu8; 48],
+            authority:  MeasurementAuthority::Caliptra,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openprot_attest_api::{DigestAlgorithm, MeasurementAuthority};
+
+    struct StubProvider {
+        name: &'static str,
+        fail: bool,
+    }
+
+    impl MeasurementProvider for StubProvider {
+        fn component_name(&self) -> &str { self.name }
+        fn measurements(&self) -> Result<Vec<Measurement>, AttestError> {
+            if self.fail {
+                Err(AttestError::Provider("intentional failure".into()))
+            } else {
+                Ok(vec![Measurement {
+                    component:  self.name.into(),
+                    version:    "0.1".into(),
+                    digest_alg: DigestAlgorithm::Sha384,
+                    digest:     vec![0xBBu8; 48],
+                    authority:  MeasurementAuthority::Platform,
+                }])
+            }
+        }
+    }
+
+    fn rom() -> Measurement {
+        Measurement {
+            component:  "ROM".into(),
+            version:    "1.0".into(),
+            digest_alg: DigestAlgorithm::Sha384,
+            digest:     vec![0xAAu8; 48],
+            authority:  MeasurementAuthority::Caliptra,
+        }
+    }
+
+    #[test]
+    fn no_providers_returns_caliptra_measurements_unchanged() {
+        let result = collect(vec![rom()], &[]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].component, "ROM");
+    }
+
+    #[test]
+    fn provider_measurements_are_appended() {
+        let providers: Vec<Box<dyn MeasurementProvider>> =
+            vec![Box::new(StubProvider { name: "UEFI", fail: false })];
+        let result = collect(vec![rom()], &providers).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].component, "ROM");
+        assert_eq!(result[1].component, "UEFI");
+    }
+
+    #[test]
+    fn multiple_providers_all_appended() {
+        let providers: Vec<Box<dyn MeasurementProvider>> = vec![
+            Box::new(StubProvider { name: "UEFI", fail: false }),
+            Box::new(StubProvider { name: "BMC",  fail: false }),
+        ];
+        let result = collect(vec![], &providers).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn failing_provider_propagates_error() {
+        let providers: Vec<Box<dyn MeasurementProvider>> =
+            vec![Box::new(StubProvider { name: "BMC", fail: true })];
+        let err = collect(vec![], &providers).unwrap_err();
+        assert!(err.to_string().contains("BMC"));
+    }
+}

--- a/services/attest/producer/src/measurements.rs
+++ b/services/attest/producer/src/measurements.rs
@@ -19,7 +19,10 @@ pub fn collect(
     let mut all = caliptra_measurements;
     for provider in providers {
         let entries = provider.measurements().map_err(|e| {
-            AttestError::Provider(format!("provider '{}' failed: {e}", provider.component_name()))
+            AttestError::Provider(format!(
+                "provider '{}' failed: {e}",
+                provider.component_name()
+            ))
         })?;
         all.extend(entries);
     }
@@ -33,25 +36,25 @@ pub fn test_caliptra_measurements() -> Vec<Measurement> {
 
     vec![
         Measurement {
-            component:  "Caliptra ROM".into(),
-            version:    "1.0.0".into(),
+            component: "Caliptra ROM".into(),
+            version: "1.0.0".into(),
             digest_alg: DigestAlgorithm::Sha384,
-            digest:     vec![0xAAu8; 48],
-            authority:  MeasurementAuthority::Caliptra,
+            digest: vec![0xAAu8; 48],
+            authority: MeasurementAuthority::Caliptra,
         },
         Measurement {
-            component:  "Caliptra FMC".into(),
-            version:    "2.3.1".into(),
+            component: "Caliptra FMC".into(),
+            version: "2.3.1".into(),
             digest_alg: DigestAlgorithm::Sha384,
-            digest:     vec![0xBBu8; 48],
-            authority:  MeasurementAuthority::Caliptra,
+            digest: vec![0xBBu8; 48],
+            authority: MeasurementAuthority::Caliptra,
         },
         Measurement {
-            component:  "Caliptra RT".into(),
-            version:    "2.3.1".into(),
+            component: "Caliptra RT".into(),
+            version: "2.3.1".into(),
             digest_alg: DigestAlgorithm::Sha384,
-            digest:     vec![0xCCu8; 48],
-            authority:  MeasurementAuthority::Caliptra,
+            digest: vec![0xCCu8; 48],
+            authority: MeasurementAuthority::Caliptra,
         },
     ]
 }
@@ -67,17 +70,19 @@ mod tests {
     }
 
     impl MeasurementProvider for StubProvider {
-        fn component_name(&self) -> &str { self.name }
+        fn component_name(&self) -> &str {
+            self.name
+        }
         fn measurements(&self) -> Result<Vec<Measurement>, AttestError> {
             if self.fail {
                 Err(AttestError::Provider("intentional failure".into()))
             } else {
                 Ok(vec![Measurement {
-                    component:  self.name.into(),
-                    version:    "0.1".into(),
+                    component: self.name.into(),
+                    version: "0.1".into(),
                     digest_alg: DigestAlgorithm::Sha384,
-                    digest:     vec![0xBBu8; 48],
-                    authority:  MeasurementAuthority::Platform,
+                    digest: vec![0xBBu8; 48],
+                    authority: MeasurementAuthority::Platform,
                 }])
             }
         }
@@ -85,11 +90,11 @@ mod tests {
 
     fn rom() -> Measurement {
         Measurement {
-            component:  "ROM".into(),
-            version:    "1.0".into(),
+            component: "ROM".into(),
+            version: "1.0".into(),
             digest_alg: DigestAlgorithm::Sha384,
-            digest:     vec![0xAAu8; 48],
-            authority:  MeasurementAuthority::Caliptra,
+            digest: vec![0xAAu8; 48],
+            authority: MeasurementAuthority::Caliptra,
         }
     }
 
@@ -103,7 +108,10 @@ mod tests {
     #[test]
     fn provider_measurements_are_appended() {
         let providers: Vec<Box<dyn MeasurementProvider>> =
-            vec![Box::new(StubProvider { name: "UEFI", fail: false })];
+            vec![Box::new(StubProvider {
+                name: "UEFI",
+                fail: false,
+            })];
         let result = collect(vec![rom()], &providers).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].component, "ROM");
@@ -113,8 +121,14 @@ mod tests {
     #[test]
     fn multiple_providers_all_appended() {
         let providers: Vec<Box<dyn MeasurementProvider>> = vec![
-            Box::new(StubProvider { name: "UEFI", fail: false }),
-            Box::new(StubProvider { name: "BMC",  fail: false }),
+            Box::new(StubProvider {
+                name: "UEFI",
+                fail: false,
+            }),
+            Box::new(StubProvider {
+                name: "BMC",
+                fail: false,
+            }),
         ];
         let result = collect(vec![], &providers).unwrap();
         assert_eq!(result.len(), 2);
@@ -123,7 +137,10 @@ mod tests {
     #[test]
     fn failing_provider_propagates_error() {
         let providers: Vec<Box<dyn MeasurementProvider>> =
-            vec![Box::new(StubProvider { name: "BMC", fail: true })];
+            vec![Box::new(StubProvider {
+                name: "BMC",
+                fail: true,
+            })];
         let err = collect(vec![], &providers).unwrap_err();
         assert!(err.to_string().contains("BMC"));
     }

--- a/services/attest/producer/src/measurements.rs
+++ b/services/attest/producer/src/measurements.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! Firmware measurement collection.

--- a/services/attest/producer/src/signer.rs
+++ b/services/attest/producer/src/signer.rs
@@ -18,14 +18,18 @@ use crate::{builder, dice_identity, measurements};
 
 /// Attestation producer backed by a Caliptra hardware signer.
 pub struct HwAttestProducer {
-    signer:    Arc<dyn CaliptraSigner>,
-    config:    AttestConfig,
+    signer: Arc<dyn CaliptraSigner>,
+    config: AttestConfig,
     providers: Vec<Box<dyn MeasurementProvider>>,
 }
 
 impl HwAttestProducer {
     pub fn new(signer: Arc<dyn CaliptraSigner>, config: AttestConfig) -> Self {
-        Self { signer, config, providers: Vec::new() }
+        Self {
+            signer,
+            config,
+            providers: Vec::new(),
+        }
     }
 
     /// Register an additional measurement provider (UEFI, BMC, etc.).

--- a/services/attest/producer/src/signer.rs
+++ b/services/attest/producer/src/signer.rs
@@ -9,7 +9,8 @@
 use std::sync::Arc;
 
 use openprot_attest_api::{
-    AttestConfig, AttestError, AttestProducer, CaliptraSigner, CertChain, MeasurementProvider,
+    AttestConfig, AttestError, AttestProducer, CaliptraSigner, CertChain,
+    MeasurementProvider,
 };
 
 use crate::{builder, dice_identity, measurements};
@@ -39,7 +40,11 @@ impl HwAttestProducer {
 }
 
 impl AttestProducer for HwAttestProducer {
-    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError> {
+    fn generate_token(
+        &self,
+        nonce: &[u8],
+        evidence: &[u8],
+    ) -> Result<Vec<u8>, AttestError> {
         let meas = measurements::collect(vec![], &self.providers)?;
         builder::build(&self.config, &*self.signer, &meas, nonce, evidence)
     }
@@ -69,7 +74,11 @@ impl SoftwareAttestProducer {
 
 #[cfg(feature = "test-support")]
 impl AttestProducer for SoftwareAttestProducer {
-    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError> {
+    fn generate_token(
+        &self,
+        nonce: &[u8],
+        evidence: &[u8],
+    ) -> Result<Vec<u8>, AttestError> {
         let meas = measurements::test_caliptra_measurements();
         builder::build(&self.config, &StubSigner, &meas, nonce, evidence)
     }

--- a/services/attest/producer/src/signer.rs
+++ b/services/attest/producer/src/signer.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Concrete [`AttestProducer`] implementations.
+//!
+//! `HwAttestProducer` — backed by a real `CaliptraSigner` (mailbox driver).
+//! `SoftwareAttestProducer` — software-only stub, available under `test-support`.
+
+use std::sync::Arc;
+
+use openprot_attest_api::{
+    AttestConfig, AttestError, AttestProducer, CaliptraSigner, CertChain, MeasurementProvider,
+};
+
+use crate::{builder, dice_identity, measurements};
+
+// ── Hardware-backed producer ──────────────────────────────────────────────────
+
+/// Attestation producer backed by a Caliptra hardware signer.
+pub struct HwAttestProducer {
+    signer:    Arc<dyn CaliptraSigner>,
+    config:    AttestConfig,
+    providers: Vec<Box<dyn MeasurementProvider>>,
+}
+
+impl HwAttestProducer {
+    pub fn new(signer: Arc<dyn CaliptraSigner>, config: AttestConfig) -> Self {
+        Self { signer, config, providers: Vec::new() }
+    }
+
+    /// Register an additional measurement provider (UEFI, BMC, etc.).
+    pub fn add_provider(&mut self, provider: Box<dyn MeasurementProvider>) {
+        self.providers.push(provider);
+    }
+}
+
+impl AttestProducer for HwAttestProducer {
+    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError> {
+        let meas = measurements::collect(vec![], &self.providers)?;
+        builder::build(&self.config, &*self.signer, &meas, nonce, evidence)
+    }
+
+    fn cert_chain(&self) -> Result<CertChain, AttestError> {
+        dice_identity::cert_chain(&*self.signer)
+    }
+}
+
+// ── Software stub (test-support) ─────────────────────────────────────────────
+
+/// Software-backed attestation producer for use in tests.
+///
+/// Uses a deterministic P-384 key; produces structurally valid COSE_Sign1
+/// tokens without any Caliptra hardware.
+#[cfg(feature = "test-support")]
+pub struct SoftwareAttestProducer {
+    config: AttestConfig,
+}
+
+#[cfg(feature = "test-support")]
+impl SoftwareAttestProducer {
+    pub fn new(config: AttestConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[cfg(feature = "test-support")]
+impl AttestProducer for SoftwareAttestProducer {
+    fn generate_token(&self, nonce: &[u8], evidence: &[u8]) -> Result<Vec<u8>, AttestError> {
+        let meas = measurements::test_caliptra_measurements();
+        builder::build(&self.config, &StubSigner, &meas, nonce, evidence)
+    }
+
+    fn cert_chain(&self) -> Result<CertChain, AttestError> {
+        Ok(CertChain(vec![stub_leaf_cert(), stub_ca_cert()]))
+    }
+}
+
+// ── Stub signer used internally by SoftwareAttestProducer ────────────────────
+
+#[cfg(feature = "test-support")]
+struct StubSigner;
+
+#[cfg(feature = "test-support")]
+impl CaliptraSigner for StubSigner {
+    fn sign_es384(&self, _payload: &[u8]) -> Result<[u8; 96], AttestError> {
+        // Deterministic all-zero signature — structurally valid for token format tests.
+        Ok([0u8; 96])
+    }
+
+    fn alias_cert_der(&self) -> Result<Vec<u8>, AttestError> {
+        Ok(stub_leaf_cert())
+    }
+
+    fn cert_chain_der(&self) -> Result<Vec<Vec<u8>>, AttestError> {
+        Ok(vec![stub_leaf_cert(), stub_ca_cert()])
+    }
+}
+
+/// Minimal 1-byte DER placeholder representing the leaf certificate.
+#[cfg(feature = "test-support")]
+fn stub_leaf_cert() -> Vec<u8> {
+    vec![0x30, 0x00] // SEQUENCE {} — placeholder, not a real X.509 cert
+}
+
+/// Minimal 1-byte DER placeholder representing the CA certificate.
+#[cfg(feature = "test-support")]
+fn stub_ca_cert() -> Vec<u8> {
+    vec![0x30, 0x00]
+}

--- a/services/attest/producer/src/signer.rs
+++ b/services/attest/producer/src/signer.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
 //! Concrete [`AttestProducer`] implementations.

--- a/services/attest/producer/tests/producer_integration.rs
+++ b/services/attest/producer/tests/producer_integration.rs
@@ -11,16 +11,20 @@ use std::time::Duration;
 
 fn config() -> AttestConfig {
     AttestConfig {
-        oemid:          OemId(vec![0x00, 0x01, 0x47, 0xae]),
-        hw_model:       "TestPlatform".into(),
-        hw_version:     "0.1.0".into(),
+        oemid: OemId(vec![0x00, 0x01, 0x47, 0xae]),
+        hw_model: "TestPlatform".into(),
+        hw_version: "0.1.0".into(),
         cert_cache_ttl: Duration::from_secs(3600),
     }
 }
 
-fn decode_payload_map(token: &[u8]) -> Vec<(ciborium::value::Value, ciborium::value::Value)> {
-    let outer: ciborium::value::Value = ciborium::de::from_reader(token).unwrap();
-    let payload_bytes = outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
+fn decode_payload_map(
+    token: &[u8],
+) -> Vec<(ciborium::value::Value, ciborium::value::Value)> {
+    let outer: ciborium::value::Value =
+        ciborium::de::from_reader(token).unwrap();
+    let payload_bytes =
+        outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
     let payload: ciborium::value::Value =
         ciborium::de::from_reader(payload_bytes.as_slice()).unwrap();
     payload.as_map().unwrap().clone()
@@ -31,7 +35,9 @@ fn find_claim(
     key: i64,
 ) -> Option<ciborium::value::Value> {
     map.iter()
-        .find(|(k, _)| k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key))
+        .find(|(k, _)| {
+            k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key)
+        })
         .map(|(_, v)| v.clone())
 }
 
@@ -41,7 +47,8 @@ fn find_claim(
 fn token_is_four_element_cbor_array() {
     let producer = SoftwareAttestProducer::new(config());
     let token = producer.generate_token(b"testnonce12345678", &[]).unwrap();
-    let value: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    let value: ciborium::value::Value =
+        ciborium::de::from_reader(token.as_slice()).unwrap();
     assert_eq!(value.as_array().unwrap().len(), 4);
 }
 
@@ -49,7 +56,8 @@ fn token_is_four_element_cbor_array() {
 fn protected_header_is_bytes() {
     let producer = SoftwareAttestProducer::new(config());
     let token = producer.generate_token(b"n", &[]).unwrap();
-    let outer: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    let outer: ciborium::value::Value =
+        ciborium::de::from_reader(token.as_slice()).unwrap();
     assert!(outer.as_array().unwrap()[0].as_bytes().is_some());
 }
 
@@ -57,7 +65,8 @@ fn protected_header_is_bytes() {
 fn signature_is_96_zero_bytes() {
     let producer = SoftwareAttestProducer::new(config());
     let token = producer.generate_token(b"n", &[]).unwrap();
-    let outer: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    let outer: ciborium::value::Value =
+        ciborium::de::from_reader(token.as_slice()).unwrap();
     let sig = outer.as_array().unwrap()[3].as_bytes().unwrap();
     assert_eq!(sig.len(), 96);
     assert!(sig.iter().all(|&b| b == 0));

--- a/services/attest/producer/tests/producer_integration.rs
+++ b/services/attest/producer/tests/producer_integration.rs
@@ -1,3 +1,4 @@
+// Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 // Integration tests for openprot-attest-producer.
 // Requires: cargo test --features test-support

--- a/services/attest/producer/tests/producer_integration.rs
+++ b/services/attest/producer/tests/producer_integration.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Integration tests for openprot-attest-producer.
+// Requires: cargo test --features test-support
+
+#![cfg(feature = "test-support")]
+
+use openprot_attest_api::{AttestConfig, AttestProducer, OemId};
+use openprot_attest_producer::SoftwareAttestProducer;
+use std::time::Duration;
+
+fn config() -> AttestConfig {
+    AttestConfig {
+        oemid:          OemId(vec![0x00, 0x01, 0x47, 0xae]),
+        hw_model:       "TestPlatform".into(),
+        hw_version:     "0.1.0".into(),
+        cert_cache_ttl: Duration::from_secs(3600),
+    }
+}
+
+fn decode_payload_map(token: &[u8]) -> Vec<(ciborium::value::Value, ciborium::value::Value)> {
+    let outer: ciborium::value::Value = ciborium::de::from_reader(token).unwrap();
+    let payload_bytes = outer.as_array().unwrap()[2].as_bytes().unwrap().clone();
+    let payload: ciborium::value::Value =
+        ciborium::de::from_reader(payload_bytes.as_slice()).unwrap();
+    payload.as_map().unwrap().clone()
+}
+
+fn find_claim(
+    map: &[(ciborium::value::Value, ciborium::value::Value)],
+    key: i64,
+) -> Option<ciborium::value::Value> {
+    map.iter()
+        .find(|(k, _)| k.as_integer().and_then(|i| i64::try_from(i).ok()) == Some(key))
+        .map(|(_, v)| v.clone())
+}
+
+// ── Token structure ──────────────────────────────────────────────────────────
+
+#[test]
+fn token_is_four_element_cbor_array() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"testnonce12345678", &[]).unwrap();
+    let value: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    assert_eq!(value.as_array().unwrap().len(), 4);
+}
+
+#[test]
+fn protected_header_is_bytes() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"n", &[]).unwrap();
+    let outer: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    assert!(outer.as_array().unwrap()[0].as_bytes().is_some());
+}
+
+#[test]
+fn signature_is_96_zero_bytes() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"n", &[]).unwrap();
+    let outer: ciborium::value::Value = ciborium::de::from_reader(token.as_slice()).unwrap();
+    let sig = outer.as_array().unwrap()[3].as_bytes().unwrap();
+    assert_eq!(sig.len(), 96);
+    assert!(sig.iter().all(|&b| b == 0));
+}
+
+// ── Payload claims ───────────────────────────────────────────────────────────
+
+#[test]
+fn nonce_claim_matches_input() {
+    let producer = SoftwareAttestProducer::new(config());
+    let nonce = b"unique_nonce_bytes";
+    let token = producer.generate_token(nonce, &[]).unwrap();
+    let map = decode_payload_map(&token);
+    let v = find_claim(&map, 10).unwrap(); // eat_nonce
+    assert_eq!(v.as_bytes().unwrap(), nonce);
+}
+
+#[test]
+fn hw_model_claim_matches_config() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"n", &[]).unwrap();
+    let map = decode_payload_map(&token);
+    let v = find_claim(&map, 259).unwrap(); // hwmodel
+    assert_eq!(v.as_text().unwrap(), "TestPlatform");
+}
+
+#[test]
+fn measurements_claim_contains_three_caliptra_components() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"n", &[]).unwrap();
+    let map = decode_payload_map(&token);
+    let v = find_claim(&map, -70000).unwrap(); // measurements
+    assert_eq!(v.as_array().unwrap().len(), 3);
+}
+
+// ── Evidence embedding ───────────────────────────────────────────────────────
+
+#[test]
+fn empty_evidence_omits_evidence_claim() {
+    let producer = SoftwareAttestProducer::new(config());
+    let token = producer.generate_token(b"n", &[]).unwrap();
+    let map = decode_payload_map(&token);
+    assert!(find_claim(&map, -70001).is_none());
+}
+
+#[test]
+fn evidence_bytes_embedded_verbatim() {
+    let producer = SoftwareAttestProducer::new(config());
+    let evidence = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let token = producer.generate_token(b"n", &evidence).unwrap();
+    let map = decode_payload_map(&token);
+    let v = find_claim(&map, -70001).unwrap();
+    assert_eq!(v.as_bytes().unwrap(), &evidence);
+}
+
+// ── Certificate chain ────────────────────────────────────────────────────────
+
+#[test]
+fn cert_chain_returns_two_certs() {
+    let producer = SoftwareAttestProducer::new(config());
+    let chain = producer.cert_chain().unwrap();
+    assert_eq!(chain.0.len(), 2);
+}

--- a/third_party/crates_io/Cargo.lock
+++ b/third_party/crates_io/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "as-slice"
@@ -158,14 +158,14 @@ checksum = "d3ca019570363e800b05ad4fd890734f28ac7b72f563ad8a35079efb793616f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -184,15 +184,42 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -206,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -216,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -229,14 +256,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -278,22 +305,22 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d4dec46b34c299ccf6b036717ae0fce602faa4f4fe816d9013b9a7c9f5ba6"
+checksum = "9c439b23bf18154d8a634543caf1ee73cceb723f2902f7ea243634159a00fd47"
 dependencies = [
  "cortex-m-rt-macros",
 ]
 
 [[package]]
 name = "cortex-m-rt-macros"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
+checksum = "061a75f3e7f3f01d649668d68e02d0ef92c7041a9c97b8fe6bc354ddbf40822d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -343,6 +370,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -412,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -549,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -564,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -574,15 +607,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -591,38 +624,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -671,6 +704,17 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -801,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -822,24 +866,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mctp"
 version = "0.2.0"
-source = "git+https://github.com/CodeConstruct/mctp-rs.git?branch=main#b134e145f93d634dff7eb9f2a01559273c687365"
+source = "git+https://github.com/CodeConstruct/mctp-rs.git?branch=main#574e3a9889fe09954f9e08b10c72e7ea9e156dd0"
 
 [[package]]
 name = "mctp"
 version = "0.2.0"
-source = "git+https://github.com/CodeConstruct/mctp-rs.git#b134e145f93d634dff7eb9f2a01559273c687365"
+source = "git+https://github.com/CodeConstruct/mctp-rs.git#574e3a9889fe09954f9e08b10c72e7ea9e156dd0"
 
 [[package]]
 name = "mctp-estack"
 version = "0.1.0"
-source = "git+https://github.com/CodeConstruct/mctp-rs.git?branch=main#b134e145f93d634dff7eb9f2a01559273c687365"
+source = "git+https://github.com/CodeConstruct/mctp-rs.git?branch=main#574e3a9889fe09954f9e08b10c72e7ea9e156dd0"
 dependencies = [
  "crc",
  "embedded-io",
@@ -862,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memo-map"
@@ -883,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
  "memo-map",
  "serde",
@@ -909,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1042,9 +1086,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1052,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1062,25 +1106,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -1112,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1139,14 +1182,14 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1226,7 +1269,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1237,7 +1280,7 @@ checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1264,7 +1307,7 @@ checksum = "30f19a85fe107b65031e0ba8ec60c34c2494069fe910d6c297f5e7cb5a6f76d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1290,6 +1333,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "cfg-if",
+ "ciborium",
  "cipher",
  "clap",
  "compiler_builtins",
@@ -1342,7 +1386,7 @@ dependencies = [
  "spdm-lib",
  "subtle",
  "syn 1.0.109",
- "syn 2.0.117",
+ "syn 2.0.119",
  "thiserror",
  "tock-registers",
  "tokio",
@@ -1354,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc_version"
@@ -1425,9 +1469,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1435,22 +1479,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1507,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -1519,9 +1563,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smbus-pec"
@@ -1555,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1609,9 +1653,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1630,22 +1685,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1655,9 +1710,9 @@ source = "git+https://github.com/tock/tock.git?rev=release-2.2#9554639b17501a9f5
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1672,20 +1727,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1696,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"
@@ -1736,9 +1791,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 
 [[package]]
 name = "vcell"
@@ -1790,40 +1845,40 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]

--- a/third_party/crates_io/Cargo.toml
+++ b/third_party/crates_io/Cargo.toml
@@ -80,6 +80,7 @@ aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
 cipher = { version = "0.4", default-features = false }
 
 # Host tool crates needed by pigweed pw_kernel/tooling
+ciborium = { version = "0.2", default-features = false }
 anyhow = "1.0.103"
 clap = { version = "4.5.40", features = ["derive", "env", "wrap_help"] }
 futures = "0.3"


### PR DESCRIPTION
First cut at an attester service library based on the OCP-EAT standard.  This has not been regression tested yet, so please put it in a staging area before merge into the repo.