### PR TITLE
[earlgrey] Increase speed of firmware loading

### DIFF
--- a/target/earlgrey/env/environments.bzl
+++ b/target/earlgrey/env/environments.bzl
@@ -231,7 +231,7 @@ def _fpga_environment_impl(ctx):
     if rom_ext:
         boot_cmd = "bootstrap {boot_image}"
     else:
-        boot_cmd = "rescue firmware {firmware}"
+        boot_cmd = "rescue firmware --rate 1500000 {firmware}"
 
     return [
         TestEnvironmentInfo(


### PR DESCRIPTION
By temporarily increasing UART speed to 1.5Mbps, the time to load firmware under test via "rescue" is reduced from 14 seconds to less than 4 seconds.