### PR TITLE
fwmanager: Add the boot-progress walk over checkpoint windows

### DIFF
--- a/services/fwmanager/BUILD.bazel
+++ b/services/fwmanager/BUILD.bazel
@@ -1,0 +1,23 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "fwmanager",
+    srcs = [
+        "src/boot_progress.rs",
+        "src/lib.rs",
+    ],
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//services/fwmanager/api:fwmanager_api",
+    ],
+)
+
+# Host tests: build on the host platform, no kernel/QEMU.
+rust_test(
+    name = "fwmanager_test",
+    crate = ":fwmanager",
+)

--- a/services/fwmanager/BUILD.bazel
+++ b/services/fwmanager/BUILD.bazel
@@ -16,8 +16,11 @@ rust_library(
     ],
 )
 
-# Host tests: build on the host platform, no kernel/QEMU.
+# Host tests: build on the host platform, no kernel/QEMU. The mock board's
+# device table is a test-only fixture: the library itself depends on the
+# api crate alone.
 rust_test(
     name = "fwmanager_test",
     crate = ":fwmanager",
+    deps = ["//target/mock:devices"],
 )

--- a/services/fwmanager/api/src/boot_monitor.rs
+++ b/services/fwmanager/api/src/boot_monitor.rs
@@ -62,7 +62,6 @@ pub trait BootMonitor {
 }
 
 #[cfg(test)]
-#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use super::*;
     use core::cell::Cell;
@@ -134,47 +133,9 @@ mod tests {
             fail: true,
         };
 
-        let err = comes_up_within(&mon, 1).expect_err("expected the monitor fault");
+        let err = mon.boot_status().expect_err("expected the monitor fault");
 
         // Display comes from the core::error::Error bound, not a Debug dump.
         assert_eq!(err.to_string(), "mock monitor fault");
-    }
-
-    // ── The orchestrator's future shape ─────────────────────────────────
-    // Usage examples for the future orchestrator, not API guarantees; move
-    // these to the orchestrator crate once it exists.
-
-    /// Poll a monitor up to `poll_budget` times. `Booting` is not a failure;
-    /// `Ok(false)` means the budget ran out before the device came up.
-    fn comes_up_within<M: BootMonitor>(mon: &M, poll_budget: usize) -> Result<bool, M::Error> {
-        for _ in 0..poll_budget {
-            if mon.boot_status()? == BootStatus::Booted {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    // A device that comes up within the poll budget reads Booted.
-    #[test]
-    fn a_device_that_comes_up_within_budget_is_booted() {
-        let mon = MockMonitor {
-            ready_after: 2,
-            polls: Cell::new(0),
-            fail: false,
-        };
-
-        assert_eq!(comes_up_within(&mon, 5).expect("boot_status failed"), true);
-    }
-
-    #[test]
-    fn a_device_that_never_comes_up_is_a_timeout_not_an_error() {
-        let mon = MockMonitor {
-            ready_after: usize::MAX,
-            polls: Cell::new(0),
-            fail: false,
-        };
-
-        assert_eq!(comes_up_within(&mon, 3).expect("boot_status failed"), false);
     }
 }

--- a/services/fwmanager/api/src/config.rs
+++ b/services/fwmanager/api/src/config.rs
@@ -13,6 +13,11 @@
 /// variant explicitly instead of falling into a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommitPolicy {
+    /// The device offers no boot evidence at all (a passive device the
+    /// orchestrator releases blind): a staged image is committed once
+    /// readback verification passes, there is nothing else to wait for.
+    /// The only legal policy for a device with no boot checkpoints.
+    None,
     /// The device reports it came up.
     Liveness,
     /// Liveness plus SPDM re-attestation of the running image.
@@ -141,8 +146,9 @@ pub const fn validate<R, G>(devices: &[DeviceConfig<R, G>]) {
     while i < devices.len() {
         assert!(!devices[i].name.is_empty(), "device name must not be empty");
         assert!(
-            !devices[i].checkpoints.is_empty(),
-            "device must declare at least one boot checkpoint"
+            !devices[i].checkpoints.is_empty()
+                || matches!(devices[i].commit_policy, CommitPolicy::None),
+            "a device without boot checkpoints must use CommitPolicy::None"
         );
         let mut c = 0;
         while c < devices[i].checkpoints.len() {
@@ -339,10 +345,21 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "at least one boot checkpoint")]
-    fn rejects_an_empty_checkpoint_list() {
+    #[should_panic(expected = "must use CommitPolicy::None")]
+    fn rejects_missing_checkpoints_with_a_liveness_gate() {
         validate(&[DeviceConfig {
             checkpoints: &[],
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    fn accepts_a_passive_device() {
+        validate(&[DeviceConfig {
+            checkpoints: &[],
+            commit_policy: CommitPolicy::None,
+            slots: const { &[slot(0)] },
+            recovery_policy: RecoveryPolicy::EscalateOnly,
             ..DEVICE
         }]);
     }

--- a/services/fwmanager/api/src/config.rs
+++ b/services/fwmanager/api/src/config.rs
@@ -58,9 +58,12 @@ pub struct BootCheckpoint<G> {
     pub window: core::time::Duration,
 }
 
-/// Identifies one slot within one device's layout. Opaque: meaning comes
-/// from the position in that device's slot table, never from a global
-/// vocabulary — slot 0 on the BMC and slot 0 on the NIC are unrelated.
+/// Identifies one slot within one device's layout. An opaque per-device
+/// token, not an index: ids need only be unique within one device's table
+/// ([`validate`] enforces exactly that) — they are not required to be
+/// contiguous, ordered, or to start at zero, and slot 0 on the BMC and
+/// slot 0 on the NIC are unrelated. Ladder order comes from table
+/// declaration order, never from id values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlotId(pub u8);
 

--- a/services/fwmanager/api/src/config.rs
+++ b/services/fwmanager/api/src/config.rs
@@ -53,6 +53,59 @@ pub struct BootCheckpoint<G> {
     pub window: core::time::Duration,
 }
 
+/// Identifies one slot within one device's layout. Opaque: meaning comes
+/// from the position in that device's slot table, never from a global
+/// vocabulary — slot 0 on the BMC and slot 0 on the NIC are unrelated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotId(pub u8);
+
+/// A distinguished duty a slot carries beyond being writable/bootable.
+///
+/// Intentionally exhaustive (not `#[non_exhaustive]`): adding a role is a
+/// breaking change, so every consumer that dispatches on roles — in
+/// particular recovery-candidate selection — is forced to handle the new
+/// role explicitly instead of falling into a wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotRole {
+    /// The slot recovery falls back to after every ordinary rung failed.
+    /// A "golden" image is this role plus `writable: false` — a property
+    /// combination, not a separate name.
+    Recovery,
+}
+
+/// One slot in a device's layout: topology as data, not a type. A layout
+/// is plain A/B, A/B + golden, or single + golden purely by what the table
+/// declares — no layout shape is named anywhere.
+#[derive(Debug, Clone, Copy)]
+pub struct SlotDesc {
+    pub id: SlotId,
+    /// May the update path write this slot? `false` on a recovery-role
+    /// slot is what makes it "golden".
+    pub writable: bool,
+    /// May the device boot from this slot? Every bootable slot is a rung
+    /// of the recovery ladder.
+    pub bootable: bool,
+    pub role: Option<SlotRole>,
+}
+
+/// What recovery may do when a device's active image fails.
+///
+/// Intentionally exhaustive (not `#[non_exhaustive]`): adding a variant is
+/// a breaking change, so every consumer that dispatches on the policy is
+/// forced to handle the new variant explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryPolicy {
+    /// Walk the ladder of bootable slots (recovery-role slot last) before
+    /// escalating. Requires a second rung — a layout with fewer than two
+    /// bootable slots is rejected by [`validate`], it must declare
+    /// [`EscalateOnly`](RecoveryPolicy::EscalateOnly) instead.
+    Ladder,
+    /// No local fallback: report and hand the device to out-of-band
+    /// operator recovery. The honest policy for a layout with no second
+    /// rung, and the only legal one for an empty layout.
+    EscalateOnly,
+}
+
 /// One managed downstream device, as declared by the board config.
 ///
 /// Generic over the board's reset signal type `R`, which must match the
@@ -73,6 +126,12 @@ pub struct DeviceConfig<R, G: 'static> {
     /// checkpoint whose window expires fails the boot.
     pub checkpoints: &'static [BootCheckpoint<G>],
     pub commit_policy: CommitPolicy,
+    /// This device's slot layout. Empty for a device that owns its boot
+    /// selection internally (the PLDM archetype) — such a layout has no
+    /// ladder rungs, so `recovery_policy` must be
+    /// [`RecoveryPolicy::EscalateOnly`].
+    pub slots: &'static [SlotDesc],
+    pub recovery_policy: RecoveryPolicy,
 }
 
 /// Checks a device table. Board configs call this in a const context so a
@@ -97,6 +156,43 @@ pub const fn validate<R, G>(devices: &[DeviceConfig<R, G>]) {
             );
             c += 1;
         }
+
+        let slots = devices[i].slots;
+        let mut bootable = 0;
+        let mut recovery_slots = 0;
+        let mut s = 0;
+        while s < slots.len() {
+            if slots[s].bootable {
+                bootable += 1;
+            }
+            if matches!(slots[s].role, Some(SlotRole::Recovery)) {
+                recovery_slots += 1;
+                assert!(slots[s].bootable, "a recovery-role slot must be bootable");
+            }
+            let mut t = s + 1;
+            while t < slots.len() {
+                assert!(
+                    slots[s].id.0 != slots[t].id.0,
+                    "slot ids must be unique within a device"
+                );
+                t += 1;
+            }
+            s += 1;
+        }
+        assert!(
+            recovery_slots <= 1,
+            "at most one recovery-role slot per device"
+        );
+        assert!(
+            slots.is_empty() || bootable > 0,
+            "a non-empty slot layout needs a bootable slot"
+        );
+        if matches!(devices[i].recovery_policy, RecoveryPolicy::Ladder) {
+            assert!(
+                bootable >= 2,
+                "a recovery ladder needs a second bootable slot"
+            );
+        }
         i += 1;
     }
 }
@@ -117,16 +213,123 @@ mod tests {
         window: Duration::from_secs(1),
     };
 
+    /// An ordinary slot: writable, bootable, no role.
+    const fn slot(id: u8) -> SlotDesc {
+        SlotDesc {
+            id: SlotId(id),
+            writable: true,
+            bootable: true,
+            role: None,
+        }
+    }
+
+    /// A recovery-role slot; non-writable, but no test depends on that.
+    const fn recovery_slot(id: u8) -> SlotDesc {
+        SlotDesc {
+            writable: false,
+            role: Some(SlotRole::Recovery),
+            ..slot(id)
+        }
+    }
+
     const DEVICE: DeviceConfig<u8, u8> = DeviceConfig {
         name: "dev",
         reset_signal: 0,
         checkpoints: &[CHECKPOINT],
         commit_policy: CommitPolicy::Liveness,
+        slots: &[slot(0), slot(1)],
+        recovery_policy: RecoveryPolicy::Ladder,
     };
 
     #[test]
     fn accepts_a_valid_table() {
         validate(&[DEVICE]);
+    }
+
+    #[test]
+    fn accepts_a_layout_with_a_recovery_slot() {
+        validate(&[DeviceConfig {
+            slots: const { &[slot(0), slot(1), recovery_slot(2)] },
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    fn accepts_an_empty_layout_with_escalate_only() {
+        validate(&[DeviceConfig {
+            slots: &[],
+            recovery_policy: RecoveryPolicy::EscalateOnly,
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "slot ids must be unique")]
+    fn rejects_duplicate_slot_ids() {
+        validate(&[DeviceConfig {
+            slots: const { &[slot(0), slot(0)] },
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "at most one recovery-role slot")]
+    fn rejects_two_recovery_role_slots() {
+        validate(&[DeviceConfig {
+            slots: const { &[slot(0), recovery_slot(1), recovery_slot(2)] },
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "recovery-role slot must be bootable")]
+    fn rejects_an_unbootable_recovery_slot() {
+        validate(&[DeviceConfig {
+            slots: const {
+                &[
+                    slot(0),
+                    slot(1),
+                    SlotDesc {
+                        bootable: false,
+                        ..recovery_slot(2)
+                    },
+                ]
+            },
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs a bootable slot")]
+    fn rejects_a_layout_with_no_bootable_slot() {
+        validate(&[DeviceConfig {
+            slots: const {
+                &[SlotDesc {
+                    bootable: false,
+                    ..slot(0)
+                }]
+            },
+            recovery_policy: RecoveryPolicy::EscalateOnly,
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs a second bootable slot")]
+    fn rejects_a_ladder_without_a_second_rung() {
+        validate(&[DeviceConfig {
+            slots: const { &[slot(0)] },
+            ..DEVICE
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs a second bootable slot")]
+    fn rejects_a_ladder_on_an_empty_layout() {
+        validate(&[DeviceConfig {
+            slots: &[],
+            ..DEVICE
+        }]);
     }
 
     #[test]

--- a/services/fwmanager/src/boot_progress.rs
+++ b/services/fwmanager/src/boot_progress.rs
@@ -1,59 +1,39 @@
 // Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
-//! Boot-progress confirmation: walk one device's configured checkpoints and
-//! judge its boot good or failed.
-//!
-//! After the orchestrator releases a device from reset
-//! ([`BootControl::release`](fwmanager_api::BootControl::release)), the
-//! device's boot is confirmed by observing each of its configured
-//! [`BootCheckpoint`]s within that checkpoint's window. Windows are
-//! sequential: checkpoint *n*'s window opens the moment checkpoint *n − 1*
-//! is observed (the first opens at release). A window that expires — or a
-//! device-reported failure — fails the boot, naming the checkpoint that
-//! died; that failure is what triggers recovery.
+//! Boot-progress confirmation: after a device is released from reset, each
+//! of its [`BootCheckpoint`]s must be observed within that checkpoint's
+//! window. Windows are sequential — checkpoint *n*'s opens when *n − 1* is
+//! observed, the first at release. An expired window or device-reported
+//! failure fails the boot, naming the checkpoint; that failure triggers
+//! recovery.
 
 use core::time::Duration;
 
 use fwmanager_api::config::{BootCheckpoint, BootSignal, DeviceConfig};
 use fwmanager_api::{BootMonitor, BootStatus};
 
-/// How many consecutive monitor read errors [`BootWalk::poll`] tolerates
-/// before it fails the walk: the read is retried on the next two polls, the
-/// third consecutive error is terminal. Any successful read resets the
-/// count. Transient faults on a transport that is itself still coming up
-/// should not condemn a boot — but a channel that stays broken cannot
-/// confirm one either. A module constant until a real transport shows a
-/// per-checkpoint budget is needed; the window deadline applies unchanged
-/// either way (read errors never extend it).
+/// Consecutive monitor read errors [`BootWalk::poll`] tolerates; one more
+/// is terminal. A successful read resets the count; read errors never
+/// extend the window. A constant until a real transport needs a
+/// per-checkpoint budget.
 const MAX_MONITOR_READ_RETRIES: u8 = 2;
 
-/// Resolves the monitor observing one boot-progress signal.
-///
-/// Owned by the board (or test) wiring: the walk never learns which backend
-/// serves which signal. `Monitor` is a single type — a board with
-/// heterogeneous backends wraps them in its own closed monitor enum, and
-/// one physical transport may back several signal kinds by handing out one
-/// thin monitor view per signal (an MCTP stack serving
-/// [`BootSignal::MctpReady`] and [`BootSignal::Heartbeat`]).
-///
-/// Returns `None` when the wiring maps no backend to `signal` — a board
-/// wiring bug the walk surfaces as a named failure rather than a hang,
-/// since the device-table schema cannot validate wiring it never sees.
+/// Resolves the monitor observing one boot-progress signal. Owned by the
+/// board wiring, typically as a closed monitor enum; one transport may back
+/// several signal kinds by handing out one thin view per signal.
 pub trait MonitorMap<G> {
-    /// The wiring's monitor type (typically its closed monitor enum).
+    /// The wiring's monitor type.
     type Monitor: BootMonitor;
 
-    /// Returns the monitor watching `signal`, or `None` if the wiring maps
-    /// no backend to it.
+    /// Returns the monitor watching `signal`; `None` (a wiring bug) fails
+    /// the walk rather than hanging it.
     fn monitor_for(&self, signal: &BootSignal<G>) -> Option<&Self::Monitor>;
 }
 
-/// A checkpoint window in the walk's time unit. `Duration::as_millis` is
-/// exact for the schema's seconds-scale windows; a sub-millisecond window
-/// rounds *up* to one millisecond so the schema's non-zero-window invariant
-/// survives the unit change, and absurd windows saturate instead of
-/// truncating.
+/// A checkpoint window in the walk's time unit. Sub-millisecond windows
+/// round up to 1 ms (preserving the schema's non-zero invariant); absurd
+/// ones saturate.
 const fn window_millis(window: Duration) -> u64 {
     let ms = window.as_millis();
     if ms == 0 {
@@ -81,11 +61,8 @@ pub enum Progress {
     Complete,
 }
 
-/// Why a device's boot walk failed.
-///
-/// Every variant names the device and the checkpoint that died — that is
-/// what [`BootCheckpoint`]'s `name` field exists for. A failure is terminal
-/// for the walk; recovery is the caller's decision, made on this value.
+/// Why a device's boot walk failed. Every variant names the device and
+/// checkpoint; a failure is terminal, recovery is the caller's decision.
 #[derive(Debug)]
 pub enum BootFailure<E> {
     /// The checkpoint's window expired without its signal — the walk's own
@@ -96,17 +73,15 @@ pub enum BootFailure<E> {
         /// The checkpoint whose window expired.
         checkpoint: &'static str,
     },
-    /// The device itself reported a boot failure
-    /// ([`BootStatus::Failed`]).
+    /// The device itself reported a boot failure ([`BootStatus::Failed`]).
     DeviceReported {
         /// The device whose boot failed.
         device: &'static str,
         /// The checkpoint being awaited when the device reported failure.
         checkpoint: &'static str,
     },
-    /// The checkpoint's monitor stayed unreadable past the retry budget
-    /// ([`MAX_MONITOR_READ_RETRIES`]) — the evidence channel itself broke,
-    /// which is not the same fault as a silent device. The concrete monitor
+    /// The checkpoint's monitor stayed unreadable past the retry budget —
+    /// a broken evidence channel, not a silent device. The concrete monitor
     /// error is the [`source()`](core::error::Error::source).
     MonitorRead {
         /// The device whose boot walk was cut short.
@@ -116,9 +91,7 @@ pub enum BootFailure<E> {
         /// The monitor's own error.
         source: E,
     },
-    /// The board wiring maps no monitor to this checkpoint's signal — a
-    /// wiring bug, surfaced instead of waiting on evidence that can never
-    /// arrive.
+    /// The board wiring maps no monitor to this checkpoint's signal.
     UnmappedSignal {
         /// The device whose boot walk was cut short.
         device: &'static str,
@@ -139,7 +112,9 @@ impl<E> core::fmt::Display for BootFailure<E> {
                     "{device}: device reported boot failure at checkpoint '{checkpoint}'"
                 )
             }
-            Self::MonitorRead { device, checkpoint, .. } => {
+            Self::MonitorRead {
+                device, checkpoint, ..
+            } => {
                 write!(
                     f,
                     "{device}: monitor read failed at checkpoint '{checkpoint}'"
@@ -164,35 +139,26 @@ impl<E: core::error::Error + 'static> core::error::Error for BootFailure<E> {
     }
 }
 
-/// One device's boot-progress walk.
-///
-/// Plain data: it holds which checkpoint is awaited and when that
-/// checkpoint's window expires. It never sleeps and never reads a clock —
-/// callers inject `now_millis` from their monotonic time source, so the
-/// walk's every verdict is reproducible on the host with literal
-/// timestamps.
-///
-/// A device with no checkpoints (a passive device, released blind under
+/// One device's boot-progress walk. Plain data — it never sleeps or reads
+/// a clock; callers inject `now_millis` from their monotonic time source.
+/// A device with no checkpoints (passive, released blind under
 /// [`CommitPolicy::None`](fwmanager_api::config::CommitPolicy::None)) is
-/// complete from construction: there is no evidence to wait for.
+/// complete from construction.
 ///
 /// # How the orchestrator uses it
 ///
-/// Declaration order in the device table is the boot order, one device at a
-/// time; releasing each device is sequenced by the flow that owns its
-/// [`BootControl`](fwmanager_api::BootControl):
+/// Declaration order in the device table is the boot order, one device at
+/// a time:
 ///
 /// ```ignore
 /// for dev in MANAGED_DEVICES {
-///     control_for(dev).release()?;          // run the just-verified image
+///     control_for(dev).release()?;
 ///     let mut walk = BootWalk::for_device(dev, now_millis());
 ///     loop {
 ///         match walk.poll(&monitors, now_millis())? {
-///             Progress::Waiting { deadline_millis, .. } => {
-///                 // Sleep until the next poll, never past the deadline.
-///                 sleep_until_millis(deadline_millis.min(now_millis() + POLL_PERIOD));
-///             }
-///             Progress::Complete => break,  // boot confirmed: next device
+///             Progress::Waiting { deadline_millis, .. } =>
+///                 sleep_until_millis(deadline_millis.min(now_millis() + POLL_PERIOD)),
+///             Progress::Complete => break,
 ///         }
 ///     }
 /// }
@@ -238,29 +204,15 @@ impl<G: 'static> BootWalk<G> {
     }
 
     /// Folds one observation of the awaited checkpoint's signal into the
-    /// walk.
+    /// walk. The pure core: [`poll`](Self::poll) obtains the observation;
+    /// callers holding boot evidence as events drive this directly (`E` is
+    /// free — no monitor-flavored failures here).
     ///
-    /// This is the pure core: it never touches a monitor — obtaining the
-    /// observation is [`poll`](Self::poll)'s job, and a caller that already
-    /// holds boot evidence as events can drive this directly. `E` is free
-    /// because this layer produces no monitor-flavored failures.
-    ///
-    /// Decision order:
-    ///
-    /// - [`BootStatus::Booted`] advances to the next checkpoint even when
-    ///   `now_millis` is at or past the deadline — the observation is
-    ///   proof, and a polling loop that oversleeps its final poll must not
-    ///   condemn a device that is provably up. The next checkpoint's window
-    ///   opens at `now_millis`.
-    /// - [`BootStatus::Failed`] fails the walk immediately, with window
-    ///   time left or not.
-    /// - [`BootStatus::Booting`] is judged against the window: the walk
-    ///   fails once `now_millis` reaches the deadline (the window is
-    ///   half-open — expiry is `now_millis >= deadline`).
-    ///
-    /// A completed walk ignores `status` and keeps returning
-    /// [`Progress::Complete`]. An `Err` is terminal: the caller stops
-    /// observing and hands the failure to recovery.
+    /// `Booted` advances even at or past the deadline (the observation is
+    /// proof; an oversleeping poller must not condemn a live device) and
+    /// opens the next window at `now_millis`. `Failed` fails immediately.
+    /// `Booting` fails once `now_millis >= deadline`. A completed walk
+    /// keeps returning [`Progress::Complete`]; an `Err` is terminal.
     pub fn observe<E>(
         &mut self,
         status: BootStatus,
@@ -301,21 +253,11 @@ impl<G: 'static> BootWalk<G> {
         }
     }
 
-    /// One poll: look up the awaited checkpoint's monitor, read it, and
-    /// fold the observation in via [`observe`](Self::observe).
-    ///
-    /// The lookup happens on every poll with the *current* checkpoint's
-    /// signal, so a device whose checkpoints ride different backends (a
-    /// GPIO line, then a heartbeat) is watched by the right monitor at each
-    /// step. A completed walk returns [`Progress::Complete`] without
-    /// consulting the map — a passive device's monitors are never read.
-    ///
-    /// A read error is retried on later polls up to
-    /// [`MAX_MONITOR_READ_RETRIES`] consecutive times, counted as absent
-    /// evidence in the meantime (the window keeps running and may expire
-    /// first); one more consecutive error fails the walk as
-    /// [`BootFailure::MonitorRead`]. As with [`observe`](Self::observe),
-    /// an `Err` is terminal.
+    /// One poll: look up the *current* checkpoint's monitor, read it, and
+    /// fold the observation in via [`observe`](Self::observe). A completed
+    /// walk never consults the map. Up to [`MAX_MONITOR_READ_RETRIES`]
+    /// consecutive read errors count as absent evidence (the window keeps
+    /// running); one more fails the walk as [`BootFailure::MonitorRead`].
     pub fn poll<M: MonitorMap<G>>(
         &mut self,
         monitors: &M,
@@ -440,7 +382,10 @@ mod tests {
                 checkpoint: "boot-complete",
             }
         ));
-        assert_eq!(err.to_string(), "bmc: checkpoint 'boot-complete' window expired");
+        assert_eq!(
+            err.to_string(),
+            "bmc: checkpoint 'boot-complete' window expired"
+        );
     }
 
     // The second checkpoint's window opens when the first is observed, not
@@ -892,7 +837,14 @@ mod tests {
         // one device at a time — and the passive cpld consumes no polls.
         assert_eq!(
             *wiring.lookups.borrow(),
-            ["gpio", "gpio", "gpio", "mctp-ready", "mctp-ready", "heartbeat"]
+            [
+                "gpio",
+                "gpio",
+                "gpio",
+                "mctp-ready",
+                "mctp-ready",
+                "heartbeat"
+            ]
         );
     }
 
@@ -912,8 +864,8 @@ mod tests {
         };
         let clock = FakeClock(Cell::new(0));
 
-        let err = walk_the_table(&wiring, &clock)
-            .expect_err("the missing heartbeat must fail the walk");
+        let err =
+            walk_the_table(&wiring, &clock).expect_err("the missing heartbeat must fail the walk");
         assert!(matches!(
             err,
             BootFailure::WindowExpired {

--- a/services/fwmanager/src/boot_progress.rs
+++ b/services/fwmanager/src/boot_progress.rs
@@ -1,0 +1,382 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Boot-progress confirmation: walk one device's configured checkpoints and
+//! judge its boot good or failed.
+//!
+//! After the orchestrator releases a device from reset
+//! ([`BootControl::release`](fwmanager_api::BootControl::release)), the
+//! device's boot is confirmed by observing each of its configured
+//! [`BootCheckpoint`]s within that checkpoint's window. Windows are
+//! sequential: checkpoint *n*'s window opens the moment checkpoint *n − 1*
+//! is observed (the first opens at release). A window that expires — or a
+//! device-reported failure — fails the boot, naming the checkpoint that
+//! died; that failure is what triggers recovery.
+
+use core::time::Duration;
+
+use fwmanager_api::config::BootCheckpoint;
+use fwmanager_api::BootStatus;
+
+/// A checkpoint window in the walk's time unit. `Duration::as_millis` is
+/// exact for the schema's seconds-scale windows; a sub-millisecond window
+/// rounds *up* to one millisecond so the schema's non-zero-window invariant
+/// survives the unit change, and absurd windows saturate instead of
+/// truncating.
+const fn window_millis(window: Duration) -> u64 {
+    let ms = window.as_millis();
+    if ms == 0 {
+        1
+    } else if ms > u64::MAX as u128 {
+        u64::MAX
+    } else {
+        ms as u64
+    }
+}
+
+/// Progress of a walk that has not failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Progress {
+    /// Still waiting on `checkpoint`; its window expires at
+    /// `deadline_millis`. The polling loop must observe the signal again no
+    /// later than that — it may poll sooner for a tighter verdict.
+    Waiting {
+        /// The awaited checkpoint's name.
+        checkpoint: &'static str,
+        /// When its window expires, in the caller's monotonic milliseconds.
+        deadline_millis: u64,
+    },
+    /// Every checkpoint was observed within its window: the boot is good.
+    Complete,
+}
+
+/// Why a device's boot walk failed.
+///
+/// Every variant names the device and the checkpoint that died — that is
+/// what [`BootCheckpoint`]'s `name` field exists for. A failure is terminal
+/// for the walk; recovery is the caller's decision, made on this value.
+#[derive(Debug)]
+pub enum BootFailure {
+    /// The checkpoint's window expired without its signal — the walk's own
+    /// judgment; hung devices report nothing.
+    WindowExpired {
+        /// The device whose boot failed.
+        device: &'static str,
+        /// The checkpoint whose window expired.
+        checkpoint: &'static str,
+    },
+    /// The device itself reported a boot failure
+    /// ([`BootStatus::Failed`]).
+    DeviceReported {
+        /// The device whose boot failed.
+        device: &'static str,
+        /// The checkpoint being awaited when the device reported failure.
+        checkpoint: &'static str,
+    },
+}
+
+impl core::fmt::Display for BootFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::WindowExpired { device, checkpoint } => {
+                write!(f, "{device}: checkpoint '{checkpoint}' window expired")
+            }
+            Self::DeviceReported { device, checkpoint } => {
+                write!(
+                    f,
+                    "{device}: device reported boot failure at checkpoint '{checkpoint}'"
+                )
+            }
+        }
+    }
+}
+
+impl core::error::Error for BootFailure {}
+
+/// One device's boot-progress walk.
+///
+/// Plain data: it holds which checkpoint is awaited and when that
+/// checkpoint's window expires. It never sleeps and never reads a clock —
+/// callers inject `now_millis` from their monotonic time source, so the
+/// walk's every verdict is reproducible on the host with literal
+/// timestamps.
+///
+/// A device with no checkpoints (a passive device, released blind under
+/// [`CommitPolicy::None`](fwmanager_api::config::CommitPolicy::None)) is
+/// complete from construction: there is no evidence to wait for.
+pub struct BootWalk<G: 'static> {
+    device: &'static str,
+    checkpoints: &'static [BootCheckpoint<G>],
+    /// Index of the checkpoint currently awaited; `== checkpoints.len()`
+    /// when the walk is complete.
+    next: usize,
+    /// When the awaited checkpoint's window expires, in the caller's
+    /// monotonic milliseconds. Meaningless once the walk is complete.
+    deadline_millis: u64,
+}
+
+impl<G: 'static> BootWalk<G> {
+    /// Starts the walk at `now_millis` — the moment the device left reset.
+    /// The first checkpoint's window opens here.
+    pub fn new(
+        device: &'static str,
+        checkpoints: &'static [BootCheckpoint<G>],
+        now_millis: u64,
+    ) -> Self {
+        let deadline_millis = match checkpoints.first() {
+            Some(first) => now_millis.saturating_add(window_millis(first.window)),
+            None => 0,
+        };
+        Self {
+            device,
+            checkpoints,
+            next: 0,
+            deadline_millis,
+        }
+    }
+
+    /// Folds one observation of the awaited checkpoint's signal into the
+    /// walk.
+    ///
+    /// This is the pure core: it never touches a monitor — obtaining the
+    /// observation is the polling layer's job, and a caller that already
+    /// holds boot evidence as events can drive this directly.
+    ///
+    /// Decision order:
+    ///
+    /// - [`BootStatus::Booted`] advances to the next checkpoint even when
+    ///   `now_millis` is at or past the deadline — the observation is
+    ///   proof, and a polling loop that oversleeps its final poll must not
+    ///   condemn a device that is provably up. The next checkpoint's window
+    ///   opens at `now_millis`.
+    /// - [`BootStatus::Failed`] fails the walk immediately, with window
+    ///   time left or not.
+    /// - [`BootStatus::Booting`] is judged against the window: the walk
+    ///   fails once `now_millis` reaches the deadline (the window is
+    ///   half-open — expiry is `now_millis >= deadline`).
+    ///
+    /// A completed walk ignores `status` and keeps returning
+    /// [`Progress::Complete`]. An `Err` is terminal: the caller stops
+    /// observing and hands the failure to recovery.
+    pub fn observe(
+        &mut self,
+        status: BootStatus,
+        now_millis: u64,
+    ) -> Result<Progress, BootFailure> {
+        let Some(awaited) = self.checkpoints.get(self.next) else {
+            return Ok(Progress::Complete);
+        };
+        match status {
+            BootStatus::Booted => {
+                self.next += 1;
+                let Some(opened) = self.checkpoints.get(self.next) else {
+                    return Ok(Progress::Complete);
+                };
+                self.deadline_millis = now_millis.saturating_add(window_millis(opened.window));
+                Ok(Progress::Waiting {
+                    checkpoint: opened.name,
+                    deadline_millis: self.deadline_millis,
+                })
+            }
+            BootStatus::Failed => Err(BootFailure::DeviceReported {
+                device: self.device,
+                checkpoint: awaited.name,
+            }),
+            BootStatus::Booting => {
+                if now_millis >= self.deadline_millis {
+                    Err(BootFailure::WindowExpired {
+                        device: self.device,
+                        checkpoint: awaited.name,
+                    })
+                } else {
+                    Ok(Progress::Waiting {
+                        checkpoint: awaited.name,
+                        deadline_millis: self.deadline_millis,
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::time::Duration;
+    use fwmanager_api::config::BootSignal;
+
+    // Checkpoint shapes mirroring the mock board's archetypes: a single
+    // GPIO boot-complete line (the bmc) and a two-checkpoint message path
+    // (the nic).
+
+    const BMC: &[BootCheckpoint<u8>] = &[BootCheckpoint {
+        name: "boot-complete",
+        signal: BootSignal::GpioBootComplete(12),
+        window: Duration::from_secs(90),
+    }];
+
+    const NIC: &[BootCheckpoint<u8>] = &[
+        BootCheckpoint {
+            name: "mctp-ready",
+            signal: BootSignal::MctpReady,
+            window: Duration::from_secs(20),
+        },
+        BootCheckpoint {
+            name: "heartbeat",
+            signal: BootSignal::Heartbeat,
+            window: Duration::from_secs(10),
+        },
+    ];
+
+    fn observe(
+        walk: &mut BootWalk<u8>,
+        status: BootStatus,
+        now_millis: u64,
+    ) -> Result<Progress, BootFailure> {
+        walk.observe(status, now_millis)
+    }
+
+    #[test]
+    fn a_single_checkpoint_observed_in_time_completes_the_walk() {
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booting, 1_000).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "boot-complete",
+                deadline_millis: 90_000,
+            }
+        );
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booted, 5_000).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    #[test]
+    fn an_expired_window_fails_the_walk_naming_the_checkpoint() {
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+
+        // One millisecond before the deadline the walk still waits...
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booting, 89_999).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "boot-complete",
+                deadline_millis: 90_000,
+            }
+        );
+
+        // ...at the deadline it fails, and the report names device and
+        // checkpoint (Display comes from the core::error::Error contract).
+        let err = observe(&mut walk, BootStatus::Booting, 90_000)
+            .expect_err("expected the window to expire");
+        assert!(matches!(
+            err,
+            BootFailure::WindowExpired {
+                device: "bmc",
+                checkpoint: "boot-complete",
+            }
+        ));
+        assert_eq!(err.to_string(), "bmc: checkpoint 'boot-complete' window expired");
+    }
+
+    // The second checkpoint's window opens when the first is observed, not
+    // at release: mctp-ready at t=15s arms heartbeat's 10s window to expire
+    // at t=25s, not t=30s.
+    #[test]
+    fn each_observation_opens_the_next_checkpoints_window() {
+        let mut walk = BootWalk::new("nic", NIC, 0);
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booted, 15_000).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "heartbeat",
+                deadline_millis: 25_000,
+            }
+        );
+
+        let err = observe(&mut walk, BootStatus::Booting, 25_000)
+            .expect_err("expected the second window to expire");
+        assert!(matches!(
+            err,
+            BootFailure::WindowExpired {
+                device: "nic",
+                checkpoint: "heartbeat",
+            }
+        ));
+    }
+
+    // The observation is proof: a polling loop that oversleeps its final
+    // poll must not condemn a device that is provably up.
+    #[test]
+    fn booted_at_the_deadline_still_advances() {
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booted, 90_000).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    #[test]
+    fn a_device_reported_failure_fails_the_walk_with_window_time_left() {
+        let mut walk = BootWalk::new("nic", NIC, 0);
+
+        let err = observe(&mut walk, BootStatus::Failed, 1_000)
+            .expect_err("expected the device-reported failure");
+        assert!(matches!(
+            err,
+            BootFailure::DeviceReported {
+                device: "nic",
+                checkpoint: "mctp-ready",
+            }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "nic: device reported boot failure at checkpoint 'mctp-ready'"
+        );
+    }
+
+    // A completed walk ignores further observations — even a Failed one:
+    // the verdict was already delivered.
+    #[test]
+    fn a_completed_walk_stays_complete() {
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+        observe(&mut walk, BootStatus::Booted, 5_000).expect("walk failed");
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Failed, 6_000).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    #[test]
+    fn a_device_with_no_checkpoints_is_complete_from_construction() {
+        let mut walk = BootWalk::new("cpld", &[], 0);
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booting, 0).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    // Sub-millisecond windows round up to one millisecond rather than
+    // expiring at the instant they open.
+    #[test]
+    fn a_sub_millisecond_window_is_not_born_expired() {
+        const TIGHT: &[BootCheckpoint<u8>] = &[BootCheckpoint {
+            name: "instant",
+            signal: BootSignal::Heartbeat,
+            window: Duration::from_nanos(1),
+        }];
+        let mut walk = BootWalk::new("dev", TIGHT, 0);
+
+        assert_eq!(
+            observe(&mut walk, BootStatus::Booting, 0).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "instant",
+                deadline_millis: 1,
+            }
+        );
+    }
+}

--- a/services/fwmanager/src/boot_progress.rs
+++ b/services/fwmanager/src/boot_progress.rs
@@ -15,8 +15,39 @@
 
 use core::time::Duration;
 
-use fwmanager_api::config::BootCheckpoint;
-use fwmanager_api::BootStatus;
+use fwmanager_api::config::{BootCheckpoint, BootSignal};
+use fwmanager_api::{BootMonitor, BootStatus};
+
+/// How many consecutive monitor read errors [`BootWalk::poll`] tolerates
+/// before it fails the walk: the read is retried on the next two polls, the
+/// third consecutive error is terminal. Any successful read resets the
+/// count. Transient faults on a transport that is itself still coming up
+/// should not condemn a boot — but a channel that stays broken cannot
+/// confirm one either. A module constant until a real transport shows a
+/// per-checkpoint budget is needed; the window deadline applies unchanged
+/// either way (read errors never extend it).
+const MAX_MONITOR_READ_RETRIES: u8 = 2;
+
+/// Resolves the monitor observing one boot-progress signal.
+///
+/// Owned by the board (or test) wiring: the walk never learns which backend
+/// serves which signal. `Monitor` is a single type — a board with
+/// heterogeneous backends wraps them in its own closed monitor enum, and
+/// one physical transport may back several signal kinds by handing out one
+/// thin monitor view per signal (an MCTP stack serving
+/// [`BootSignal::MctpReady`] and [`BootSignal::Heartbeat`]).
+///
+/// Returns `None` when the wiring maps no backend to `signal` — a board
+/// wiring bug the walk surfaces as a named failure rather than a hang,
+/// since the device-table schema cannot validate wiring it never sees.
+pub trait MonitorMap<G> {
+    /// The wiring's monitor type (typically its closed monitor enum).
+    type Monitor: BootMonitor;
+
+    /// Returns the monitor watching `signal`, or `None` if the wiring maps
+    /// no backend to it.
+    fn monitor_for(&self, signal: &BootSignal<G>) -> Option<&Self::Monitor>;
+}
 
 /// A checkpoint window in the walk's time unit. `Duration::as_millis` is
 /// exact for the schema's seconds-scale windows; a sub-millisecond window
@@ -56,7 +87,7 @@ pub enum Progress {
 /// what [`BootCheckpoint`]'s `name` field exists for. A failure is terminal
 /// for the walk; recovery is the caller's decision, made on this value.
 #[derive(Debug)]
-pub enum BootFailure {
+pub enum BootFailure<E> {
     /// The checkpoint's window expired without its signal — the walk's own
     /// judgment; hung devices report nothing.
     WindowExpired {
@@ -73,9 +104,30 @@ pub enum BootFailure {
         /// The checkpoint being awaited when the device reported failure.
         checkpoint: &'static str,
     },
+    /// The checkpoint's monitor stayed unreadable past the retry budget
+    /// ([`MAX_MONITOR_READ_RETRIES`]) — the evidence channel itself broke,
+    /// which is not the same fault as a silent device. The concrete monitor
+    /// error is the [`source()`](core::error::Error::source).
+    MonitorRead {
+        /// The device whose boot walk was cut short.
+        device: &'static str,
+        /// The checkpoint whose monitor could not be read.
+        checkpoint: &'static str,
+        /// The monitor's own error.
+        source: E,
+    },
+    /// The board wiring maps no monitor to this checkpoint's signal — a
+    /// wiring bug, surfaced instead of waiting on evidence that can never
+    /// arrive.
+    UnmappedSignal {
+        /// The device whose boot walk was cut short.
+        device: &'static str,
+        /// The checkpoint whose signal has no monitor.
+        checkpoint: &'static str,
+    },
 }
 
-impl core::fmt::Display for BootFailure {
+impl<E> core::fmt::Display for BootFailure<E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::WindowExpired { device, checkpoint } => {
@@ -87,11 +139,30 @@ impl core::fmt::Display for BootFailure {
                     "{device}: device reported boot failure at checkpoint '{checkpoint}'"
                 )
             }
+            Self::MonitorRead { device, checkpoint, .. } => {
+                write!(
+                    f,
+                    "{device}: monitor read failed at checkpoint '{checkpoint}'"
+                )
+            }
+            Self::UnmappedSignal { device, checkpoint } => {
+                write!(
+                    f,
+                    "{device}: no monitor wired for checkpoint '{checkpoint}'"
+                )
+            }
         }
     }
 }
 
-impl core::error::Error for BootFailure {}
+impl<E: core::error::Error + 'static> core::error::Error for BootFailure<E> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::MonitorRead { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
 
 /// One device's boot-progress walk.
 ///
@@ -113,6 +184,9 @@ pub struct BootWalk<G: 'static> {
     /// When the awaited checkpoint's window expires, in the caller's
     /// monotonic milliseconds. Meaningless once the walk is complete.
     deadline_millis: u64,
+    /// Consecutive monitor read errors on the awaited checkpoint; reset by
+    /// any successful read.
+    read_errors: u8,
 }
 
 impl<G: 'static> BootWalk<G> {
@@ -132,6 +206,7 @@ impl<G: 'static> BootWalk<G> {
             checkpoints,
             next: 0,
             deadline_millis,
+            read_errors: 0,
         }
     }
 
@@ -139,8 +214,9 @@ impl<G: 'static> BootWalk<G> {
     /// walk.
     ///
     /// This is the pure core: it never touches a monitor — obtaining the
-    /// observation is the polling layer's job, and a caller that already
-    /// holds boot evidence as events can drive this directly.
+    /// observation is [`poll`](Self::poll)'s job, and a caller that already
+    /// holds boot evidence as events can drive this directly. `E` is free
+    /// because this layer produces no monitor-flavored failures.
     ///
     /// Decision order:
     ///
@@ -158,11 +234,11 @@ impl<G: 'static> BootWalk<G> {
     /// A completed walk ignores `status` and keeps returning
     /// [`Progress::Complete`]. An `Err` is terminal: the caller stops
     /// observing and hands the failure to recovery.
-    pub fn observe(
+    pub fn observe<E>(
         &mut self,
         status: BootStatus,
         now_millis: u64,
-    ) -> Result<Progress, BootFailure> {
+    ) -> Result<Progress, BootFailure<E>> {
         let Some(awaited) = self.checkpoints.get(self.next) else {
             return Ok(Progress::Complete);
         };
@@ -197,13 +273,73 @@ impl<G: 'static> BootWalk<G> {
             }
         }
     }
+
+    /// One poll: look up the awaited checkpoint's monitor, read it, and
+    /// fold the observation in via [`observe`](Self::observe).
+    ///
+    /// The lookup happens on every poll with the *current* checkpoint's
+    /// signal, so a device whose checkpoints ride different backends (a
+    /// GPIO line, then a heartbeat) is watched by the right monitor at each
+    /// step. A completed walk returns [`Progress::Complete`] without
+    /// consulting the map — a passive device's monitors are never read.
+    ///
+    /// A read error is retried on later polls up to
+    /// [`MAX_MONITOR_READ_RETRIES`] consecutive times, counted as absent
+    /// evidence in the meantime (the window keeps running and may expire
+    /// first); one more consecutive error fails the walk as
+    /// [`BootFailure::MonitorRead`]. As with [`observe`](Self::observe),
+    /// an `Err` is terminal.
+    pub fn poll<M: MonitorMap<G>>(
+        &mut self,
+        monitors: &M,
+        now_millis: u64,
+    ) -> Result<Progress, BootFailure<<M::Monitor as BootMonitor>::Error>> {
+        let Some(awaited) = self.checkpoints.get(self.next) else {
+            return Ok(Progress::Complete);
+        };
+        let Some(monitor) = monitors.monitor_for(&awaited.signal) else {
+            return Err(BootFailure::UnmappedSignal {
+                device: self.device,
+                checkpoint: awaited.name,
+            });
+        };
+        match monitor.boot_status() {
+            Ok(status) => {
+                self.read_errors = 0;
+                self.observe(status, now_millis)
+            }
+            Err(source) => {
+                if self.read_errors < MAX_MONITOR_READ_RETRIES {
+                    self.read_errors += 1;
+                    self.observe(BootStatus::Booting, now_millis)
+                } else {
+                    Err(BootFailure::MonitorRead {
+                        device: self.device,
+                        checkpoint: awaited.name,
+                        source,
+                    })
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::Cell;
     use core::time::Duration;
-    use fwmanager_api::config::BootSignal;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct MockFault;
+
+    impl core::fmt::Display for MockFault {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("mock monitor fault")
+        }
+    }
+
+    impl core::error::Error for MockFault {}
 
     // Checkpoint shapes mirroring the mock board's archetypes: a single
     // GPIO boot-complete line (the bmc) and a two-checkpoint message path
@@ -232,7 +368,7 @@ mod tests {
         walk: &mut BootWalk<u8>,
         status: BootStatus,
         now_millis: u64,
-    ) -> Result<Progress, BootFailure> {
+    ) -> Result<Progress, BootFailure<MockFault>> {
         walk.observe(status, now_millis)
     }
 
@@ -378,5 +514,271 @@ mod tests {
                 deadline_millis: 1,
             }
         );
+    }
+
+    // ── The poll layer: monitors behind the MonitorMap seam ─────────────
+
+    /// Replays a fixed script of reads; the last entry repeats forever.
+    struct ScriptedMonitor {
+        script: &'static [Result<BootStatus, MockFault>],
+        cursor: Cell<usize>,
+    }
+
+    impl ScriptedMonitor {
+        fn new(script: &'static [Result<BootStatus, MockFault>]) -> Self {
+            Self {
+                script,
+                cursor: Cell::new(0),
+            }
+        }
+    }
+
+    impl BootMonitor for ScriptedMonitor {
+        type Error = MockFault;
+
+        fn boot_status(&self) -> Result<BootStatus, MockFault> {
+            let i = self.cursor.get();
+            self.cursor.set(i + 1);
+            self.script[i.min(self.script.len() - 1)]
+        }
+    }
+
+    /// One MCTP endpoint backing two signal kinds: the wiring hands out one
+    /// thin view per signal, all reading this shared backend.
+    struct MctpEndpoint {
+        ready: Cell<bool>,
+        heartbeat_seen: Cell<bool>,
+    }
+
+    enum MctpSignalKind {
+        Ready,
+        Heartbeat,
+    }
+
+    /// The wiring's closed monitor enum — the shape a board declares.
+    enum MockMonitor<'a> {
+        Gpio(&'a ScriptedMonitor),
+        Mctp(&'a MctpEndpoint, MctpSignalKind),
+    }
+
+    impl BootMonitor for MockMonitor<'_> {
+        type Error = MockFault;
+
+        fn boot_status(&self) -> Result<BootStatus, MockFault> {
+            let up = match self {
+                Self::Gpio(mon) => return mon.boot_status(),
+                Self::Mctp(ep, MctpSignalKind::Ready) => ep.ready.get(),
+                Self::Mctp(ep, MctpSignalKind::Heartbeat) => ep.heartbeat_seen.get(),
+            };
+            Ok(if up {
+                BootStatus::Booted
+            } else {
+                BootStatus::Booting
+            })
+        }
+    }
+
+    struct MockWiring<'a> {
+        gpio: Option<MockMonitor<'a>>,
+        mctp_ready: Option<MockMonitor<'a>>,
+        heartbeat: Option<MockMonitor<'a>>,
+    }
+
+    impl<'a> MonitorMap<u8> for MockWiring<'a> {
+        type Monitor = MockMonitor<'a>;
+
+        fn monitor_for(&self, signal: &BootSignal<u8>) -> Option<&MockMonitor<'a>> {
+            match signal {
+                BootSignal::GpioBootComplete(_) => self.gpio.as_ref(),
+                BootSignal::MctpReady => self.mctp_ready.as_ref(),
+                BootSignal::Heartbeat => self.heartbeat.as_ref(),
+                BootSignal::VersionQuery => None,
+            }
+        }
+    }
+
+    /// Wiring for walks that must never consult a monitor.
+    struct PanickingMap;
+
+    impl MonitorMap<u8> for PanickingMap {
+        type Monitor = ScriptedMonitor;
+
+        fn monitor_for(&self, _: &BootSignal<u8>) -> Option<&ScriptedMonitor> {
+            panic!("this walk must never consult a monitor")
+        }
+    }
+
+    /// Wiring that maps nothing — a board wiring bug.
+    struct NoMonitors;
+
+    impl MonitorMap<u8> for NoMonitors {
+        type Monitor = ScriptedMonitor;
+
+        fn monitor_for(&self, _: &BootSignal<u8>) -> Option<&ScriptedMonitor> {
+            None
+        }
+    }
+
+    // The lookup happens per poll with the current checkpoint's signal, so
+    // both of the nic's checkpoints are answered by the one MCTP endpoint
+    // through its per-signal views.
+    #[test]
+    fn one_backend_serves_several_signal_kinds_through_per_signal_views() {
+        let endpoint = MctpEndpoint {
+            ready: Cell::new(false),
+            heartbeat_seen: Cell::new(false),
+        };
+        let wiring = MockWiring {
+            gpio: None,
+            mctp_ready: Some(MockMonitor::Mctp(&endpoint, MctpSignalKind::Ready)),
+            heartbeat: Some(MockMonitor::Mctp(&endpoint, MctpSignalKind::Heartbeat)),
+        };
+        let mut walk = BootWalk::new("nic", NIC, 0);
+
+        assert_eq!(
+            walk.poll(&wiring, 1_000).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "mctp-ready",
+                deadline_millis: 20_000,
+            }
+        );
+
+        endpoint.ready.set(true);
+        assert_eq!(
+            walk.poll(&wiring, 2_000).expect("walk failed"),
+            Progress::Waiting {
+                checkpoint: "heartbeat",
+                deadline_millis: 12_000,
+            }
+        );
+
+        endpoint.heartbeat_seen.set(true);
+        assert_eq!(
+            walk.poll(&wiring, 3_000).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    // Two consecutive read errors are tolerated as absent evidence, a
+    // successful read resets the count, and the third consecutive error is
+    // terminal — with the concrete monitor error kept on the source() chain.
+    #[test]
+    fn transient_read_errors_are_retried_then_terminal() {
+        const SCRIPT: &[Result<BootStatus, MockFault>] = &[
+            Err(MockFault),
+            Err(MockFault),
+            Ok(BootStatus::Booting),
+            Err(MockFault),
+            Err(MockFault),
+            Err(MockFault),
+        ];
+        let gpio = ScriptedMonitor::new(SCRIPT);
+        let wiring = MockWiring {
+            gpio: Some(MockMonitor::Gpio(&gpio)),
+            mctp_ready: None,
+            heartbeat: None,
+        };
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+
+        for poll in 1..=5u64 {
+            assert!(
+                matches!(
+                    walk.poll(&wiring, poll * 1_000),
+                    Ok(Progress::Waiting { .. })
+                ),
+                "poll {poll} should still be waiting"
+            );
+        }
+
+        let err = walk
+            .poll(&wiring, 6_000)
+            .expect_err("expected the third consecutive read error to be terminal");
+        assert!(matches!(
+            err,
+            BootFailure::MonitorRead {
+                device: "bmc",
+                checkpoint: "boot-complete",
+                ..
+            }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "bmc: monitor read failed at checkpoint 'boot-complete'"
+        );
+        let source = core::error::Error::source(&err).expect("MonitorRead must carry a source");
+        assert!(source.downcast_ref::<MockFault>().is_some());
+    }
+
+    // A backend that can only answer "up yet?" (a single ready line) never
+    // produces Failed; the failure verdict must not depend on it — expiry
+    // is the walk's own judgment.
+    #[test]
+    fn a_monitor_that_never_reports_failed_still_yields_a_verdict() {
+        const STUCK: &[Result<BootStatus, MockFault>] = &[Ok(BootStatus::Booting)];
+        let gpio = ScriptedMonitor::new(STUCK);
+        let wiring = MockWiring {
+            gpio: Some(MockMonitor::Gpio(&gpio)),
+            mctp_ready: None,
+            heartbeat: None,
+        };
+        let mut walk = BootWalk::new("bmc", BMC, 0);
+
+        assert!(matches!(
+            walk.poll(&wiring, 89_999),
+            Ok(Progress::Waiting { .. })
+        ));
+        assert!(matches!(
+            walk.poll(&wiring, 90_000),
+            Err(BootFailure::WindowExpired {
+                device: "bmc",
+                checkpoint: "boot-complete",
+            })
+        ));
+    }
+
+    #[test]
+    fn an_unmapped_signal_is_a_named_failure_not_a_hang() {
+        let mut walk = BootWalk::new("nic", NIC, 0);
+
+        let err = walk
+            .poll(&NoMonitors, 0)
+            .expect_err("expected the missing wiring to surface");
+        assert!(matches!(
+            err,
+            BootFailure::UnmappedSignal {
+                device: "nic",
+                checkpoint: "mctp-ready",
+            }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "nic: no monitor wired for checkpoint 'mctp-ready'"
+        );
+    }
+
+    // A passive device is released blind: complete from the first poll,
+    // and its monitors — it has none — are provably never consulted.
+    #[test]
+    fn a_passive_device_never_consults_the_map() {
+        let mut walk = BootWalk::new("cpld", &[], 0);
+
+        assert_eq!(
+            walk.poll(&PanickingMap, 0).expect("walk failed"),
+            Progress::Complete
+        );
+        // Polling past completion stays Complete without a lookup.
+        assert_eq!(
+            walk.poll(&PanickingMap, 1_000).expect("walk failed"),
+            Progress::Complete
+        );
+    }
+
+    // Compile fence: BootFailure satisfies the full error contract, so it
+    // can ride any seam that expects a core::error::Error.
+    fn _assert_error_contract<E: core::error::Error>() {}
+
+    #[test]
+    fn boot_failure_is_a_core_error() {
+        _assert_error_contract::<BootFailure<MockFault>>();
     }
 }

--- a/services/fwmanager/src/boot_progress.rs
+++ b/services/fwmanager/src/boot_progress.rs
@@ -15,7 +15,7 @@
 
 use core::time::Duration;
 
-use fwmanager_api::config::{BootCheckpoint, BootSignal};
+use fwmanager_api::config::{BootCheckpoint, BootSignal, DeviceConfig};
 use fwmanager_api::{BootMonitor, BootStatus};
 
 /// How many consecutive monitor read errors [`BootWalk::poll`] tolerates
@@ -175,6 +175,28 @@ impl<E: core::error::Error + 'static> core::error::Error for BootFailure<E> {
 /// A device with no checkpoints (a passive device, released blind under
 /// [`CommitPolicy::None`](fwmanager_api::config::CommitPolicy::None)) is
 /// complete from construction: there is no evidence to wait for.
+///
+/// # How the orchestrator uses it
+///
+/// Declaration order in the device table is the boot order, one device at a
+/// time; releasing each device is sequenced by the flow that owns its
+/// [`BootControl`](fwmanager_api::BootControl):
+///
+/// ```ignore
+/// for dev in MANAGED_DEVICES {
+///     control_for(dev).release()?;          // run the just-verified image
+///     let mut walk = BootWalk::for_device(dev, now_millis());
+///     loop {
+///         match walk.poll(&monitors, now_millis())? {
+///             Progress::Waiting { deadline_millis, .. } => {
+///                 // Sleep until the next poll, never past the deadline.
+///                 sleep_until_millis(deadline_millis.min(now_millis() + POLL_PERIOD));
+///             }
+///             Progress::Complete => break,  // boot confirmed: next device
+///         }
+///     }
+/// }
+/// ```
 pub struct BootWalk<G: 'static> {
     device: &'static str,
     checkpoints: &'static [BootCheckpoint<G>],
@@ -208,6 +230,11 @@ impl<G: 'static> BootWalk<G> {
             deadline_millis,
             read_errors: 0,
         }
+    }
+
+    /// Convenience constructor over a device-table entry.
+    pub fn for_device<R>(device: &DeviceConfig<R, G>, now_millis: u64) -> Self {
+        Self::new(device.name, device.checkpoints, now_millis)
     }
 
     /// Folds one observation of the awaited checkpoint's signal into the
@@ -780,5 +807,119 @@ mod tests {
     #[test]
     fn boot_failure_is_a_core_error() {
         _assert_error_contract::<BootFailure<MockFault>>();
+    }
+
+    // ── The mock board, end to end ───────────────────────────────────────
+    // The composition loop from the type-level docs, run over the real
+    // mock device table: bmc, then nic, then the passive cpld.
+
+    use std::cell::RefCell;
+
+    struct FakeClock(Cell<u64>);
+
+    impl FakeClock {
+        fn now(&self) -> u64 {
+            self.0.get()
+        }
+
+        fn advance(&self, millis: u64) {
+            self.0.set(self.0.get() + millis);
+        }
+    }
+
+    /// Records every signal lookup, proving which device's evidence was
+    /// consulted when (each poll makes exactly one lookup).
+    struct RecordingWiring<'a> {
+        inner: MockWiring<'a>,
+        lookups: RefCell<Vec<&'static str>>,
+    }
+
+    impl<'a> MonitorMap<u8> for RecordingWiring<'a> {
+        type Monitor = MockMonitor<'a>;
+
+        fn monitor_for(&self, signal: &BootSignal<u8>) -> Option<&MockMonitor<'a>> {
+            self.lookups.borrow_mut().push(match signal {
+                BootSignal::GpioBootComplete(_) => "gpio",
+                BootSignal::MctpReady => "mctp-ready",
+                BootSignal::Heartbeat => "heartbeat",
+                BootSignal::VersionQuery => "version-query",
+            });
+            self.inner.monitor_for(signal)
+        }
+    }
+
+    /// The doc-sketch loop made concrete: release is out of scope here, so
+    /// each device's walk starts at the current fake time and waiting
+    /// advances the clock by a fixed poll period.
+    fn walk_the_table<M>(wiring: &M, clock: &FakeClock) -> Result<(), BootFailure<MockFault>>
+    where
+        M: MonitorMap<u8>,
+        M::Monitor: BootMonitor<Error = MockFault>,
+    {
+        for dev in board_devices::MANAGED_DEVICES {
+            let mut walk = BootWalk::for_device(dev, clock.now());
+            while let Progress::Waiting { .. } = walk.poll(wiring, clock.now())? {
+                clock.advance(1_000);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn the_mock_board_boots_in_declaration_order() {
+        // Scripted evidence per signal (the Gpio arm is just "a scripted
+        // backend" here; which transport it models is irrelevant).
+        let gpio = ScriptedMonitor::new(&[
+            Ok(BootStatus::Booting),
+            Ok(BootStatus::Booting),
+            Ok(BootStatus::Booted),
+        ]);
+        let mctp_ready = ScriptedMonitor::new(&[Ok(BootStatus::Booting), Ok(BootStatus::Booted)]);
+        let heartbeat = ScriptedMonitor::new(&[Ok(BootStatus::Booted)]);
+        let wiring = RecordingWiring {
+            inner: MockWiring {
+                gpio: Some(MockMonitor::Gpio(&gpio)),
+                mctp_ready: Some(MockMonitor::Gpio(&mctp_ready)),
+                heartbeat: Some(MockMonitor::Gpio(&heartbeat)),
+            },
+            lookups: RefCell::new(Vec::new()),
+        };
+        let clock = FakeClock(Cell::new(0));
+
+        walk_the_table(&wiring, &clock).expect("the mock board must boot");
+
+        // bmc's evidence is exhausted before nic's is first consulted —
+        // one device at a time — and the passive cpld consumes no polls.
+        assert_eq!(
+            *wiring.lookups.borrow(),
+            ["gpio", "gpio", "gpio", "mctp-ready", "mctp-ready", "heartbeat"]
+        );
+    }
+
+    #[test]
+    fn a_boot_failure_stops_the_table_walk_naming_the_culprit() {
+        let gpio = ScriptedMonitor::new(&[Ok(BootStatus::Booted)]);
+        let mctp_ready = ScriptedMonitor::new(&[Ok(BootStatus::Booted)]);
+        // The heartbeat never arrives: nic's second window must expire.
+        let heartbeat = ScriptedMonitor::new(&[Ok(BootStatus::Booting)]);
+        let wiring = RecordingWiring {
+            inner: MockWiring {
+                gpio: Some(MockMonitor::Gpio(&gpio)),
+                mctp_ready: Some(MockMonitor::Gpio(&mctp_ready)),
+                heartbeat: Some(MockMonitor::Gpio(&heartbeat)),
+            },
+            lookups: RefCell::new(Vec::new()),
+        };
+        let clock = FakeClock(Cell::new(0));
+
+        let err = walk_the_table(&wiring, &clock)
+            .expect_err("the missing heartbeat must fail the walk");
+        assert!(matches!(
+            err,
+            BootFailure::WindowExpired {
+                device: "nic",
+                checkpoint: "heartbeat",
+            }
+        ));
     }
 }

--- a/services/fwmanager/src/lib.rs
+++ b/services/fwmanager/src/lib.rs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Boot Orchestrator core: orchestration logic over the capability seams in
-//! `fwmanager-api`.
-//!
-//! This crate is sans-IO: time is injected as monotonic milliseconds and
-//! boot evidence arrives through the [`fwmanager_api::BootMonitor`] seam, so
-//! every decision it makes is host-testable. The kernel-side pump (real
-//! clock, sleeping between polls) lives with the runtime, not here.
+//! `fwmanager-api`. Sans-IO — time is injected as monotonic milliseconds and
+//! evidence arrives through [`fwmanager_api::BootMonitor`] — so every
+//! decision is host-testable; the kernel-side pump lives with the runtime.
 
 #![cfg_attr(not(test), no_std)]
 

--- a/services/fwmanager/src/lib.rs
+++ b/services/fwmanager/src/lib.rs
@@ -13,4 +13,4 @@
 
 mod boot_progress;
 
-pub use boot_progress::{BootFailure, BootWalk, Progress};
+pub use boot_progress::{BootFailure, BootWalk, MonitorMap, Progress};

--- a/services/fwmanager/src/lib.rs
+++ b/services/fwmanager/src/lib.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Boot Orchestrator core: orchestration logic over the capability seams in
+//! `fwmanager-api`.
+//!
+//! This crate is sans-IO: time is injected as monotonic milliseconds and
+//! boot evidence arrives through the [`fwmanager_api::BootMonitor`] seam, so
+//! every decision it makes is host-testable. The kernel-side pump (real
+//! clock, sleeping between polls) lives with the runtime, not here.
+
+#![cfg_attr(not(test), no_std)]
+
+mod boot_progress;
+
+pub use boot_progress::{BootFailure, BootWalk, Progress};

--- a/target/mock/devices.rs
+++ b/target/mock/devices.rs
@@ -11,6 +11,7 @@ use core::time::Duration;
 
 use fwmanager_api::config::{
     BootCheckpoint, BootSignal, CommitPolicy, DeviceConfig, RecoveryPolicy, SlotDesc, SlotId,
+    SlotRole,
 };
 
 /// Declaration order is the boot order: the orchestrator releases devices
@@ -72,6 +73,40 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
         // only escalate.
         slots: &[],
         recovery_policy: RecoveryPolicy::EscalateOnly,
+    },
+    // Passive downstream SPI device (symbiont archetype): the eRoT fronts
+    // the device's flash and releases it blind — it produces no boot
+    // evidence, so there are no checkpoints and nothing gates commit
+    // beyond readback verification. Its flash still carries a full
+    // layout; with no boot signal, the ladder is walked on verification
+    // failures only.
+    DeviceConfig {
+        name: "cpld",
+        reset_signal: 9,
+        checkpoints: &[],
+        commit_policy: CommitPolicy::None,
+        slots: &[
+            SlotDesc {
+                id: SlotId(0),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+            SlotDesc {
+                id: SlotId(1),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+            // Golden: recovery role and never written after provisioning.
+            SlotDesc {
+                id: SlotId(2),
+                writable: false,
+                bootable: true,
+                role: Some(SlotRole::Recovery),
+            },
+        ],
+        recovery_policy: RecoveryPolicy::Ladder,
     },
 ];
 

--- a/target/mock/devices.rs
+++ b/target/mock/devices.rs
@@ -9,7 +9,9 @@
 
 use core::time::Duration;
 
-use fwmanager_api::config::{BootCheckpoint, BootSignal, CommitPolicy, DeviceConfig};
+use fwmanager_api::config::{
+    BootCheckpoint, BootSignal, CommitPolicy, DeviceConfig, RecoveryPolicy, SlotDesc, SlotId,
+};
 
 /// Declaration order is the boot order: the orchestrator releases devices
 /// top to bottom, one at a time.
@@ -28,6 +30,24 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
             window: Duration::from_secs(90),
         }],
         commit_policy: CommitPolicy::Liveness,
+        // Plain A/B: two equal writable slots, recovery falls back to the
+        // other one. Real boards declare their own topology; a golden
+        // slot is optional.
+        slots: &[
+            SlotDesc {
+                id: SlotId(0),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+            SlotDesc {
+                id: SlotId(1),
+                writable: true,
+                bootable: true,
+                role: None,
+            },
+        ],
+        recovery_policy: RecoveryPolicy::Ladder,
     },
     // PLDM device (NIC archetype): self-updating, SPDM-capable. Two
     // checkpoints, exercising the multi-checkpoint path.
@@ -47,6 +67,11 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
             },
         ],
         commit_policy: CommitPolicy::LivenessAndAttestation,
+        // Self-updating device: it owns its boot selection, the eRoT never
+        // sees its slot topology. No local ladder rungs, so recovery can
+        // only escalate.
+        slots: &[],
+        recovery_policy: RecoveryPolicy::EscalateOnly,
     },
 ];
 


### PR DESCRIPTION
**Stacked on #394** — the first three commits are that PR; review starts at `fwmanager: Add the orchestrator root crate with the boot-walk core`.

`BootWalk` is the first consumer of the fwmanager capability seams: after a device is released from reset, it walks the device's configured `BootCheckpoint`s and judges the boot good or failed. Windows are sequential (each opens when the previous checkpoint is observed), `Booted` at the deadline still advances, and a passive device (`CommitPolicy::None`) is complete from construction. The walk is sans-IO — time is injected as monotonic milliseconds — so every verdict is host-tested; the kernel-side pump comes with the orchestrator runtime.

Signal-to-monitor dispatch stays out of the api crate: a `MonitorMap` owned by the board wiring resolves each checkpoint's signal, so `BootMonitor` is untouched and one transport can back several signal kinds through per-signal views. `poll()` tolerates two consecutive monitor read errors (transports can glitch during bring-up); the third fails the walk as `MonitorRead` with the concrete error on the `source()` chain. An unwired signal fails as `UnmappedSignal` instead of hanging.

The end-to-end test runs the composition loop over the mock device table: declaration order is boot order, one device at a time, the passive cpld consumes no polls, and a missing heartbeat stops the walk naming `nic`/`heartbeat`. The `comes_up_within` placeholder in the api tests is retired in favor of the walker's tests.

Part of 9elements/openprot#3 (recovery initiation trigger) and 9elements/openprot#15 (boot-failure judgment for partition fallback).