### PR TITLE
docs: drop removed multilingual field from book.toml

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,7 +4,6 @@
 [book]
 authors = ["OpenProt Team"]
 language = "en"
-multilingual = false
 src = "src"
 title = "OpenProt Documentation"
 


### PR DESCRIPTION
mdbook 0.5 rejects the field; serve refused to start.

Assisted-by: Claude:claude-fable-5