### PR TITLE
ast10x0: Add the eRoT production image skeleton

### DIFF
--- a/target/ast10x0/erot/BUILD.bazel
+++ b/target/ast10x0/erot/BUILD.bazel
@@ -1,0 +1,61 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
+load("@pigweed//pw_kernel/tooling:target_codegen.bzl", "target_codegen")
+load("@pigweed//pw_kernel/tooling:target_linker_script.bzl", "target_linker_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//target/ast10x0:defs.bzl", "TARGET_COMPATIBLE_WITH")
+
+filegroup(
+    name = "system_config",
+    srcs = ["system.json5"],
+)
+
+target_codegen(
+    name = "codegen",
+    arch = "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+    system_config = ":system_config",
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+)
+
+target_linker_script(
+    name = "linker_script",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    template = "//target/ast10x0:linker_script_template",
+)
+
+rust_binary(
+    name = "target",
+    srcs = ["target.rs"],
+    edition = "2024",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    deps = [
+        ":codegen",
+        ":linker_script",
+        "//target/ast10x0:entry",
+        "@pigweed//pw_kernel/arch/arm_cortex_m:arch_arm_cortex_m",
+        "@pigweed//pw_kernel/kernel",
+        "@pigweed//pw_kernel/subsys/console:console_backend",
+        "@pigweed//pw_kernel/target:target_common",
+        "@pigweed//pw_log/rust:pw_log",
+    ],
+)
+
+# The flashable eRoT: `bazel build //target/ast10x0/erot:erot` (with the
+# hardware platform config) emits both the ELF and the raw .bin that goes
+# to the AST1060's SPI NOR at offset 0 — the flash layout is exactly what
+# system.json5 declares.
+system_image(
+    name = "erot",
+    kernel = ":target",
+    platform = "//target/ast10x0",
+    system_config = ":system_config",
+    tags = ["kernel"],
+    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    userspace = False,
+    visibility = ["//visibility:public"],
+)

--- a/target/ast10x0/erot/system.json5
+++ b/target/ast10x0/erot/system.json5
@@ -1,0 +1,33 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+// OpenPRoT eRoT production image for the AST1060 — skeleton.
+//
+// This is THE composition file: what appears under `apps` below is what
+// exists on the flashed eRoT, fixed at build time. Kernel-only today;
+// each service joins as its app lands. The intended final composition:
+//
+//   apps: [
+//     // i2c_server: owns the I²C MMIO block + IRQs, serves bus access
+//     // over IPC (the pattern proven in tests/mctp/server).
+//     // mctp_server: MCTP over the i2c channel_initiator.
+//     // orchestrator: its thread owns the
+//     //   Orchestrator state machine and the boot walks, blocking in
+//     //   object_wait on {timer at next walk deadline, IPC channels}.
+//     //   Needs: channel_initiators to mctp (and flash, once that
+//     //   service exists), a memory_mapping for the reset/ready GPIO
+//     //   block, and the board device table for its chain.
+//   ]
+{
+    arch: {
+        type: "armv7m",
+        vector_table_start_address: 0x00000000,
+        vector_table_size_bytes: 1280,
+    },
+    kernel: {
+        flash_start_address: 0x00000500,
+        flash_size_bytes: 262144,
+        ram_start_address: 0x00040500,
+        ram_size_bytes: 391936, // ends at RAM_NC boundary (0x000A0000)
+    },
+}

--- a/target/ast10x0/erot/target.rs
+++ b/target/ast10x0/erot/target.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! OpenPRoT eRoT production image for the AST1060 — skeleton.
+//!
+//! Kernel boots, announces itself, and parks. The composition plan —
+//! which services this image grows and in what order — is documented in
+//! `system.json5`, the file that will hold them. Board bring-up (pinctrl
+//! for the I²C buses and the reset/ready GPIO lines) joins here as the
+//! services that own that hardware land.
+
+#![no_std]
+#![no_main]
+
+use console_backend::console_backend_write_all;
+use target_common::{declare_target, TargetInterface};
+use {console_backend as _, entry as _};
+
+pub struct Target {}
+
+impl TargetInterface for Target {
+    const NAME: &'static str = "OpenPRoT eRoT (AST1060)";
+
+    fn main() -> ! {
+        pw_log::info!("=== OpenPRoT eRoT (AST1060) ===");
+        let _ = console_backend_write_all(b"openprot erot: kernel up; no services composed yet\n");
+
+        #[expect(clippy::empty_loop)]
+        loop {}
+    }
+}
+
+declare_target!(Target);


### PR DESCRIPTION
TL;DR This is just a skeleton, so that we can already create a .bin file to boot on the AST1060. It just writes out that it started and goes into a loop.

target/ast10x0/erot is where the real eRoT system gets composed: its system.json5 will list the apps (i2c server, mctp server, fwmanager with the orchestrator), and the planned layout is in there as comments. For now the image is kernel-only and just prints that it is up.

Build the flashable image with:

    bazel build --config=k_ast1060_evb //target/ast10x0/erot:erot

This produces bazel-bin/target/ast10x0/erot/erot.bin for the AST1060 SPI NOR, laid out as declared in system.json5. The QEMU flavor builds with --config=virt_ast10x0 (booted manually with bazel run; there is deliberately no QEMU test target yet — a kernel-only image has no composition to break, the test joins with the first app block).