### PR TITLE
[ci] Remove bazel-contrib/setup-bazel from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
-
     - name: Presubmit Checks
       # The presubmit workflow performs formatting checks, license checks
       # C/C++ include checks and clippy lints.
@@ -39,13 +32,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
-
     - name: Run tests
       # See workflows.json for the `ci` definition.
       run: ./pw ci
@@ -57,13 +43,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-
-    - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        repository-cache: false
 
     - name: Build
       # See workflows.json for the `default` definition.


### PR DESCRIPTION
`bazel-contrib/setup-bazel` forces the `--output_base` in ~/.bazelrc to have consistent file prefixes across execution environments. This is not required in the GitHub self-hosted runner setup as the Bazel cache is setup in self-hosted workspace.