### PR TITLE
orchestrator: Add the per-device image layout to the device-table schema

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1384,7 +1384,7 @@
     "@@pigweed+//pw_toolchain/rust:extensions.bzl%pw_rust": {
       "general": {
         "bzlTransitiveDigest": "4K/ADdJohpexBCsXAc1O/B44plfS7LXTry5X/4o1fV4=",
-        "usagesDigest": "amr5GUEsmqaVoFmHc78dtpzHP+01Zp4LshArrY2aH2M=",
+        "usagesDigest": "P/at/nhjXS/v8GyCsw8NWKUvL8Wr+QI/w1jc6Z03HHY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1410,7 +1410,7 @@
             "attributes": {
               "build_file": "@@pigweed+//pw_toolchain/rust:rust_analyzer.BUILD",
               "path": "fuchsia/third_party/rust-analyzer/linux-arm64",
-              "tag": "git_revision:61504e12b88ba8b251aabca786a94973e4010a12"
+              "tag": "git_revision:baabc5825f3f6640e99fe32887bbeced640f825e"
             }
           },
           "rust_bindgen_linux_aarch64": {
@@ -1442,7 +1442,7 @@
             "attributes": {
               "build_file": "@@pigweed+//pw_toolchain/rust:rust_analyzer.BUILD",
               "path": "fuchsia/third_party/rust-analyzer/linux-amd64",
-              "tag": "git_revision:61504e12b88ba8b251aabca786a94973e4010a12"
+              "tag": "git_revision:baabc5825f3f6640e99fe32887bbeced640f825e"
             }
           },
           "rust_bindgen_linux_x86_64": {
@@ -1474,7 +1474,7 @@
             "attributes": {
               "build_file": "@@pigweed+//pw_toolchain/rust:rust_analyzer.BUILD",
               "path": "fuchsia/third_party/rust-analyzer/mac-arm64",
-              "tag": "git_revision:61504e12b88ba8b251aabca786a94973e4010a12"
+              "tag": "git_revision:baabc5825f3f6640e99fe32887bbeced640f825e"
             }
           },
           "rust_bindgen_macos_aarch64": {
@@ -1506,7 +1506,7 @@
             "attributes": {
               "build_file": "@@pigweed+//pw_toolchain/rust:rust_analyzer.BUILD",
               "path": "fuchsia/third_party/rust-analyzer/mac-amd64",
-              "tag": "git_revision:61504e12b88ba8b251aabca786a94973e4010a12"
+              "tag": "git_revision:baabc5825f3f6640e99fe32887bbeced640f825e"
             }
           },
           "rust_bindgen_macos_x86_64": {

--- a/services/orchestrator/config/src/lib.rs
+++ b/services/orchestrator/config/src/lib.rs
@@ -81,9 +81,12 @@ impl<G> BootCheckpoint<G> {
     }
 }
 
-/// Identifies one slot within one device's layout. Opaque: meaning comes
-/// from the position in that device's slot table, never from a global
-/// vocabulary — slot 0 on the BMC and slot 0 on the NIC are unrelated.
+/// Identifies one slot within one device's layout. An opaque per-device
+/// token, not an index: ids need only be unique within one device's table
+/// ([`DeviceConfig::new`] enforces exactly that) — they are not required
+/// to be contiguous, ordered, or to start at zero, and slot 0 on the BMC
+/// and slot 0 on the NIC are unrelated. Ladder order comes from table
+/// declaration order, never from id values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlotId(pub u8);
 

--- a/services/orchestrator/config/src/lib.rs
+++ b/services/orchestrator/config/src/lib.rs
@@ -81,6 +81,41 @@ impl<G> BootCheckpoint<G> {
     }
 }
 
+/// Identifies one slot within one device's layout. Opaque: meaning comes
+/// from the position in that device's slot table, never from a global
+/// vocabulary — slot 0 on the BMC and slot 0 on the NIC are unrelated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotId(pub u8);
+
+/// A distinguished duty a slot carries beyond being writable/bootable.
+///
+/// Intentionally exhaustive (not `#[non_exhaustive]`): adding a role is a
+/// breaking change, so every consumer that dispatches on roles — in
+/// particular recovery-candidate selection — is forced to handle the new
+/// role explicitly instead of falling into a wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotRole {
+    /// The slot recovery falls back to after every ordinary rung failed.
+    /// A "golden" image is this role plus `writable: false` — a property
+    /// combination, not a separate name.
+    Recovery,
+}
+
+/// One slot in a device's layout: topology as data, not a type. A layout
+/// is plain A/B, A/B + golden, or single + golden purely by what the table
+/// declares — no layout shape is named anywhere.
+#[derive(Debug, Clone, Copy)]
+pub struct Slot {
+    pub id: SlotId,
+    /// May the update path write this slot? `false` on a recovery-role
+    /// slot is what makes it "golden".
+    pub writable: bool,
+    /// May the device boot from this slot? Every bootable slot is a rung
+    /// of the recovery ladder.
+    pub bootable: bool,
+    pub role: Option<SlotRole>,
+}
+
 /// One managed downstream device, as declared by the board config.
 ///
 /// Generic over the board's reset signal type `R` (which must match the
@@ -100,6 +135,7 @@ pub struct DeviceConfig<R, G: 'static> {
     name: &'static str,
     reset_signal: R,
     checkpoints: &'static [BootCheckpoint<G>],
+    slots: &'static [Slot],
 }
 
 impl<R, G> DeviceConfig<R, G> {
@@ -109,14 +145,17 @@ impl<R, G> DeviceConfig<R, G> {
     /// # Panics
     ///
     /// Panics — a build error in const context — if `name` is empty, if
-    /// `checkpoints` is empty, or if two checkpoints share a name
-    /// (failure reports identify a checkpoint by name; a duplicate would
-    /// make them ambiguous).
+    /// `checkpoints` is empty, if two checkpoints share a name (failure
+    /// reports identify a checkpoint by name; a duplicate would make them
+    /// ambiguous), or if `slots` breaks a layout rule: unique ids, at
+    /// most one recovery-role slot (which must be bootable), and a
+    /// bootable slot in any non-empty layout.
     #[must_use]
     pub const fn new(
         name: &'static str,
         reset_signal: R,
         checkpoints: &'static [BootCheckpoint<G>],
+        slots: &'static [Slot],
     ) -> Self {
         assert!(!name.is_empty(), "device name must not be empty");
         assert!(
@@ -135,10 +174,40 @@ impl<R, G> DeviceConfig<R, G> {
             }
             c += 1;
         }
+        let mut bootable = 0;
+        let mut recovery_slots = 0;
+        let mut s = 0;
+        while s < slots.len() {
+            if slots[s].bootable {
+                bootable += 1;
+            }
+            if matches!(slots[s].role, Some(SlotRole::Recovery)) {
+                recovery_slots += 1;
+                assert!(slots[s].bootable, "a recovery-role slot must be bootable");
+            }
+            let mut t = s + 1;
+            while t < slots.len() {
+                assert!(
+                    slots[s].id.0 != slots[t].id.0,
+                    "slot ids must be unique within a device"
+                );
+                t += 1;
+            }
+            s += 1;
+        }
+        assert!(
+            recovery_slots <= 1,
+            "at most one recovery-role slot per device"
+        );
+        assert!(
+            slots.is_empty() || bootable > 0,
+            "a non-empty slot layout needs a bootable slot"
+        );
         Self {
             name,
             reset_signal,
             checkpoints,
+            slots,
         }
     }
 
@@ -161,6 +230,17 @@ impl<R, G> DeviceConfig<R, G> {
     #[must_use]
     pub const fn checkpoints(&self) -> &'static [BootCheckpoint<G>] {
         self.checkpoints
+    }
+
+    /// This device's slot layout. The recovery ladder is derived from it,
+    /// never declared: bootable slots in declaration order, recovery-role
+    /// slot last, escalation to out-of-band recovery once no rung is left.
+    /// A layout without rungs — e.g. empty, for a device that owns its
+    /// boot selection internally (the PLDM archetype) — leaves escalation
+    /// as the only step.
+    #[must_use]
+    pub const fn slots(&self) -> &'static [Slot] {
+        self.slots
     }
 }
 
@@ -197,33 +277,120 @@ mod tests {
     const CHECKPOINT_DUP: BootCheckpoint<u8> =
         BootCheckpoint::new("boot-complete", 1, Duration::from_secs(1));
 
+    /// An ordinary slot: writable, bootable, no role.
+    const fn slot(id: u8) -> Slot {
+        Slot {
+            id: SlotId(id),
+            writable: true,
+            bootable: true,
+            role: None,
+        }
+    }
+
+    /// A recovery-role slot; non-writable, but no test depends on that.
+    const fn recovery_slot(id: u8) -> Slot {
+        Slot {
+            writable: false,
+            role: Some(SlotRole::Recovery),
+            ..slot(id)
+        }
+    }
+
     #[test]
     fn accepts_a_valid_table() {
-        let device = DeviceConfig::new("dev", 0u8, &[CHECKPOINT]);
+        let device = DeviceConfig::new("dev", 0u8, &[CHECKPOINT], const { &[slot(0), slot(1)] });
         assert_eq!(device.name(), "dev");
         assert_eq!(*device.reset_signal(), 0);
         assert_eq!(device.checkpoints().len(), 1);
         assert_eq!(device.checkpoints()[0].name(), "boot-complete");
         assert_eq!(*device.checkpoints()[0].signal(), 0);
         assert_eq!(device.checkpoints()[0].timeout(), Duration::from_secs(1));
+        assert_eq!(device.slots().len(), 2);
+    }
+
+    #[test]
+    fn accepts_a_layout_with_a_recovery_slot() {
+        let _ = DeviceConfig::new(
+            "dev",
+            0u8,
+            &[CHECKPOINT],
+            const { &[slot(0), slot(1), recovery_slot(2)] },
+        );
+    }
+
+    #[test]
+    fn accepts_an_empty_layout() {
+        let _ = DeviceConfig::new("dev", 0u8, &[CHECKPOINT], &[]);
     }
 
     #[test]
     #[should_panic(expected = "checkpoint names must be unique")]
     fn rejects_duplicate_checkpoint_names() {
-        let _ = DeviceConfig::new("dev", 0u8, &[CHECKPOINT, CHECKPOINT_DUP]);
+        let _ = DeviceConfig::new("dev", 0u8, &[CHECKPOINT, CHECKPOINT_DUP], &[]);
     }
 
     #[test]
     #[should_panic(expected = "device name must not be empty")]
     fn rejects_an_empty_device_name() {
-        let _ = DeviceConfig::new("", 0u8, &[CHECKPOINT]);
+        let _ = DeviceConfig::new("", 0u8, &[CHECKPOINT], &[]);
     }
 
     #[test]
     #[should_panic(expected = "at least one boot checkpoint")]
     fn rejects_an_empty_checkpoint_list() {
-        let _ = DeviceConfig::new("dev", 0u8, &[] as &[BootCheckpoint<u8>]);
+        let _ = DeviceConfig::new("dev", 0u8, &[] as &[BootCheckpoint<u8>], &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "slot ids must be unique")]
+    fn rejects_duplicate_slot_ids() {
+        let _ = DeviceConfig::new("dev", 0u8, &[CHECKPOINT], const { &[slot(0), slot(0)] });
+    }
+
+    #[test]
+    #[should_panic(expected = "at most one recovery-role slot")]
+    fn rejects_two_recovery_role_slots() {
+        let _ = DeviceConfig::new(
+            "dev",
+            0u8,
+            &[CHECKPOINT],
+            const { &[slot(0), recovery_slot(1), recovery_slot(2)] },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "recovery-role slot must be bootable")]
+    fn rejects_an_unbootable_recovery_slot() {
+        let _ = DeviceConfig::new(
+            "dev",
+            0u8,
+            &[CHECKPOINT],
+            const {
+                &[
+                    slot(0),
+                    Slot {
+                        bootable: false,
+                        ..recovery_slot(1)
+                    },
+                ]
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "needs a bootable slot")]
+    fn rejects_a_layout_with_no_bootable_slot() {
+        let _ = DeviceConfig::new(
+            "dev",
+            0u8,
+            &[CHECKPOINT],
+            const {
+                &[Slot {
+                    bootable: false,
+                    ..slot(0)
+                }]
+            },
+        );
     }
 
     #[test]

--- a/services/orchestrator/config/src/lib.rs
+++ b/services/orchestrator/config/src/lib.rs
@@ -107,16 +107,67 @@ pub enum SlotRole {
 /// One slot in a device's layout: topology as data, not a type. A layout
 /// is plain A/B, A/B + golden, or single + golden purely by what the table
 /// declares — no layout shape is named anywhere.
+///
+/// Immutable, and only constructible through [`Slot::new`], which
+/// enforces the per-slot invariant — an invalid slot is unrepresentable,
+/// not merely rejected later. Rules that span a whole layout (unique ids,
+/// one recovery slot, ladder rungs) stay in [`DeviceConfig::new`], which
+/// sees the list.
 #[derive(Debug, Clone, Copy)]
 pub struct Slot {
-    pub id: SlotId,
+    id: SlotId,
+    writable: bool,
+    bootable: bool,
+    role: Option<SlotRole>,
+}
+
+impl Slot {
+    /// Declares one slot. Const, so board tables still build at compile
+    /// time — where a rejected slot is a build error, the same teeth as
+    /// [`DeviceConfig::new`]. (A `Result`-returning constructor cannot
+    /// build a `&'static` table; panicking in const context is how schema
+    /// rules fail the build.)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `role` is [`SlotRole::Recovery`] and `bootable` is
+    /// `false` — recovery boots the device from that slot, so an
+    /// unbootable recovery slot is a contradiction.
+    pub const fn new(id: SlotId, writable: bool, bootable: bool, role: Option<SlotRole>) -> Self {
+        assert!(
+            !matches!(role, Some(SlotRole::Recovery)) || bootable,
+            "a recovery-role slot must be bootable"
+        );
+        Self {
+            id,
+            writable,
+            bootable,
+            role,
+        }
+    }
+
+    /// This slot's id, unique within the device (checked by
+    /// [`DeviceConfig::new`]).
+    pub const fn id(&self) -> SlotId {
+        self.id
+    }
+
     /// May the update path write this slot? `false` on a recovery-role
     /// slot is what makes it "golden".
-    pub writable: bool,
+    pub const fn writable(&self) -> bool {
+        self.writable
+    }
+
     /// May the device boot from this slot? Every bootable slot is a rung
     /// of the recovery ladder.
-    pub bootable: bool,
-    pub role: Option<SlotRole>,
+    pub const fn bootable(&self) -> bool {
+        self.bootable
+    }
+
+    /// This slot's special role, if any.
+    pub const fn role(&self) -> Option<SlotRole> {
+        self.role
+    }
 }
 
 /// One managed downstream device, as declared by the board config.
@@ -151,8 +202,8 @@ impl<R, G> DeviceConfig<R, G> {
     /// `checkpoints` is empty, if two checkpoints share a name (failure
     /// reports identify a checkpoint by name; a duplicate would make them
     /// ambiguous), or if `slots` breaks a layout rule: unique ids, at
-    /// most one recovery-role slot (which must be bootable), and a
-    /// bootable slot in any non-empty layout.
+    /// most one recovery-role slot, and a bootable slot in any non-empty
+    /// layout.
     #[must_use]
     pub const fn new(
         name: &'static str,
@@ -181,17 +232,18 @@ impl<R, G> DeviceConfig<R, G> {
         let mut recovery_slots = 0;
         let mut s = 0;
         while s < slots.len() {
-            if slots[s].bootable {
+            if slots[s].bootable() {
                 bootable += 1;
             }
-            if matches!(slots[s].role, Some(SlotRole::Recovery)) {
+            // Recovery ⇒ bootable is enforced by Slot::new — an
+            // unbootable recovery slot is unrepresentable here.
+            if matches!(slots[s].role(), Some(SlotRole::Recovery)) {
                 recovery_slots += 1;
-                assert!(slots[s].bootable, "a recovery-role slot must be bootable");
             }
             let mut t = s + 1;
             while t < slots.len() {
                 assert!(
-                    slots[s].id.0 != slots[t].id.0,
+                    slots[s].id().0 != slots[t].id().0,
                     "slot ids must be unique within a device"
                 );
                 t += 1;
@@ -282,21 +334,12 @@ mod tests {
 
     /// An ordinary slot: writable, bootable, no role.
     const fn slot(id: u8) -> Slot {
-        Slot {
-            id: SlotId(id),
-            writable: true,
-            bootable: true,
-            role: None,
-        }
+        Slot::new(SlotId(id), true, true, None)
     }
 
     /// A recovery-role slot; non-writable, but no test depends on that.
     const fn recovery_slot(id: u8) -> Slot {
-        Slot {
-            writable: false,
-            role: Some(SlotRole::Recovery),
-            ..slot(id)
-        }
+        Slot::new(SlotId(id), false, true, Some(SlotRole::Recovery))
     }
 
     #[test]
@@ -361,23 +404,12 @@ mod tests {
         );
     }
 
+    // The per-slot invariant fails at construction, before any list-level
+    // check could run — an invalid slot is unrepresentable.
     #[test]
     #[should_panic(expected = "recovery-role slot must be bootable")]
-    fn rejects_an_unbootable_recovery_slot() {
-        let _ = DeviceConfig::new(
-            "dev",
-            0u8,
-            &[CHECKPOINT],
-            const {
-                &[
-                    slot(0),
-                    Slot {
-                        bootable: false,
-                        ..recovery_slot(1)
-                    },
-                ]
-            },
-        );
+    fn rejects_an_unbootable_recovery_slot_at_construction() {
+        Slot::new(SlotId(2), false, false, Some(SlotRole::Recovery));
     }
 
     #[test]
@@ -387,12 +419,7 @@ mod tests {
             "dev",
             0u8,
             &[CHECKPOINT],
-            const {
-                &[Slot {
-                    bootable: false,
-                    ..slot(0)
-                }]
-            },
+            const { &[Slot::new(SlotId(0), true, false, None)] },
         );
     }
 

--- a/target/ast10x0/tests/orchestrator/runtime/main.rs
+++ b/target/ast10x0/tests/orchestrator/runtime/main.rs
@@ -64,6 +64,8 @@ const SOC: DeviceConfig<u8, u8> = DeviceConfig::new(
         BootCheckpoint::new("bl1", 0, core::time::Duration::from_millis(50)),
         BootCheckpoint::new("kernel", 0, core::time::Duration::from_millis(50)),
     ],
+    // Slot topology is irrelevant to the boot walk; empty is legal.
+    &[],
 );
 
 /// The device table speaks `core::time::Duration`; the runtime speaks the

--- a/target/mock/devices.rs
+++ b/target/mock/devices.rs
@@ -9,7 +9,7 @@
 
 use core::time::Duration;
 
-use orchestrator_config::{BootCheckpoint, DeviceConfig};
+use orchestrator_config::{BootCheckpoint, DeviceConfig, Slot, SlotId};
 
 /// The mock board's boot-signal vocabulary. The schema carries these
 /// opaquely; only this board's `EvidenceReader` gives them meaning.
@@ -41,6 +41,23 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, MockSignal>] = &[
             MockSignal::Gpio(12),
             Duration::from_secs(90),
         )],
+        // Plain A/B: two equal writable slots, recovery falls back to the
+        // other one. Real boards declare their own topology; a golden
+        // slot is optional.
+        &[
+            Slot {
+                id: SlotId(0),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+            Slot {
+                id: SlotId(1),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+        ],
     ),
     // PLDM device (NIC archetype): self-updating, SPDM-capable. Two
     // checkpoints, exercising the multi-checkpoint path: transport up
@@ -52,6 +69,10 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, MockSignal>] = &[
             BootCheckpoint::new("mctp-ready", MockSignal::MctpReady, Duration::from_secs(20)),
             BootCheckpoint::new("heartbeat", MockSignal::Heartbeat, Duration::from_secs(10)),
         ],
+        // Self-updating device: it owns its boot selection, the eRoT never
+        // sees its slot topology. No local ladder rungs, so recovery can
+        // only escalate.
+        &[],
     ),
 ];
 

--- a/target/mock/devices.rs
+++ b/target/mock/devices.rs
@@ -45,18 +45,8 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, MockSignal>] = &[
         // other one. Real boards declare their own topology; a golden
         // slot is optional.
         &[
-            Slot {
-                id: SlotId(0),
-                writable: true,
-                bootable: true,
-                role: None,
-            },
-            Slot {
-                id: SlotId(1),
-                writable: true,
-                bootable: true,
-                role: None,
-            },
+            Slot::new(SlotId(0), true, true, None),
+            Slot::new(SlotId(1), true, true, None),
         ],
     ),
     // PLDM device (NIC archetype): self-updating, SPDM-capable. Two


### PR DESCRIPTION
Redesigned since the last review round: SlotDesc, RecoveryPolicy and the
per-slot flags are gone, so the earlier comments no longer apply.

Board tables now say where each device's images live. `ImageLayout` holds the
slots the eRoT writes plus the golden image; a `Slot` is an id and a `Region`, a
byte range counted from the start of that device's firmware partition.
`ImageLayout::new` rejects duplicate slot ids and overlapping regions at build
time.

Golden is its own type, not a flag on a slot, so code that picks a write target
or checks the SVN floor never sees it. The floor has to skip it: a golden
image's security version is fixed when the board is made, so enforcing the floor
would eventually make the last image that still boots unbootable.

The layout is optional. A device that takes its own updates over PLDM and picks
what it boots declares none.

`assert_retry_reaches_every_image` closes the gap rusty1968 raised: boards call
it from a const fence, so a retry budget too small to boot every image fails the
build. The floor is one more than the image count, because the last restore the
budget allows is never booted.

Part of 9elements/openprot#1.
