### PR TITLE
docs: Say platform driver, not shell

### DIFF
--- a/services/orchestrator/capabilities/src/boot_watch.rs
+++ b/services/orchestrator/capabilities/src/boot_watch.rs
@@ -40,7 +40,8 @@ pub enum WalkVerdict {
         deadline_millis: u64,
     },
     /// Every checkpoint passed — the device is up. Which state-machine
-    /// event this becomes is the shell's mapping, by component kind:
+    /// event this becomes is the platform driver's mapping, by component
+    /// kind:
     /// `ComponentReady` for an iRoT-backed device, `Booted` for a
     /// symbiont.
     Complete,

--- a/services/orchestrator/sm/README.md
+++ b/services/orchestrator/sm/README.md
@@ -8,14 +8,14 @@ Pure-reducer eRoT boot-sequence state machine. Walks the platform trust chain
 then governs the operational lifecycle (attestation, firmware update, corruption
 recovery).
 
-**No I/O, no hardware.** Every action is an [`Effect`] the surrounding shell
-carries out. Every piece of outside information arrives as an [`Event`].
+**No I/O, no hardware.** Every action is an [`Effect`] the surrounding
+platform driver carries out. Every piece of outside information arrives as an [`Event`].
 
 ## Key types
 
 | Type | Role |
 |---|---|
-| `ComponentId` | Opaque `u8` — the shell maps it to hardware; the core never inspects it. |
+| `ComponentId` | Opaque `u8` — the platform driver maps it to hardware; the core never inspects it. |
 | `ComponentKind` | `Active` (eRoT + iRoT gates) or `Passive` (eRoT gate only). |
 | `ComponentAttrs` | `kind` + `required`: if `false`, a failed component is skipped (held in reset) rather than triggering recovery. |
 | `Orchestrator<N>` | Public handle for the caller's event loop. Call `dispatch` or `dispatch_with` once per event. |

--- a/target/ast10x0/tests/orchestrator/runtime/main.rs
+++ b/target/ast10x0/tests/orchestrator/runtime/main.rs
@@ -7,15 +7,16 @@
 //! watchdog keeper (`orchestrator-timer`), and the board device table
 //! ([`DeviceConfig`], `orchestrator-config`).
 //!
-//! The runtime owns the clock and the mapping, so the shell stays thin:
+//! The runtime owns the clock and the mapping, so the platform driver stays
+//! thin:
 //!   - boot windows come from the device table ([`BootCheckpoint::timeout`]);
-//!     the shell only converts `core::time::Duration` to the kernel's
-//!     [`Duration`] at the arm site.
+//!     the platform driver only converts `core::time::Duration` to the
+//!     kernel's [`Duration`] at the arm site.
 //!   - [`BootWatchdogs::arm_boot`] takes that *relative* window; the runtime
 //!     computes the absolute deadline.
 //!   - [`BootWatchdogs::wait_deadline`] is handed straight to `object_wait`.
 //!   - [`BootWatchdogs::poll_expired`] yields the `Event`s the core consumes —
-//!     no mapping in the shell.
+//!     no mapping in the platform driver.
 //!
 //! Coverage: the *inner checkpoint walk* (`bl1` → `kernel`, re-armed through the
 //! runtime) for a single component, the *outer component walk* across a
@@ -66,7 +67,7 @@ const SOC: DeviceConfig<u8, u8> = DeviceConfig::new(
 );
 
 /// The device table speaks `core::time::Duration`; the runtime speaks the
-/// kernel's [`Duration`]. Converting is the shell's job.
+/// kernel's [`Duration`]. Converting is the platform driver's job.
 fn window(timeout: core::time::Duration) -> Duration {
     Duration::from_millis(timeout.as_millis() as u64)
 }


### PR DESCRIPTION
PR #357 settled on "platform driver" for the effect-carrying layer around the pure state machine. This sweeps the leftover "shell" wording in doc comments and the sm README. Docs only, no code changes.