### PR TITLE
Use device config as orchestrator chain source

### DIFF
--- a/services/orchestrator/config/src/lib.rs
+++ b/services/orchestrator/config/src/lib.rs
@@ -7,6 +7,24 @@
 
 #![cfg_attr(not(test), no_std)]
 
+/// Stable identifier shared by the board device table and orchestrator core.
+///
+/// The value is opaque to the state machine. Keeping the type in this
+/// dependency-free config crate lets every layer refer to the same device without
+/// maintaining a second positional-id convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComponentId(u8);
+
+impl ComponentId {
+    pub const fn new(id: u8) -> Self {
+        Self(id)
+    }
+
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
 /// What the orchestrator requires before it commits a staged image.
 ///
 /// Intentionally exhaustive (not `#[non_exhaustive]`): adding a variant is
@@ -67,6 +85,8 @@ pub struct BootCheckpoint<G> {
 /// Adding a field is a breaking change that updates every board table.
 #[derive(Debug, Clone, Copy)]
 pub struct DeviceConfig<R, G: 'static> {
+    /// Stable id used by the orchestrator, update manager, and board drivers.
+    pub id: ComponentId,
     pub name: &'static str,
     /// Reset signal id, passed to HalBootControl::new.
     pub reset_signal: R,
@@ -80,9 +100,18 @@ pub struct DeviceConfig<R, G: 'static> {
 /// Checks a device table. Board configs call this in a const context so a
 /// bad table fails the build.
 pub const fn validate<R, G>(devices: &[DeviceConfig<R, G>]) {
+    assert!(!devices.is_empty(), "device table must not be empty");
     let mut i = 0;
     while i < devices.len() {
         assert!(!devices[i].name.is_empty(), "device name must not be empty");
+        let mut j = i + 1;
+        while j < devices.len() {
+            assert!(
+                devices[i].id.get() != devices[j].id.get(),
+                "component id must be unique"
+            );
+            j += 1;
+        }
         assert!(
             !devices[i].checkpoints.is_empty(),
             "device must declare at least one boot checkpoint"
@@ -120,6 +149,7 @@ mod tests {
     };
 
     const DEVICE: DeviceConfig<u8, u8> = DeviceConfig {
+        id: ComponentId::new(0),
         name: "dev",
         reset_signal: 0,
         checkpoints: &[CHECKPOINT],
@@ -132,9 +162,34 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "device table must not be empty")]
+    fn rejects_an_empty_table() {
+        validate::<u8, u8>(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "component id must be unique")]
+    fn rejects_a_duplicate_component_id() {
+        validate(&[
+            DEVICE,
+            DeviceConfig {
+                name: "other",
+                ..DEVICE
+            },
+        ]);
+    }
+
+    #[test]
     #[should_panic(expected = "device name must not be empty")]
     fn rejects_an_empty_device_name() {
-        validate(&[DEVICE, DeviceConfig { name: "", ..DEVICE }]);
+        validate(&[
+            DEVICE,
+            DeviceConfig {
+                id: ComponentId::new(1),
+                name: "",
+                ..DEVICE
+            },
+        ]);
     }
 
     #[test]

--- a/services/orchestrator/sm/BUILD.bazel
+++ b/services/orchestrator/sm/BUILD.bazel
@@ -14,6 +14,7 @@ rust_library(
     edition = "2024",
     visibility = ["//visibility:public"],
     deps = [
+        "//services/orchestrator/config:orchestrator_config",
         "@rust_crates//:heapless",
     ],
 )

--- a/services/orchestrator/sm/src/model.rs
+++ b/services/orchestrator/sm/src/model.rs
@@ -5,20 +5,8 @@
 //! events, effects, states, and the validated [`Chain`] of trust. These types
 //! carry no reducer behavior; the state machine itself lives in the crate root.
 
-/// An opaque identifier for one platform component. The core never inspects it;
-/// the board layer decides which real hardware each id refers to.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct ComponentId(u8);
-
-impl ComponentId {
-    pub const fn new(id: u8) -> Self {
-        Self(id)
-    }
-
-    pub const fn get(self) -> u8 {
-        self.0
-    }
-}
+pub use orchestrator_config::ComponentId;
+use orchestrator_config::DeviceConfig;
 
 /// How a component in the trust chain is classified. The board supplies one
 /// [`ComponentKind`] per [`ComponentId`] when building the chain.
@@ -379,10 +367,12 @@ pub enum State {
 /// A validated **chain of trust**: the ordered list of components the eRoT
 /// walks, verifies, and supervises, in walk order.
 ///
-/// Build one with [`TryFrom`]/[`TryInto`] from a `heapless::Vec` of
-/// `(ComponentId, ComponentAttrs)` pairs. The conversion is the single place
-/// the reducer's structural invariants are enforced, so a malformed chain
-/// fails closed at the boundary instead of misbehaving later:
+/// Board integrations should use [`Chain::from_device_configs`] so device
+/// count, order, and ids come directly from their `DeviceConfig` array. Tests
+/// and lower-level callers can also use [`TryFrom`]/[`TryInto`] with a
+/// `heapless::Vec` of `(ComponentId, ComponentAttrs)` pairs. Both paths enforce
+/// the reducer's structural invariants at the boundary, so a malformed chain
+/// fails closed instead of misbehaving later:
 ///
 /// - the chain is non-empty,
 /// - every [`ComponentId`] is unique,
@@ -425,6 +415,24 @@ pub enum ChainError {
 }
 
 impl<const N: usize> Chain<N> {
+    /// Build the chain directly from the board's device table.
+    ///
+    /// Device count, order, and ids come from the same table used by the board
+    /// drivers. `attrs_for` supplies policy by stable id without introducing a
+    /// second ordered list that could drift from the hardware configuration.
+    pub fn from_device_configs<R, G>(
+        devices: &[DeviceConfig<R, G>; N],
+        mut attrs_for: impl FnMut(ComponentId) -> ComponentAttrs,
+    ) -> Result<Self, ChainError> {
+        let mut entries = heapless::Vec::new();
+        for device in devices {
+            entries
+                .push((device.id, attrs_for(device.id)))
+                .expect("device array length matches chain capacity");
+        }
+        entries.try_into()
+    }
+
     /// Consume the validated chain, yielding its components in walk order.
     pub(crate) fn into_entries(self) -> heapless::Vec<(ComponentId, ComponentAttrs), N> {
         self.entries

--- a/services/orchestrator/sm/src/tests.rs
+++ b/services/orchestrator/sm/src/tests.rs
@@ -1549,6 +1549,43 @@ fn chain_rejects_empty() {
     assert_eq!(Chain::try_from(empty).unwrap_err(), ChainError::Empty);
 }
 
+/// Device order and ids are inherited from the board table instead of being
+/// repeated in an independently maintained orchestrator list.
+#[test]
+fn chain_builds_from_device_config_source_of_truth() {
+    use core::time::Duration;
+    use orchestrator_config::{BootCheckpoint, BootSignal, CommitPolicy, DeviceConfig};
+
+    const CHECKPOINT: BootCheckpoint<u8> = BootCheckpoint {
+        name: "ready",
+        signal: BootSignal::GpioBootComplete(1),
+        window: Duration::from_secs(1),
+    };
+    const DEVICES: [DeviceConfig<u8, u8>; 2] = [
+        DeviceConfig {
+            id: C1,
+            name: "first",
+            reset_signal: 2,
+            checkpoints: &[CHECKPOINT],
+            commit_policy: CommitPolicy::Liveness,
+        },
+        DeviceConfig {
+            id: C0,
+            name: "second",
+            reset_signal: 3,
+            checkpoints: &[CHECKPOINT],
+            commit_policy: CommitPolicy::Liveness,
+        },
+    ];
+
+    let chain = Chain::from_device_configs(&DEVICES, |_| ComponentAttrs::passive_required())
+        .expect("valid device table");
+    let entries = chain.into_entries();
+
+    assert_eq!(entries.as_slice()[0].0, C1);
+    assert_eq!(entries.as_slice()[1].0, C0);
+}
+
 /// A repeated `ComponentId` is rejected: the reducer's linear id lookups would
 /// otherwise be ambiguous.
 #[test]

--- a/target/mock/devices.rs
+++ b/target/mock/devices.rs
@@ -9,17 +9,18 @@
 
 use core::time::Duration;
 
-use orchestrator_config::{BootCheckpoint, BootSignal, CommitPolicy, DeviceConfig};
+use orchestrator_config::{BootCheckpoint, BootSignal, CommitPolicy, ComponentId, DeviceConfig};
 
 /// Declaration order is the boot order: the orchestrator releases devices
 /// top to bottom, one at a time.
 ///
 /// The mock board's reset controller and boot monitor both address
 /// signals by plain index, so both id types are `u8`.
-pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
+pub const MANAGED_DEVICES: [DeviceConfig<u8, u8>; 2] = [
     // Direct-flash SPI device (BMC archetype): the eRoT fronts its flash.
     // Single checkpoint: it raises a boot-complete GPIO.
     DeviceConfig {
+        id: ComponentId::new(0),
         name: "bmc",
         reset_signal: 7,
         checkpoints: &[BootCheckpoint {
@@ -32,6 +33,7 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
     // PLDM device (NIC archetype): self-updating, SPDM-capable. Two
     // checkpoints, exercising the multi-checkpoint path.
     DeviceConfig {
+        id: ComponentId::new(1),
         name: "nic",
         reset_signal: 3,
         checkpoints: &[
@@ -50,4 +52,4 @@ pub const MANAGED_DEVICES: &[DeviceConfig<u8, u8>] = &[
     },
 ];
 
-const _: () = orchestrator_config::validate(MANAGED_DEVICES);
+const _: () = orchestrator_config::validate(&MANAGED_DEVICES);


### PR DESCRIPTION
Closes #375

## Summary
- move ComponentId into the dependency-free orchestrator API so board configuration and the state machine share one id type
- store the stable component id in DeviceConfig and reject empty tables or duplicate ids during const validation
- add Chain::from_device_configs, deriving chain size, order, and ids from the board array while looking up policy by id
- convert the mock board table to a fixed-size array with explicit ids

This removes the independently maintained positional-id/order convention. A board integration can no longer reorder its orchestrator chain separately from its device table when it uses the new constructor; the array length also fixes the Chain capacity at compile time.

## Validation
- bazel test //services/orchestrator/api:orchestrator_api_test
- bazel test //services/orchestrator/sm:orchestrator_sm_test
- bazel build //target/mock:devices
- rustfmt --check on all changed Rust files
- git diff --check