### PR TITLE
fwmanager: downstream update lifecycle tests with slot and boot-progress capabilities

### DIFF
--- a/platform/impls/baremetal/mock/BUILD.bazel
+++ b/platform/impls/baremetal/mock/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
     deps = [
         "//hal/blocking",
         "//hal/blocking/flash",
+        "//services/fwmanager/api:fwmanager_api",
         "//util/types",
         "@rust_crates//:cortex-m",
         "@rust_crates//:embedded-hal",

--- a/platform/impls/baremetal/mock/BUILD.bazel
+++ b/platform/impls/baremetal/mock/BUILD.bazel
@@ -15,6 +15,8 @@ rust_library(
     edition = "2024",
     deps = [
         "//hal/blocking",
+        "//hal/blocking/flash",
+        "//util/types",
         "@rust_crates//:cortex-m",
         "@rust_crates//:embedded-hal",
     ],

--- a/platform/impls/baremetal/mock/src/downstream_device.rs
+++ b/platform/impls/baremetal/mock/src/downstream_device.rs
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Mock downstream device: one managed device as the eRoT sees it — a reset
-//! line in, a boot-complete line out, and its firmware flash.
-//!
-//! All three handles observe the same device state, so a test can bind them
-//! to real adapters and treat the eRoT plus device as a black box: load a
-//! firmware image, run the boot flow, and check only externally visible
-//! outcomes (was the device released, did it report boot-complete).
+//! line in, a boot-complete line out, A/B firmware slots, a staging region,
+//! and a slot-selection store. All handles observe the same device state,
+//! so tests can bind real adapters and assert only on externally visible
+//! outcomes.
 
 use core::cell::RefCell;
 use core::num::NonZero;
 
+use fwmanager_api::SlotControl;
 use hal_flash::{Flash, FlashAddress};
 use openprot_hal_blocking::gpio_port::{
     GpioError, GpioErrorKind, GpioErrorType, GpioPort, PinMask,
@@ -21,7 +20,7 @@ use util_types::PowerOf2Usize;
 
 use crate::system_control::MockSystemControlError;
 
-/// Flash size of the mock device.
+/// Flash size of the mock device (per slot and for the staging region).
 pub const MOCK_DEVICE_FLASH_SIZE: usize = 256;
 
 struct DeviceState {
@@ -33,13 +32,37 @@ struct DeviceState {
     /// Hardware latch on the boot-complete line. Cleared by the reset line,
     /// as the platform wiring requires.
     ready_latched: bool,
-    flash: [u8; MOCK_DEVICE_FLASH_SIZE],
+    /// The device's two firmware slots (A = 0, B = 1).
+    slots: [[u8; MOCK_DEVICE_FLASH_SIZE]; 2],
+    /// Staging area an update is written to before activation.
+    staging: [u8; MOCK_DEVICE_FLASH_SIZE],
+    /// The slot the device boots by default; survives resets.
+    committed_slot: usize,
+    /// Slot armed for a trial boot. One-shot as a boot selector (consumed
+    /// by the release that boots it); promotable until commit/rollback.
+    trial_slot: Option<usize>,
+    /// Whether the armed trial was already consumed by a boot.
+    trial_consumed: bool,
     flash_reads: usize,
     /// Recorded at the first release: had the device's flash been read by
     /// then? Lets tests prove verification preceded release.
     release_preceded_by_flash_read: Option<bool>,
+    /// The slot the device booted at its most recent release.
+    last_boot_slot: Option<usize>,
+    /// Program operations that touched a *bootable slot* while the device
+    /// was running — must stay zero in a correct flow. Staging writes
+    /// don't count.
+    programs_while_running: usize,
+    /// Recorded at the first commit: had the device reported boot-complete
+    /// by then? Proves commit waited for boot confirmation.
+    commit_preceded_by_ready: Option<bool>,
+    commit_count: usize,
+    rollback_count: usize,
     reset_fault: Option<MockSystemControlError>,
     gpio_fault: Option<GpioErrorKind>,
+    /// When set, every flash program operation fails, simulating a device
+    /// whose firmware write path is broken.
+    program_fault: bool,
 }
 
 impl DeviceState {
@@ -55,6 +78,15 @@ impl DeviceState {
             }
         }
         self.ready_latched
+    }
+
+    /// The slot the next release would boot: an armed, not-yet-consumed
+    /// trial wins, otherwise the committed slot.
+    fn boot_slot(&self) -> usize {
+        match self.trial_slot {
+            Some(trial) if !self.trial_consumed => trial,
+            _ => self.committed_slot,
+        }
     }
 }
 
@@ -74,23 +106,34 @@ impl MockDownstreamDevice {
                 boots_after,
                 polls_since_release: 0,
                 ready_latched: false,
-                flash: [0xFF; MOCK_DEVICE_FLASH_SIZE],
+                slots: [[0xFF; MOCK_DEVICE_FLASH_SIZE]; 2],
+                staging: [0xFF; MOCK_DEVICE_FLASH_SIZE],
+                committed_slot: 0,
+                trial_slot: None,
+                trial_consumed: false,
                 flash_reads: 0,
                 release_preceded_by_flash_read: None,
+                last_boot_slot: None,
+                programs_while_running: 0,
+                commit_preceded_by_ready: None,
+                commit_count: 0,
+                rollback_count: 0,
                 reset_fault: None,
                 gpio_fault: None,
+                program_fault: false,
             }),
         }
     }
 
-    /// Writes `image` to the start of the device's flash.
+    /// Writes `image` to the start of the device's current boot slot.
     ///
     /// # Panics
     ///
     /// Panics if `image` exceeds [`MOCK_DEVICE_FLASH_SIZE`].
     pub fn load_firmware(&self, image: &[u8]) {
         let mut state = self.state.borrow_mut();
-        state.flash[..image.len()].copy_from_slice(image);
+        let slot = state.boot_slot();
+        state.slots[slot][..image.len()].copy_from_slice(image);
     }
 
     /// Latches the boot-complete line, simulating evidence left over from a
@@ -123,9 +166,42 @@ impl MockDownstreamDevice {
         }
     }
 
-    /// The device's firmware flash, as the eRoT's interposer sees it.
+    /// The device's firmware flash, as the eRoT's interposer sees it:
+    /// reads and writes land in the slot the next release would boot.
     pub fn flash(&self) -> MockDeviceFlash<'_> {
-        MockDeviceFlash { state: &self.state }
+        MockDeviceFlash {
+            state: &self.state,
+            region: MockRegion::BootSlot,
+        }
+    }
+
+    /// A specific flash region of the device. Accesses through this handle
+    /// don't count toward [`Self::flash_reads`] — that instrumentation
+    /// proves boot-image verification, not update plumbing.
+    pub fn region_flash(&self, region: MockRegion) -> MockDeviceFlash<'_> {
+        MockDeviceFlash {
+            state: &self.state,
+            region,
+        }
+    }
+
+    /// The device's slot-selection store, for the eRoT's [`SlotControl`]
+    /// binding.
+    pub fn slot_store(&self) -> MockDeviceSlotStore<'_> {
+        MockDeviceSlotStore { state: &self.state }
+    }
+
+    /// Re-script when the device asserts boot-complete after its next
+    /// release; `None` makes it never come up. Lets one test cover several
+    /// boot cycles with different outcomes.
+    pub fn set_boots_after(&self, boots_after: Option<usize>) {
+        self.state.borrow_mut().boots_after = boots_after;
+    }
+
+    /// Makes every flash program operation fail, simulating a device whose
+    /// firmware write path is broken.
+    pub fn inject_program_fault(&self) {
+        self.state.borrow_mut().program_fault = true;
     }
 
     pub fn is_in_reset(&self) -> bool {
@@ -144,6 +220,43 @@ impl MockDownstreamDevice {
     /// release, `Some(false)` if not, `None` if it was never released.
     pub fn release_preceded_by_flash_read(&self) -> Option<bool> {
         self.state.borrow().release_preceded_by_flash_read
+    }
+
+    /// The slot committed as the device's default boot selection.
+    pub fn committed_slot(&self) -> usize {
+        self.state.borrow().committed_slot
+    }
+
+    /// The slot the device booted at its most recent release, `None` if it
+    /// was never released.
+    pub fn last_boot_slot(&self) -> Option<usize> {
+        self.state.borrow().last_boot_slot
+    }
+
+    /// Program operations that touched a bootable slot while the device was
+    /// running — nonzero means firmware was written under a live device.
+    /// Staging writes are exempt.
+    pub fn programs_while_running(&self) -> usize {
+        self.state.borrow().programs_while_running
+    }
+
+    /// `Some(true)` if the device had reported boot-complete before its
+    /// first commit, `Some(false)` if not, `None` if nothing was committed.
+    pub fn commit_preceded_by_ready(&self) -> Option<bool> {
+        self.state.borrow().commit_preceded_by_ready
+    }
+
+    pub fn commit_count(&self) -> usize {
+        self.state.borrow().commit_count
+    }
+
+    pub fn rollback_count(&self) -> usize {
+        self.state.borrow().rollback_count
+    }
+
+    /// The raw content of `slot`, for image-landed-where-expected checks.
+    pub fn slot_content(&self, slot: usize) -> [u8; MOCK_DEVICE_FLASH_SIZE] {
+        self.state.borrow().slots[slot]
     }
 }
 
@@ -181,6 +294,12 @@ impl ResetControl for MockDeviceResetLine<'_> {
         }
         state.in_reset = false;
         state.polls_since_release = 0;
+        let slot = state.boot_slot();
+        state.last_boot_slot = Some(slot);
+        // One-shot arming: this boot consumes the trial selector.
+        if state.trial_slot.is_some() {
+            state.trial_consumed = true;
+        }
         Ok(())
     }
 
@@ -288,13 +407,27 @@ impl GpioPort for MockDeviceReadyLine<'_> {
 pub enum MockFlashError {
     /// Access past [`MOCK_DEVICE_FLASH_SIZE`].
     OutOfRange,
+    /// The device's firmware write path is broken (injected fault).
+    ProgramFault,
 }
 
-/// The device's firmware flash. Reads count toward
-/// [`MockDownstreamDevice::flash_reads`], so tests can prove the eRoT
-/// verified firmware before releasing the device.
+/// One addressable flash region of the mock device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MockRegion {
+    /// The slot the device's next release would boot (an armed, unconsumed
+    /// trial, else the committed slot).
+    BootSlot,
+    /// An explicit firmware slot (A = 0, B = 1).
+    Slot(usize),
+    /// The staging area updates are written to before activation.
+    Staging,
+}
+
+/// A flash view of the device. Only the [`MockRegion::BootSlot`] view
+/// counts reads toward [`MockDownstreamDevice::flash_reads`].
 pub struct MockDeviceFlash<'d> {
     state: &'d RefCell<DeviceState>,
+    region: MockRegion,
 }
 
 impl MockDeviceFlash<'_> {
@@ -305,6 +438,17 @@ impl MockDeviceFlash<'_> {
             return Err(MockFlashError::OutOfRange);
         }
         Ok(start..end)
+    }
+
+    fn region_mut<'s>(&self, state: &'s mut DeviceState) -> &'s mut [u8; MOCK_DEVICE_FLASH_SIZE] {
+        match self.region {
+            MockRegion::BootSlot => {
+                let slot = state.boot_slot();
+                &mut state.slots[slot]
+            }
+            MockRegion::Slot(slot) => &mut state.slots[slot],
+            MockRegion::Staging => &mut state.staging,
+        }
     }
 }
 
@@ -320,8 +464,11 @@ impl Flash for MockDeviceFlash<'_> {
     fn read(&mut self, start_addr: FlashAddress, buf: &mut [u8]) -> Result<(), MockFlashError> {
         let range = Self::range(start_addr, buf.len())?;
         let mut state = self.state.borrow_mut();
-        buf.copy_from_slice(&state.flash[range]);
-        state.flash_reads += 1;
+        let region = self.region_mut(&mut state);
+        buf.copy_from_slice(&region[range]);
+        if self.region == MockRegion::BootSlot {
+            state.flash_reads += 1;
+        }
         Ok(())
     }
 
@@ -331,13 +478,91 @@ impl Flash for MockDeviceFlash<'_> {
         size: PowerOf2Usize,
     ) -> Result<(), MockFlashError> {
         let range = Self::range(start_addr, size.get())?;
-        self.state.borrow_mut().flash[range].fill(0xFF);
+        let mut state = self.state.borrow_mut();
+        self.region_mut(&mut state)[range].fill(0xFF);
         Ok(())
     }
 
     fn program(&mut self, start_addr: FlashAddress, data: &[u8]) -> Result<(), MockFlashError> {
         let range = Self::range(start_addr, data.len())?;
-        self.state.borrow_mut().flash[range].copy_from_slice(data);
+        let mut state = self.state.borrow_mut();
+        if state.program_fault {
+            return Err(MockFlashError::ProgramFault);
+        }
+        if !state.in_reset && self.region != MockRegion::Staging {
+            state.programs_while_running += 1;
+        }
+        self.region_mut(&mut state)[range].copy_from_slice(data);
+        Ok(())
+    }
+}
+
+/// Error of the mock device's slot store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MockSlotError {
+    /// Commit or rollback was called with no trial armed.
+    NoTrialArmed,
+    /// A slot index outside A/B.
+    InvalidSlot,
+}
+
+impl core::fmt::Display for MockSlotError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NoTrialArmed => f.write_str("no trial slot armed"),
+            Self::InvalidSlot => f.write_str("slot index outside A/B"),
+        }
+    }
+}
+
+impl core::error::Error for MockSlotError {}
+
+/// The device's slot-selection store, implementing [`SlotControl`] with
+/// one-shot arming. Records whether the first commit happened after the
+/// device reported boot-complete.
+pub struct MockDeviceSlotStore<'d> {
+    state: &'d RefCell<DeviceState>,
+}
+
+impl SlotControl for MockDeviceSlotStore<'_> {
+    type SlotId = usize;
+    type Error = MockSlotError;
+
+    fn active_slot(&self) -> Result<usize, MockSlotError> {
+        Ok(self.state.borrow().committed_slot)
+    }
+
+    fn trial_slot(&self) -> Result<Option<usize>, MockSlotError> {
+        Ok(self.state.borrow().trial_slot)
+    }
+
+    fn set_trial(&mut self, slot: usize) -> Result<(), MockSlotError> {
+        if slot > 1 {
+            return Err(MockSlotError::InvalidSlot);
+        }
+        let mut state = self.state.borrow_mut();
+        state.trial_slot = Some(slot);
+        state.trial_consumed = false;
+        Ok(())
+    }
+
+    fn commit(&mut self) -> Result<(), MockSlotError> {
+        let mut state = self.state.borrow_mut();
+        let trial = state.trial_slot.take().ok_or(MockSlotError::NoTrialArmed)?;
+        if state.commit_preceded_by_ready.is_none() {
+            state.commit_preceded_by_ready = Some(state.ready_latched);
+        }
+        state.committed_slot = trial;
+        state.trial_consumed = false;
+        state.commit_count += 1;
+        Ok(())
+    }
+
+    fn rollback(&mut self) -> Result<(), MockSlotError> {
+        let mut state = self.state.borrow_mut();
+        state.trial_slot.take().ok_or(MockSlotError::NoTrialArmed)?;
+        state.trial_consumed = false;
+        state.rollback_count += 1;
         Ok(())
     }
 }

--- a/platform/impls/baremetal/mock/src/downstream_device.rs
+++ b/platform/impls/baremetal/mock/src/downstream_device.rs
@@ -1,0 +1,343 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Mock downstream device: one managed device as the eRoT sees it — a reset
+//! line in, a boot-complete line out, and its firmware flash.
+//!
+//! All three handles observe the same device state, so a test can bind them
+//! to real adapters and treat the eRoT plus device as a black box: load a
+//! firmware image, run the boot flow, and check only externally visible
+//! outcomes (was the device released, did it report boot-complete).
+
+use core::cell::RefCell;
+use core::num::NonZero;
+
+use hal_flash::{Flash, FlashAddress};
+use openprot_hal_blocking::gpio_port::{
+    GpioError, GpioErrorKind, GpioErrorType, GpioPort, PinMask,
+};
+use openprot_hal_blocking::system_control::{ErrorType, ResetControl};
+use util_types::PowerOf2Usize;
+
+use crate::system_control::MockSystemControlError;
+
+/// Flash size of the mock device.
+pub const MOCK_DEVICE_FLASH_SIZE: usize = 256;
+
+struct DeviceState {
+    in_reset: bool,
+    /// Boot-complete polls after release until the device asserts ready;
+    /// `None` means the device never comes up.
+    boots_after: Option<usize>,
+    polls_since_release: usize,
+    /// Hardware latch on the boot-complete line. Cleared by the reset line,
+    /// as the platform wiring requires.
+    ready_latched: bool,
+    flash: [u8; MOCK_DEVICE_FLASH_SIZE],
+    flash_reads: usize,
+    /// Recorded at the first release: had the device's flash been read by
+    /// then? Lets tests prove verification preceded release.
+    release_preceded_by_flash_read: Option<bool>,
+    reset_fault: Option<MockSystemControlError>,
+    gpio_fault: Option<GpioErrorKind>,
+}
+
+impl DeviceState {
+    /// One boot-complete sample: a running device asserts the line once it
+    /// has finished booting; the latch holds it until the next reset.
+    fn sample_ready(&mut self) -> bool {
+        if !self.in_reset {
+            self.polls_since_release += 1;
+            if let Some(n) = self.boots_after
+                && self.polls_since_release > n
+            {
+                self.ready_latched = true;
+            }
+        }
+        self.ready_latched
+    }
+}
+
+/// One simulated downstream device (for example a BMC), initially held in
+/// reset with erased flash.
+pub struct MockDownstreamDevice {
+    state: RefCell<DeviceState>,
+}
+
+impl MockDownstreamDevice {
+    /// A device that asserts boot-complete `boots_after` status polls after
+    /// its release from reset; `None` builds a device that never comes up.
+    pub fn held_in_reset(boots_after: Option<usize>) -> Self {
+        Self {
+            state: RefCell::new(DeviceState {
+                in_reset: true,
+                boots_after,
+                polls_since_release: 0,
+                ready_latched: false,
+                flash: [0xFF; MOCK_DEVICE_FLASH_SIZE],
+                flash_reads: 0,
+                release_preceded_by_flash_read: None,
+                reset_fault: None,
+                gpio_fault: None,
+            }),
+        }
+    }
+
+    /// Writes `image` to the start of the device's flash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `image` exceeds [`MOCK_DEVICE_FLASH_SIZE`].
+    pub fn load_firmware(&self, image: &[u8]) {
+        let mut state = self.state.borrow_mut();
+        state.flash[..image.len()].copy_from_slice(image);
+    }
+
+    /// Latches the boot-complete line, simulating evidence left over from a
+    /// previous boot cycle.
+    pub fn latch_ready(&self) {
+        self.state.borrow_mut().ready_latched = true;
+    }
+
+    /// Makes every reset-line operation fail with `err`.
+    pub fn inject_reset_fault(&self, err: MockSystemControlError) {
+        self.state.borrow_mut().reset_fault = Some(err);
+    }
+
+    /// Makes every boot-complete sample fail with `kind`.
+    pub fn inject_gpio_fault(&self, kind: GpioErrorKind) {
+        self.state.borrow_mut().gpio_fault = Some(kind);
+    }
+
+    /// The device's reset line, for the eRoT's reset controller binding.
+    pub fn reset_line(&self) -> MockDeviceResetLine<'_> {
+        MockDeviceResetLine { state: &self.state }
+    }
+
+    /// The device's boot-complete line, read back as `pin` of a GPIO input
+    /// bank.
+    pub fn ready_line(&self, pin: MockPinMask) -> MockDeviceReadyLine<'_> {
+        MockDeviceReadyLine {
+            state: &self.state,
+            pin,
+        }
+    }
+
+    /// The device's firmware flash, as the eRoT's interposer sees it.
+    pub fn flash(&self) -> MockDeviceFlash<'_> {
+        MockDeviceFlash { state: &self.state }
+    }
+
+    pub fn is_in_reset(&self) -> bool {
+        self.state.borrow().in_reset
+    }
+
+    pub fn polls_since_release(&self) -> usize {
+        self.state.borrow().polls_since_release
+    }
+
+    pub fn flash_reads(&self) -> usize {
+        self.state.borrow().flash_reads
+    }
+
+    /// `Some(true)` if the device's flash had been read before its first
+    /// release, `Some(false)` if not, `None` if it was never released.
+    pub fn release_preceded_by_flash_read(&self) -> Option<bool> {
+        self.state.borrow().release_preceded_by_flash_read
+    }
+}
+
+/// The device's reset line. The line selection already happened when this
+/// handle was made, so the `ResetId` is ignored.
+pub struct MockDeviceResetLine<'d> {
+    state: &'d RefCell<DeviceState>,
+}
+
+impl ErrorType for MockDeviceResetLine<'_> {
+    type Error = MockSystemControlError;
+}
+
+impl ResetControl for MockDeviceResetLine<'_> {
+    type ResetId = u8;
+
+    fn reset_assert(&mut self, _: &u8) -> Result<(), MockSystemControlError> {
+        let mut state = self.state.borrow_mut();
+        if let Some(err) = state.reset_fault {
+            return Err(err);
+        }
+        state.in_reset = true;
+        // The latch's clear input is tied to the device's reset line.
+        state.ready_latched = false;
+        Ok(())
+    }
+
+    fn reset_deassert(&mut self, _: &u8) -> Result<(), MockSystemControlError> {
+        let mut state = self.state.borrow_mut();
+        if let Some(err) = state.reset_fault {
+            return Err(err);
+        }
+        if state.release_preceded_by_flash_read.is_none() {
+            state.release_preceded_by_flash_read = Some(state.flash_reads > 0);
+        }
+        state.in_reset = false;
+        state.polls_since_release = 0;
+        Ok(())
+    }
+
+    fn reset_pulse(
+        &mut self,
+        id: &u8,
+        _: core::time::Duration,
+    ) -> Result<(), MockSystemControlError> {
+        self.reset_assert(id)?;
+        self.reset_deassert(id)
+    }
+
+    fn reset_is_asserted(&self, _: &u8) -> Result<bool, MockSystemControlError> {
+        Ok(self.state.borrow().in_reset)
+    }
+}
+
+/// Bitmask over the mock GPIO input bank the device's boot-complete line is
+/// wired to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MockPinMask(pub u8);
+
+impl PinMask for MockPinMask {
+    fn empty() -> Self {
+        Self(0)
+    }
+
+    fn all() -> Self {
+        Self(u8::MAX)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    fn union(&self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    fn intersection(&self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    fn toggle(&self) -> Self {
+        Self(!self.0)
+    }
+}
+
+/// Error of the mock GPIO input bank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MockGpioFault(pub GpioErrorKind);
+
+impl GpioError for MockGpioFault {
+    fn kind(&self) -> GpioErrorKind {
+        self.0
+    }
+}
+
+/// GPIO input bank carrying the device's boot-complete line. Input-only:
+/// the output-side methods panic.
+pub struct MockDeviceReadyLine<'d> {
+    state: &'d RefCell<DeviceState>,
+    pin: MockPinMask,
+}
+
+impl GpioErrorType for MockDeviceReadyLine<'_> {
+    type Error = MockGpioFault;
+}
+
+impl GpioPort for MockDeviceReadyLine<'_> {
+    type Config = ();
+    type Mask = MockPinMask;
+
+    fn read_input(&self) -> Result<MockPinMask, MockGpioFault> {
+        let mut state = self.state.borrow_mut();
+        if let Some(kind) = state.gpio_fault {
+            return Err(MockGpioFault(kind));
+        }
+        Ok(if state.sample_ready() {
+            self.pin
+        } else {
+            MockPinMask::empty()
+        })
+    }
+
+    fn configure(&mut self, _: MockPinMask, _: ()) -> Result<(), MockGpioFault> {
+        panic!("the mock device's ready line is input-only");
+    }
+
+    fn set_reset(&mut self, _: MockPinMask, _: MockPinMask) -> Result<(), MockGpioFault> {
+        panic!("the mock device's ready line is input-only");
+    }
+
+    fn toggle(&mut self, _: MockPinMask) -> Result<(), MockGpioFault> {
+        panic!("the mock device's ready line is input-only");
+    }
+}
+
+/// Error of the mock device flash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MockFlashError {
+    /// Access past [`MOCK_DEVICE_FLASH_SIZE`].
+    OutOfRange,
+}
+
+/// The device's firmware flash. Reads count toward
+/// [`MockDownstreamDevice::flash_reads`], so tests can prove the eRoT
+/// verified firmware before releasing the device.
+pub struct MockDeviceFlash<'d> {
+    state: &'d RefCell<DeviceState>,
+}
+
+impl MockDeviceFlash<'_> {
+    fn range(addr: FlashAddress, len: usize) -> Result<core::ops::Range<usize>, MockFlashError> {
+        let start = addr.offset() as usize;
+        let end = start.checked_add(len).ok_or(MockFlashError::OutOfRange)?;
+        if end > MOCK_DEVICE_FLASH_SIZE {
+            return Err(MockFlashError::OutOfRange);
+        }
+        Ok(start..end)
+    }
+}
+
+impl Flash for MockDeviceFlash<'_> {
+    type Error = MockFlashError;
+
+    fn geometry(&mut self) -> Result<(NonZero<usize>, PowerOf2Usize, u32), MockFlashError> {
+        let size = NonZero::new(MOCK_DEVICE_FLASH_SIZE).unwrap();
+        let page = PowerOf2Usize::new(MOCK_DEVICE_FLASH_SIZE).unwrap();
+        Ok((size, page, 1 << MOCK_DEVICE_FLASH_SIZE.trailing_zeros()))
+    }
+
+    fn read(&mut self, start_addr: FlashAddress, buf: &mut [u8]) -> Result<(), MockFlashError> {
+        let range = Self::range(start_addr, buf.len())?;
+        let mut state = self.state.borrow_mut();
+        buf.copy_from_slice(&state.flash[range]);
+        state.flash_reads += 1;
+        Ok(())
+    }
+
+    fn erase(
+        &mut self,
+        start_addr: FlashAddress,
+        size: PowerOf2Usize,
+    ) -> Result<(), MockFlashError> {
+        let range = Self::range(start_addr, size.get())?;
+        self.state.borrow_mut().flash[range].fill(0xFF);
+        Ok(())
+    }
+
+    fn program(&mut self, start_addr: FlashAddress, data: &[u8]) -> Result<(), MockFlashError> {
+        let range = Self::range(start_addr, data.len())?;
+        self.state.borrow_mut().flash[range].copy_from_slice(data);
+        Ok(())
+    }
+}

--- a/platform/impls/baremetal/mock/src/lib.rs
+++ b/platform/impls/baremetal/mock/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::arithmetic_side_effects)]
 
+pub mod downstream_device;
 pub mod hash;
 pub mod i2c_hardware;
 pub mod system_control;

--- a/services/fwmanager/api/BUILD.bazel
+++ b/services/fwmanager/api/BUILD.bazel
@@ -8,8 +8,10 @@ rust_library(
     srcs = [
         "src/boot_control.rs",
         "src/boot_monitor.rs",
+        "src/boot_progress.rs",
         "src/config.rs",
         "src/lib.rs",
+        "src/slot_control.rs",
     ],
     edition = "2024",
     visibility = ["//visibility:public"],

--- a/services/fwmanager/api/src/boot_control.rs
+++ b/services/fwmanager/api/src/boot_control.rs
@@ -33,11 +33,14 @@
 /// dev.hold_in_reset()?;
 /// store.set_trial(new_slot)?;      // tentative boot selection — not yet committed
 /// dev.release()?;                  // boot the trial image
-/// match monitor.await_boot(window)? {
-///     Booted           => store.commit(new_slot)?,   // observed good => make it active
-///     Failed | Timeout => { /* nothing committed; previous slot still active */ }
+/// match await_boot(&monitor, poll_budget)? {
+///     Booted           => store.commit()?,   // observed good => promote the trial
+///     Failed | Timeout => store.rollback()?, // disarm; previous slot still active
 /// }
 /// ```
+///
+/// The slot store and the boot window are the [`crate::SlotControl`] and
+/// [`crate::await_boot`] capabilities.
 pub trait BootControl {
     /// The error type reported by this device's boot control.
     ///

--- a/services/fwmanager/api/src/boot_progress.rs
+++ b/services/fwmanager/api/src/boot_progress.rs
@@ -1,0 +1,118 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic boot-window observation on top of [`BootMonitor`].
+
+use crate::{BootMonitor, BootStatus};
+
+/// The outcome of watching one boot window: evidence (`Booted`/`Failed`)
+/// or an expired window (`Timeout`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootProgress {
+    /// Boot completion observed within the window.
+    Booted,
+    /// The device reported a boot failure within the window.
+    Failed,
+    /// The window expired with no evidence either way.
+    Timeout,
+}
+
+/// Watch a boot window by polling `monitor` at most `poll_budget` times.
+///
+/// The poll budget is the deterministic rendering of a checkpoint's wall
+/// clock window, so tests never sleep.
+///
+/// # Errors
+///
+/// Propagates the first monitor read error.
+pub fn await_boot<M: BootMonitor>(
+    monitor: &M,
+    poll_budget: usize,
+) -> Result<BootProgress, M::Error> {
+    for _ in 0..poll_budget {
+        match monitor.boot_status()? {
+            BootStatus::Booted => return Ok(BootProgress::Booted),
+            BootStatus::Failed => return Ok(BootProgress::Failed),
+            BootStatus::Booting => {}
+        }
+    }
+    Ok(BootProgress::Timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    /// A monitor scripted by "boots after N polls", HAL-free.
+    struct ScriptedMonitor {
+        polls_left: Cell<Option<usize>>,
+        report_failure: bool,
+    }
+
+    #[derive(Debug)]
+    struct Unreachable;
+
+    impl core::fmt::Display for Unreachable {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("monitor read failed")
+        }
+    }
+
+    impl core::error::Error for Unreachable {}
+
+    impl BootMonitor for ScriptedMonitor {
+        type Error = Unreachable;
+
+        fn boot_status(&self) -> Result<BootStatus, Unreachable> {
+            match self.polls_left.get() {
+                Some(0) => Ok(if self.report_failure {
+                    BootStatus::Failed
+                } else {
+                    BootStatus::Booted
+                }),
+                Some(n) => {
+                    self.polls_left.set(Some(n - 1));
+                    Ok(BootStatus::Booting)
+                }
+                None => Ok(BootStatus::Booting),
+            }
+        }
+    }
+
+    #[test]
+    fn boot_within_budget_is_booted() {
+        let monitor = ScriptedMonitor {
+            polls_left: Cell::new(Some(3)),
+            report_failure: false,
+        };
+        assert_eq!(await_boot(&monitor, 10).unwrap(), BootProgress::Booted);
+    }
+
+    #[test]
+    fn reported_failure_ends_the_window_early() {
+        let monitor = ScriptedMonitor {
+            polls_left: Cell::new(Some(2)),
+            report_failure: true,
+        };
+        assert_eq!(await_boot(&monitor, 10).unwrap(), BootProgress::Failed);
+    }
+
+    #[test]
+    fn exhausted_budget_is_timeout() {
+        let monitor = ScriptedMonitor {
+            polls_left: Cell::new(None),
+            report_failure: false,
+        };
+        assert_eq!(await_boot(&monitor, 10).unwrap(), BootProgress::Timeout);
+    }
+
+    #[test]
+    fn zero_budget_never_polls_and_times_out() {
+        let monitor = ScriptedMonitor {
+            polls_left: Cell::new(Some(0)),
+            report_failure: false,
+        };
+        assert_eq!(await_boot(&monitor, 0).unwrap(), BootProgress::Timeout);
+    }
+}

--- a/services/fwmanager/api/src/lib.rs
+++ b/services/fwmanager/api/src/lib.rs
@@ -24,7 +24,11 @@
 
 mod boot_control;
 mod boot_monitor;
+mod boot_progress;
 pub mod config;
+mod slot_control;
 
 pub use boot_control::BootControl;
 pub use boot_monitor::{BootMonitor, BootStatus};
+pub use boot_progress::{await_boot, BootProgress};
+pub use slot_control::SlotControl;

--- a/services/fwmanager/api/src/slot_control.rs
+++ b/services/fwmanager/api/src/slot_control.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Home of the [`SlotControl`] capability contract.
+
+/// Actuation capability: select which firmware slot a managed device boots.
+///
+/// Implemented eRoT-side, for devices whose slot mechanism the eRoT actuates
+/// directly (interposed flash, the eRoT's own A/B image). PLDM devices keep
+/// slot selection internal and do not implement this.
+///
+/// # Trial semantics
+///
+/// - The **committed** slot is what the device boots by default.
+/// - [`SlotControl::set_trial`] arms a slot for the *next boot only*: the
+///   arming is one-shot, consumed by the boot it triggers, so an interrupted
+///   trial falls back to the committed slot.
+/// - [`SlotControl::commit`] promotes the trial slot to committed;
+///   [`SlotControl::rollback`] disarms it. Both error with no trial armed.
+pub trait SlotControl {
+    /// Identifies one bootable slot of the device (e.g. A/B index).
+    type SlotId: Copy + PartialEq + core::fmt::Debug;
+
+    /// The error type reported by this device's slot control.
+    type Error: core::error::Error;
+
+    /// The committed slot — what the device boots absent an armed trial.
+    fn active_slot(&self) -> Result<Self::SlotId, Self::Error>;
+
+    /// The armed trial slot, if any.
+    fn trial_slot(&self) -> Result<Option<Self::SlotId>, Self::Error>;
+
+    /// Arm `slot` to boot on the next release, without committing it.
+    fn set_trial(&mut self, slot: Self::SlotId) -> Result<(), Self::Error>;
+
+    /// Promote the armed trial slot to committed and disarm the trial.
+    ///
+    /// # Errors
+    ///
+    /// Errors if no trial is armed.
+    fn commit(&mut self) -> Result<(), Self::Error>;
+
+    /// Disarm the trial without promoting; the committed slot stays active.
+    ///
+    /// # Errors
+    ///
+    /// Errors if no trial is armed.
+    fn rollback(&mut self) -> Result<(), Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A SlotControl implemented against no HAL at all — the contract must be
+    // satisfiable from any stack (mock, IPC proxy, simulator).
+    struct MockSlots {
+        committed: u8,
+        trial: Option<u8>,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct NoTrialArmed;
+
+    impl core::fmt::Display for NoTrialArmed {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("no trial slot armed")
+        }
+    }
+
+    impl core::error::Error for NoTrialArmed {}
+
+    impl SlotControl for MockSlots {
+        type SlotId = u8;
+        type Error = NoTrialArmed;
+
+        fn active_slot(&self) -> Result<u8, NoTrialArmed> {
+            Ok(self.committed)
+        }
+
+        fn trial_slot(&self) -> Result<Option<u8>, NoTrialArmed> {
+            Ok(self.trial)
+        }
+
+        fn set_trial(&mut self, slot: u8) -> Result<(), NoTrialArmed> {
+            self.trial = Some(slot);
+            Ok(())
+        }
+
+        fn commit(&mut self) -> Result<(), NoTrialArmed> {
+            self.committed = self.trial.take().ok_or(NoTrialArmed)?;
+            Ok(())
+        }
+
+        fn rollback(&mut self) -> Result<(), NoTrialArmed> {
+            self.trial.take().ok_or(NoTrialArmed)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn commit_promotes_the_trial_slot() {
+        let mut slots = MockSlots {
+            committed: 0,
+            trial: None,
+        };
+
+        slots.set_trial(1).unwrap();
+        assert_eq!(slots.trial_slot().unwrap(), Some(1));
+        slots.commit().unwrap();
+
+        assert_eq!(slots.active_slot().unwrap(), 1);
+        assert_eq!(slots.trial_slot().unwrap(), None);
+    }
+
+    #[test]
+    fn rollback_disarms_without_promoting() {
+        let mut slots = MockSlots {
+            committed: 0,
+            trial: None,
+        };
+
+        slots.set_trial(1).unwrap();
+        slots.rollback().unwrap();
+
+        assert_eq!(slots.active_slot().unwrap(), 0);
+        assert_eq!(slots.trial_slot().unwrap(), None);
+    }
+
+    #[test]
+    fn commit_and_rollback_error_with_no_trial_armed() {
+        let mut slots = MockSlots {
+            committed: 0,
+            trial: None,
+        };
+
+        assert_eq!(slots.commit().unwrap_err(), NoTrialArmed);
+        assert_eq!(slots.rollback().unwrap_err(), NoTrialArmed);
+        assert_eq!(slots.active_slot().unwrap(), 0);
+    }
+}

--- a/services/fwmanager/tests/BUILD.bazel
+++ b/services/fwmanager/tests/BUILD.bazel
@@ -1,0 +1,21 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_test")
+
+# Host end-to-end, black-box: a MockDownstreamDevice on the eRoT's seams
+# (reset line, boot-complete line, firmware flash). The flow verifies the
+# device's firmware first and only then releases it from reset — the same
+# effect order the orchestrator state machine produces. No kernel, no QEMU.
+rust_test(
+    name = "boot_flow_test",
+    srcs = ["boot_flow.rs"],
+    edition = "2024",
+    deps = [
+        "//hal/blocking",
+        "//hal/blocking/flash",
+        "//platform/impls/baremetal/mock",
+        "//services/fwmanager/api:fwmanager_api",
+        "//services/fwmanager/hal-adapters:fwmanager_hal_adapters",
+    ],
+)

--- a/services/fwmanager/tests/BUILD.bazel
+++ b/services/fwmanager/tests/BUILD.bazel
@@ -19,3 +19,21 @@ rust_test(
         "//services/fwmanager/hal-adapters:fwmanager_hal_adapters",
     ],
 )
+
+# The downstream firmware-update lifecycle, same black-box style: staging,
+# activation under reset, trial boot, commit/rollback — asserted purely on
+# the device's externally visible signals. The test-local drivers are the
+# executable spec for the orchestrator (PR #357).
+rust_test(
+    name = "lifecycle_update_test",
+    srcs = ["lifecycle_update.rs"],
+    edition = "2024",
+    deps = [
+        "//hal/blocking",
+        "//hal/blocking/flash",
+        "//platform/impls/baremetal/mock",
+        "//services/fwmanager/api:fwmanager_api",
+        "//services/fwmanager/hal-adapters:fwmanager_hal_adapters",
+        "//util/types",
+    ],
+)

--- a/services/fwmanager/tests/boot_flow.rs
+++ b/services/fwmanager/tests/boot_flow.rs
@@ -1,0 +1,208 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Host integration test for the eRoT boot flow, black-box style: verify
+//! the device's firmware, release it from reset only on a pass, poll for
+//! boot completion — asserting only on externally visible outcomes. The
+//! flow mirrors the orchestrator's effect order (VerifyFirmware ->
+//! ReleaseReset -> await ready). No kernel, no QEMU.
+
+use std::error::Error;
+
+use fwmanager_api::{BootControl, BootMonitor, BootStatus};
+use fwmanager_hal_adapters::{GpioBootMonitor, HalBootControl};
+use hal_flash::{Flash, FlashAddress};
+use openprot_hal_blocking::gpio_port::{ActivePolarity, GpioErrorKind};
+use openprot_platform_mock::downstream_device::{MockDownstreamDevice, MockPinMask};
+use openprot_platform_mock::system_control::MockSystemControlError;
+
+// Board binding: BMC reset on controller line 7, boot-complete on GPIO
+// line 4. Normally set in the board's devices.rs.
+const BMC_RESET: u8 = 7;
+const BMC_READY: MockPinMask = MockPinMask(1 << 4);
+
+// Firmware image format for this test: 4 magic bytes, payload, and a final
+// byte that makes the XOR over the whole image zero. Stands in for real
+// signature verification.
+const IMAGE_LEN: usize = 16;
+const MAGIC: [u8; 4] = *b"OPRT";
+
+fn valid_image() -> [u8; IMAGE_LEN] {
+    let mut image = [0u8; IMAGE_LEN];
+    image[..4].copy_from_slice(&MAGIC);
+    image[4..IMAGE_LEN - 1].fill(0xAB);
+    let checksum = image[..IMAGE_LEN - 1].iter().fold(0, |acc, b| acc ^ b);
+    image[IMAGE_LEN - 1] = checksum;
+    image
+}
+
+fn corrupt_image() -> [u8; IMAGE_LEN] {
+    let mut image = valid_image();
+    image[7] ^= 0x01;
+    image
+}
+
+/// The eRoT's verification step: read the device's firmware over the flash
+/// seam and check it.
+fn firmware_is_valid<F: Flash>(flash: &mut F) -> Result<bool, F::Error> {
+    let mut image = [0u8; IMAGE_LEN];
+    flash.read(FlashAddress::new(0), &mut image)?;
+    let checksum = image.iter().fold(0, |acc, b| acc ^ b);
+    Ok(image[..4] == MAGIC && checksum == 0)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BootOutcome {
+    Booted,
+    TimedOut,
+    /// Firmware failed verification; the device was never released.
+    FirmwareRejected,
+}
+
+/// The eRoT's boot flow for one managed device: hold it in reset, verify
+/// its firmware, and only on a pass release it and poll for boot completion
+/// within the budget. `TimedOut` is a policy outcome, not an error.
+fn supervise_boot<C, M, F>(
+    control: &mut C,
+    monitor: &M,
+    flash: &mut F,
+    poll_budget: usize,
+) -> Result<BootOutcome, Box<dyn Error>>
+where
+    C: BootControl,
+    M: BootMonitor,
+    F: Flash,
+    C::Error: 'static,
+    M::Error: 'static,
+    F::Error: core::fmt::Debug,
+{
+    control.hold_in_reset()?;
+    if !firmware_is_valid(flash).map_err(|e| format!("flash read failed: {e:?}"))? {
+        return Ok(BootOutcome::FirmwareRejected);
+    }
+    control.release()?;
+    for _ in 0..poll_budget {
+        if monitor.boot_status()? == BootStatus::Booted {
+            return Ok(BootOutcome::Booted);
+        }
+    }
+    Ok(BootOutcome::TimedOut)
+}
+
+/// The eRoT's capability bindings for the device, as a board's devices.rs
+/// would make them.
+fn erot_for(
+    device: &MockDownstreamDevice,
+) -> (
+    HalBootControl<openprot_platform_mock::downstream_device::MockDeviceResetLine<'_>>,
+    openprot_platform_mock::downstream_device::MockDeviceReadyLine<'_>,
+) {
+    let control = HalBootControl::new(device.reset_line(), BMC_RESET);
+    (control, device.ready_line(BMC_READY))
+}
+
+#[test]
+fn valid_firmware_boots_within_budget() {
+    let device = MockDownstreamDevice::held_in_reset(Some(3));
+    device.load_firmware(&valid_image());
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let outcome =
+        supervise_boot(&mut control, &monitor, &mut device.flash(), 10).expect("boot flow failed");
+
+    assert_eq!(outcome, BootOutcome::Booted);
+    assert!(!device.is_in_reset());
+}
+
+#[test]
+fn corrupt_firmware_is_rejected_and_the_device_never_released() {
+    let device = MockDownstreamDevice::held_in_reset(Some(0));
+    device.load_firmware(&corrupt_image());
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let outcome =
+        supervise_boot(&mut control, &monitor, &mut device.flash(), 10).expect("boot flow failed");
+
+    assert_eq!(outcome, BootOutcome::FirmwareRejected);
+    // Verification happened, release did not.
+    assert!(device.flash_reads() > 0);
+    assert!(device.is_in_reset());
+    assert_eq!(device.polls_since_release(), 0);
+}
+
+#[test]
+fn firmware_is_verified_before_the_device_is_released() {
+    let device = MockDownstreamDevice::held_in_reset(Some(0));
+    device.load_firmware(&valid_image());
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    supervise_boot(&mut control, &monitor, &mut device.flash(), 10).expect("boot flow failed");
+
+    assert_eq!(device.release_preceded_by_flash_read(), Some(true));
+}
+
+#[test]
+fn a_hung_device_is_a_timeout_not_an_error() {
+    let device = MockDownstreamDevice::held_in_reset(None);
+    device.load_firmware(&valid_image());
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let outcome =
+        supervise_boot(&mut control, &monitor, &mut device.flash(), 5).expect("boot flow failed");
+
+    assert_eq!(outcome, BootOutcome::TimedOut);
+}
+
+// Evidence from a previous boot cycle must never read as Booted: the flow
+// re-asserts reset first, and the reset line clears the latch.
+#[test]
+fn stale_boot_evidence_is_cleared_by_the_reset_cycle() {
+    let device = MockDownstreamDevice::held_in_reset(None);
+    device.load_firmware(&valid_image());
+    device.latch_ready();
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let outcome =
+        supervise_boot(&mut control, &monitor, &mut device.flash(), 5).expect("boot flow failed");
+
+    assert_eq!(outcome, BootOutcome::TimedOut);
+}
+
+#[test]
+fn a_failing_reset_controller_aborts_before_release() {
+    let device = MockDownstreamDevice::held_in_reset(Some(0));
+    device.load_firmware(&valid_image());
+    device.inject_reset_fault(MockSystemControlError::HardwareFailure);
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let err = supervise_boot(&mut control, &monitor, &mut device.flash(), 5)
+        .expect_err("expected the reset fault");
+
+    assert_eq!(err.to_string(), "boot control error: HardwareFailure");
+    assert!(device.is_in_reset());
+    assert_eq!(device.polls_since_release(), 0);
+}
+
+#[test]
+fn a_monitor_fault_surfaces_with_kind_and_cause() {
+    let device = MockDownstreamDevice::held_in_reset(Some(0));
+    device.load_firmware(&valid_image());
+    device.inject_gpio_fault(GpioErrorKind::HardwareFailure);
+    let (mut control, ready) = erot_for(&device);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+
+    let err = supervise_boot(&mut control, &monitor, &mut device.flash(), 5)
+        .expect_err("expected the monitor fault");
+
+    assert_eq!(err.to_string(), "boot monitor error: HardwareFailure");
+    let cause = err
+        .source()
+        .expect("the concrete HAL error must be the cause");
+    assert_eq!(cause.to_string(), "MockGpioFault(HardwareFailure)");
+}

--- a/services/fwmanager/tests/lifecycle_update.rs
+++ b/services/fwmanager/tests/lifecycle_update.rs
@@ -1,0 +1,367 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Host integration tests for the downstream firmware-update lifecycle,
+//! black-box style: every assertion is on externally visible signals —
+//! reset transitions, what was flashed while the device was held, which
+//! slot booted, what got committed.
+//!
+//! `stage_update`/`activate_update` are test-local stand-ins for the
+//! orchestrator (PR #357): when it lands, it replaces these drivers and
+//! the assertions stay.
+
+use std::error::Error;
+
+use fwmanager_api::{await_boot, BootControl, BootMonitor, BootProgress, SlotControl};
+use fwmanager_hal_adapters::{GpioBootMonitor, HalBootControl};
+use hal_flash::{Flash, FlashAddress};
+use openprot_hal_blocking::gpio_port::ActivePolarity;
+use openprot_platform_mock::downstream_device::{
+    MockDownstreamDevice, MockPinMask, MockRegion, MOCK_DEVICE_FLASH_SIZE,
+};
+
+// Board binding: BMC reset on controller line 7, boot-complete on GPIO
+// line 4. Normally set in the board's devices.rs.
+const BMC_RESET: u8 = 7;
+const BMC_READY: MockPinMask = MockPinMask(1 << 4);
+
+// Same stand-in image format as boot_flow.rs: 4 magic bytes, payload, and a
+// final byte making the XOR over the whole image zero.
+const IMAGE_LEN: usize = 16;
+const MAGIC: [u8; 4] = *b"OPRT";
+
+fn image_with_payload(fill: u8) -> [u8; IMAGE_LEN] {
+    let mut image = [0u8; IMAGE_LEN];
+    image[..4].copy_from_slice(&MAGIC);
+    image[4..IMAGE_LEN - 1].fill(fill);
+    let checksum = image[..IMAGE_LEN - 1].iter().fold(0, |acc, b| acc ^ b);
+    image[IMAGE_LEN - 1] = checksum;
+    image
+}
+
+fn running_image() -> [u8; IMAGE_LEN] {
+    image_with_payload(0xAB)
+}
+
+fn update_image() -> [u8; IMAGE_LEN] {
+    image_with_payload(0xCD)
+}
+
+fn corrupt_update_image() -> [u8; IMAGE_LEN] {
+    let mut image = update_image();
+    image[7] ^= 0x01;
+    image
+}
+
+fn image_is_valid(image: &[u8; IMAGE_LEN]) -> bool {
+    let checksum = image.iter().fold(0, |acc, b| acc ^ b);
+    image[..4] == MAGIC && checksum == 0
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum UpdateOutcome {
+    /// Trial boot confirmed; the new slot is committed.
+    Committed,
+    /// The staged image failed authentication; staging was discarded and no
+    /// slot or reset line was ever touched.
+    RejectedStaged,
+    /// The device's firmware write path reported a failure; nothing was
+    /// armed or committed and the device was released on its old slot.
+    WriteFailed,
+    /// The trial boot produced no (or negative) evidence; the trial was
+    /// rolled back and the device rebooted on its old slot.
+    RolledBack,
+}
+
+/// Stage `image` into the device's staging region and authenticate it
+/// there. Rejection discards the staged bytes. The device keeps running —
+/// staging never touches the reset line or a bootable slot.
+fn stage_update<F: Flash>(
+    staging: &mut F,
+    image: &[u8; IMAGE_LEN],
+) -> Result<Option<UpdateOutcome>, Box<dyn Error>>
+where
+    F::Error: core::fmt::Debug,
+{
+    if staging.program(FlashAddress::new(0), image).is_err() {
+        return Ok(Some(UpdateOutcome::WriteFailed));
+    }
+
+    // AuthenticateUpdate: read back what actually landed and check it.
+    let mut staged = [0u8; IMAGE_LEN];
+    staging
+        .read(FlashAddress::new(0), &mut staged)
+        .map_err(|e| format!("staging read failed: {e:?}"))?;
+    if !image_is_valid(&staged) {
+        staging
+            .erase(
+                FlashAddress::new(0),
+                util_types::PowerOf2Usize::new(MOCK_DEVICE_FLASH_SIZE).unwrap(),
+            )
+            .map_err(|e| format!("staging erase failed: {e:?}"))?;
+        return Ok(Some(UpdateOutcome::RejectedStaged));
+    }
+    Ok(None)
+}
+
+/// Activate the staged update on the device's inactive slot as a trial
+/// boot: hold the device in reset, flash the slot while nothing runs, arm
+/// it as a trial, release, and watch the boot window. Commit only on
+/// observed boot completion; anything else rolls back and reboots the old
+/// slot.
+#[allow(clippy::too_many_arguments)]
+fn activate_update<C, M, S, F1, F2>(
+    control: &mut C,
+    monitor: &M,
+    slots: &mut S,
+    staging: &mut F1,
+    target_flash: &mut F2,
+    target_slot: usize,
+    poll_budget: usize,
+) -> Result<UpdateOutcome, Box<dyn Error>>
+where
+    C: BootControl,
+    M: BootMonitor,
+    S: SlotControl<SlotId = usize>,
+    F1: Flash,
+    F2: Flash,
+    C::Error: 'static,
+    M::Error: 'static,
+    S::Error: 'static,
+    F1::Error: core::fmt::Debug,
+    F2::Error: core::fmt::Debug,
+{
+    // The device must be frozen before its firmware is touched.
+    control.hold_in_reset()?;
+
+    // Copy staging into the inactive slot.
+    let mut staged = [0u8; IMAGE_LEN];
+    staging
+        .read(FlashAddress::new(0), &mut staged)
+        .map_err(|e| format!("staging read failed: {e:?}"))?;
+    if target_flash.program(FlashAddress::new(0), &staged).is_err() {
+        // The device told us its firmware write failed. Nothing is armed;
+        // releasing boots the untouched committed slot.
+        control.release()?;
+        return Ok(UpdateOutcome::WriteFailed);
+    }
+
+    // Arm the trial and boot it.
+    slots.set_trial(target_slot)?;
+    control.release()?;
+
+    match await_boot(monitor, poll_budget)? {
+        BootProgress::Booted => {
+            slots.commit()?;
+            Ok(UpdateOutcome::Committed)
+        }
+        BootProgress::Failed | BootProgress::Timeout => {
+            control.hold_in_reset()?;
+            slots.rollback()?;
+            control.release()?; // reboot the still-committed old slot
+            Ok(UpdateOutcome::RolledBack)
+        }
+    }
+}
+
+/// Rig: a device running `running_image()` from slot A, plus the eRoT's
+/// capability bindings. Returns the device already booted and confirmed.
+fn booted_device() -> MockDownstreamDevice {
+    let device = MockDownstreamDevice::held_in_reset(Some(1));
+    device.load_firmware(&running_image());
+    {
+        let mut control = HalBootControl::new(device.reset_line(), BMC_RESET);
+        let ready = device.ready_line(BMC_READY);
+        let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+        control.release().expect("initial release");
+        assert_eq!(
+            await_boot(&monitor, 10).expect("initial boot"),
+            BootProgress::Booted
+        );
+    }
+    device
+}
+
+/// A successful downstream update: the eRoT stages the new image, holds the
+/// device in reset for the whole time firmware is being flashed, reboots it
+/// on the new slot, and commits only after observing the booted state.
+#[test]
+fn update_succeeds_and_device_is_held_in_reset_while_flashed() {
+    let device = booted_device();
+    let target = 1 - device.committed_slot();
+
+    let mut control = HalBootControl::new(device.reset_line(), BMC_RESET);
+    let ready = device.ready_line(BMC_READY);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+    let mut slots = device.slot_store();
+    let mut staging = device.region_flash(MockRegion::Staging);
+    let mut target_flash = device.region_flash(MockRegion::Slot(target));
+
+    assert_eq!(stage_update(&mut staging, &update_image()).unwrap(), None);
+    let outcome = activate_update(
+        &mut control,
+        &monitor,
+        &mut slots,
+        &mut staging,
+        &mut target_flash,
+        target,
+        10,
+    )
+    .expect("update flow failed");
+
+    assert_eq!(outcome, UpdateOutcome::Committed);
+    // Reset discipline: no firmware byte was ever written to a running
+    // device — every program op happened while the reset line was asserted.
+    assert_eq!(device.programs_while_running(), 0);
+    // The device was rebooted into the new slot and reached the booted
+    // state before anything was committed.
+    assert_eq!(device.last_boot_slot(), Some(target));
+    assert_eq!(device.commit_preceded_by_ready(), Some(true));
+    assert_eq!(device.committed_slot(), target);
+    assert_eq!(device.commit_count(), 1);
+    assert_eq!(device.rollback_count(), 0);
+    assert!(!device.is_in_reset());
+    // The new image really is what the new slot runs.
+    assert_eq!(device.slot_content(target)[..IMAGE_LEN], update_image());
+}
+
+/// The device's firmware write path fails during activation: the eRoT
+/// notices the failed write, arms and commits nothing, and the device comes
+/// back up on its old slot with its old image untouched.
+#[test]
+fn failed_firmware_write_is_noticed_and_nothing_is_committed() {
+    let device = booted_device();
+    let old_slot = device.committed_slot();
+    let target = 1 - old_slot;
+
+    let mut control = HalBootControl::new(device.reset_line(), BMC_RESET);
+    let ready = device.ready_line(BMC_READY);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+    let mut slots = device.slot_store();
+    let mut staging = device.region_flash(MockRegion::Staging);
+    let mut target_flash = device.region_flash(MockRegion::Slot(target));
+
+    assert_eq!(stage_update(&mut staging, &update_image()).unwrap(), None);
+    // The device's write path breaks after staging succeeded.
+    device.inject_program_fault();
+
+    let outcome = activate_update(
+        &mut control,
+        &monitor,
+        &mut slots,
+        &mut staging,
+        &mut target_flash,
+        target,
+        10,
+    )
+    .expect("update flow failed");
+
+    assert_eq!(outcome, UpdateOutcome::WriteFailed);
+    // Nothing was armed or committed; the old slot is still the boot
+    // selection and the device was released back onto it.
+    assert_eq!(device.committed_slot(), old_slot);
+    assert_eq!(device.commit_count(), 0);
+    assert_eq!(device.last_boot_slot(), Some(old_slot));
+    assert!(!device.is_in_reset());
+    // The target slot was never written: still erased.
+    assert!(device.slot_content(target).iter().all(|&b| b == 0xFF));
+}
+
+/// A corrupt staged image is rejected during staging: the staged bytes are
+/// discarded and the running device is never disturbed — no reset, no slot
+/// write, no trial.
+#[test]
+fn corrupt_staged_image_is_rejected_without_touching_the_device() {
+    let device = booted_device();
+    let target = 1 - device.committed_slot();
+
+    let mut staging = device.region_flash(MockRegion::Staging);
+    let outcome = stage_update(&mut staging, &corrupt_update_image()).unwrap();
+
+    assert_eq!(outcome, Some(UpdateOutcome::RejectedStaged));
+    assert!(!device.is_in_reset(), "staging must not reset the device");
+    assert!(device.slot_content(target).iter().all(|&b| b == 0xFF));
+    assert_eq!(device.commit_count(), 0);
+    assert_eq!(device.rollback_count(), 0);
+    // Discarded: the staging region holds no image anymore.
+    let mut staged = [0u8; IMAGE_LEN];
+    staging.read(FlashAddress::new(0), &mut staged).unwrap();
+    assert!(staged.iter().all(|&b| b == 0xFF));
+}
+
+/// The trial image never reaches the booted state: the boot window expires,
+/// the trial is rolled back, and the device is rebooted on the old slot —
+/// which stays committed.
+#[test]
+fn trial_boot_timeout_rolls_back_and_reboots_the_old_slot() {
+    let device = booted_device();
+    let old_slot = device.committed_slot();
+    let target = 1 - old_slot;
+
+    let mut control = HalBootControl::new(device.reset_line(), BMC_RESET);
+    let ready = device.ready_line(BMC_READY);
+    let monitor = GpioBootMonitor::new(&ready, BMC_READY, ActivePolarity::ActiveHigh);
+    let mut slots = device.slot_store();
+    let mut staging = device.region_flash(MockRegion::Staging);
+    let mut target_flash = device.region_flash(MockRegion::Slot(target));
+
+    assert_eq!(stage_update(&mut staging, &update_image()).unwrap(), None);
+    // The new image is broken in a way verification can't see: it flashes
+    // fine but the device never asserts boot-complete running it.
+    device.set_boots_after(None);
+
+    let outcome = activate_update(
+        &mut control,
+        &monitor,
+        &mut slots,
+        &mut staging,
+        &mut target_flash,
+        target,
+        10,
+    )
+    .expect("update flow failed");
+
+    assert_eq!(outcome, UpdateOutcome::RolledBack);
+    assert_eq!(device.rollback_count(), 1);
+    assert_eq!(device.commit_count(), 0);
+    assert_eq!(device.committed_slot(), old_slot);
+    // The recovery reboot went back to the old slot.
+    assert_eq!(device.last_boot_slot(), Some(old_slot));
+    assert!(!device.is_in_reset());
+}
+
+/// Negative control for the instrumentation itself: a deliberately careless
+/// driver that breaks the update rules must be *caught* by the device's
+/// detectors. Until the real orchestrator replaces the test-local drivers,
+/// this is what keeps the other tests honest — it proves their assertions
+/// would fail for an implementation that flashes a live device or commits
+/// without boot confirmation, rather than passing vacuously.
+#[test]
+fn instrumentation_catches_a_driver_that_violates_the_update_rules() {
+    let device = booted_device();
+    let target = 1 - device.committed_slot();
+
+    let mut control = HalBootControl::new(device.reset_line(), BMC_RESET);
+    let mut slots = device.slot_store();
+    let mut target_flash = device.region_flash(MockRegion::Slot(target));
+
+    // Violation 1: write firmware into a bootable slot while the device is
+    // running — no hold_in_reset first.
+    assert!(!device.is_in_reset());
+    target_flash
+        .program(FlashAddress::new(0), &update_image())
+        .unwrap();
+
+    // Violation 2: arm the trial and commit it immediately after the
+    // reboot, without waiting for any boot evidence.
+    control.hold_in_reset().unwrap(); // clears the stale ready latch
+    slots.set_trial(target).unwrap();
+    control.release().unwrap();
+    slots.commit().unwrap(); // no await_boot — nothing confirmed this image
+
+    // Both detectors must have recorded the violations. If either of these
+    // assertions ever fails, the positive tests above have lost their
+    // teeth.
+    assert_eq!(device.programs_while_running(), 1);
+    assert_eq!(device.commit_preceded_by_ready(), Some(false));
+}


### PR DESCRIPTION
Host-level, black-box integration tests for the downstream firmware-update lifecycle: a MockDownstreamDevice on the eRoT's seams (reset line, boot-complete line, slot flash, staging flash, slot store), with every assertion made on externally visible signals — reset transitions, what was flashed while the device was held, which slot the device booted, what got committed. Plain rust_test, no kernel, no QEMU.

Covered scenarios: a successful update proves the device is held in reset the whole time firmware is written, is rebooted on the new slot, and is committed only after the booted state was observed; a device whose firmware write path fails is noticed through the flash seam, with nothing armed or committed and the old slot untouched; a corrupt staged image is rejected during staging without disturbing the running device; a trial-boot window that expires without evidence rolls back and reboots the still-committed slot. A negative-control test runs a deliberately careless driver and asserts the instrumentation catches it, so the positive assertions cannot pass vacuously.

Supporting pieces: the SlotControl capability (trial/commit/rollback slot selection) and BootProgress/await_boot (a bounded boot window over the existing BootMonitor, rendered as a deterministic poll budget — tests never sleep) are added to the fwmanager api leaf, per #377. The mock downstream device grows A/B slots, a staging region, a slot store, fault injection for a broken write path, and the ordering instrumentation the tests assert on. The existing boot_flow tests pass unchanged on the extended mock.

There is deliberately no orchestrator dependency: stage_update/activate_update in the test file are the reference rendering of the trial-boot protocol sketched in the BootControl docs. They are the executable spec for the orchestrator from #357 — when it merges, the real state machine replaces these test-local drivers and the assertions stay.

Refs #377.