### PR TITLE
target/veer: add Caliptra-SS register crate and third-party BUILD wiring

### DIFF
--- a/target/veer/registers/BUILD.bazel
+++ b/target/veer/registers/BUILD.bazel
@@ -1,0 +1,17 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Umbrella crate re-exporting all Caliptra-SS peripheral register modules.
+rust_library(
+    name = "registers",
+    srcs = ["registers.rs"],
+    crate_name = "caliptra_ss_registers",
+    edition = "2024",
+    deps = [
+        "//third_party/caliptra/caliptra-mcu-sw:firmware_registers_generated",
+    ],
+)

--- a/target/veer/registers/README.md
+++ b/target/veer/registers/README.md
@@ -1,0 +1,28 @@
+# target/veer/registers
+
+Umbrella crate (`caliptra_ss_registers`) that re-exports the generated
+register definitions for every Caliptra Subsystem peripheral.
+
+## Source
+
+Registers are generated from the Caliptra-SS SystemRDL sources by
+`caliptra_mcu_registers_generator` and live in the pinned
+`caliptra-mcu-sw` third-party dependency at
+`registers/generated-firmware/src/`. Each peripheral module exposes a
+`bits` sub-module of `tock_registers::register_bitfields!` types plus a
+base address constant (e.g. `I3C_CSR_ADDR = 0x2000_4000`).
+
+## Usage
+
+Add `//target/veer/registers` to your `deps` and import the peripheral
+module you need:
+
+```rust
+use caliptra_ss_registers::i3c;
+// Bitfield types for register reads/writes
+use i3c::bits::Control;
+
+// Base address for MMIO pointer construction
+const BASE: u32 = i3c::I3C_CSR_ADDR;
+
+```

--- a/target/veer/registers/registers.rs
+++ b/target/veer/registers/registers.rs
@@ -1,0 +1,24 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+//! Caliptra Subsystem register definitions.
+//!
+//! Re-exports the generated firmware register modules from caliptra-mcu-sw so
+//! peripheral drivers in `target/veer/peripherals/` have a single import path.
+
+#![no_std]
+
+pub use caliptra_mcu_registers_generated::axicdma;
+pub use caliptra_mcu_registers_generated::defines;
+pub use caliptra_mcu_registers_generated::doe_mbox;
+pub use caliptra_mcu_registers_generated::el2_pic_ctrl;
+pub use caliptra_mcu_registers_generated::fuses;
+pub use caliptra_mcu_registers_generated::i3c;
+pub use caliptra_mcu_registers_generated::lc_ctrl;
+pub use caliptra_mcu_registers_generated::mbox;
+pub use caliptra_mcu_registers_generated::mci;
+pub use caliptra_mcu_registers_generated::otp_ctrl;
+pub use caliptra_mcu_registers_generated::primary_flash_ctrl;
+pub use caliptra_mcu_registers_generated::secondary_flash_ctrl;
+pub use caliptra_mcu_registers_generated::sha512_acc;
+pub use caliptra_mcu_registers_generated::soc;

--- a/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
+++ b/third_party/caliptra/caliptra-mcu-sw/BUILD.bazel
@@ -23,6 +23,19 @@ rust_library(
     ],
 )
 
+# no_std register definitions for Caliptra-SS peripherals (I3C, DMA, fuses, …).
+rust_library(
+    name = "firmware_registers_generated",
+    srcs = ["@caliptra_mcu_sw//:all_files"],
+    crate_name = "caliptra_mcu_registers_generated",
+    crate_root = "@caliptra_mcu_sw//:registers/generated-firmware/src/lib.rs",
+    edition = "2021",
+    deps = [
+        "//third_party/caliptra:crate_tock-registers",
+        "//third_party/caliptra:crate_zeroize",
+    ],
+)
+
 rust_library(
     name = "emulator_bmc",
     srcs = ["@caliptra_mcu_sw//:emulator_bmc_srcs"],

--- a/third_party/caliptra/caliptra-mcu-sw/overlay.BUILD
+++ b/third_party/caliptra/caliptra-mcu-sw/overlay.BUILD
@@ -17,6 +17,7 @@ exports_files(
         "rom/src/lib.rs",
         "common/testing/src/lib.rs",
         "registers/generated-emulator/src/lib.rs",
+        "registers/generated-firmware/src/lib.rs",
         "emulator/consts/src/lib.rs",
         "caliptra-util-host/apps/mailbox/server/src/lib.rs",
         "builder/src/lib.rs",


### PR DESCRIPTION
Exposes Caliptra-SS peripheral register definitions to the openprot VeeR target. Adds `firmware_registers_generated` Bazel wiring and an umbrella `caliptra_ss_registers` crate under `target/veer/registers/`.