### PR TITLE
orchestrator: Wire CommitSvnFloor through the platform driver

### DIFF
--- a/services/orchestrator/driver/src/board.rs
+++ b/services/orchestrator/driver/src/board.rs
@@ -7,6 +7,7 @@
 use openprot_orchestrator_sm::{ComponentId, ComponentKind};
 
 pub use orchestrator_capabilities::{BootControl, BootWatch};
+use orchestrator_capabilities::{Svn, SvnFloor};
 
 /// Access to one component's active firmware image, however it is reached —
 /// interposed flash, a PLDM/MCTP transfer, a RAM copy in tests.
@@ -46,8 +47,8 @@ impl<S: ImageSource> ImageSource for &mut S {
     }
 }
 
-/// Judges a component's firmware image; board wiring decides what
-/// "authentic" means.
+/// Judges a component's firmware image; board wiring decides what counts
+/// as authenticated.
 pub trait Verifier {
     /// The error type reported by this verifier.
     type Error: core::error::Error;
@@ -83,8 +84,15 @@ impl<V: Verifier> Verifier for &mut V {
 /// A [`Verifier`]'s judgment of one image.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verdict {
-    /// Reported as `Event::VerificationPassed`.
-    Authenticated,
+    /// Reported as `Event::VerificationPassed`. Carries the image's
+    /// manifest SVN: verification is the only authenticated reading of the
+    /// manifest, so this is the one value the anti-rollback commit
+    /// ([`Effect::CommitSvnFloor`](openprot_orchestrator_sm::Effect)) may
+    /// trust.
+    Authenticated {
+        /// The verified image's security version number.
+        svn: Svn,
+    },
     /// Reported as `Event::VerificationFailed`.
     Rejected,
 }
@@ -154,7 +162,23 @@ pub trait BoardCapabilities {
     type BootControl: BootControl;
     /// Boot-checkpoint supervision for the managed components.
     type BootWatch: BootWatch;
+    /// The anti-rollback floor of the managed components. The SVN number
+    /// survives reset and power loss, otherwise a power cycle would
+    /// re-admit images below the floor.
+    type SvnFloor: SvnFloor;
     // Later seams: Recovery, Staging.
+}
+
+/// Who keeps one component's anti-rollback floor. Spelled as its own type
+/// so a board must state the choice; an eRoT floor and a device tracking
+/// its own SVN are different wirings, not a present or absent value.
+pub enum SvnFloorBinding<F: SvnFloor> {
+    /// The eRoT holds the floor and `CommitSvnFloor` advances it.
+    Erot(F),
+    /// The component tracks its own SVN (iRoT, or a PLDM device
+    /// committing internally). The eRoT keeps no second floor and its
+    /// `CommitSvnFloor` is a no-op.
+    SelfManaged,
 }
 
 /// Everything the board supplies, built once at bring-up and handed to
@@ -168,6 +192,7 @@ pub trait BoardCapabilities {
 ///     type Verifier = ManifestVerifier;   // signature + SVN via the crypto engine
 ///     type BootControl = ExtrstGpio;      // per-component reset line
 ///     type BootWatch = CheckpointWalk;    // GPIO checkpoint walk over the boot window
+///     type SvnFloor = OtpSvnFloor;        // fuse-backed anti-rollback floor
 /// }
 /// let board = Board::<Ast1060Board, 2> {
 ///     images: [bmc_image, cpld_image],
@@ -175,6 +200,7 @@ pub trait BoardCapabilities {
 ///     boot_controls: [bmc_reset, cpld_reset],
 ///     boot_watches: [bmc_walk, cpld_walk],
 ///     component_kinds: [ComponentKind::Active, ComponentKind::Passive],
+///     svn_floors: [SvnFloorBinding::Erot(bmc_floor), SvnFloorBinding::SelfManaged],
 /// };
 /// ```
 pub struct Board<B: BoardCapabilities, const N: usize> {
@@ -193,5 +219,8 @@ pub struct Board<B: BoardCapabilities, const N: usize> {
     /// `ComponentReady` for `Active`, `Booted` for `Passive`. Comes from
     /// the same board table as the SM's chain, so both sides agree.
     pub component_kinds: [ComponentKind; N],
+    /// `svn_floors[i]` says who keeps `ComponentId(i)`'s anti-rollback
+    /// floor, same indexing as `images`.
+    pub svn_floors: [SvnFloorBinding<B::SvnFloor>; N],
     // Later seams add fields, e.g. recovery: [B::Recovery; N].
 }

--- a/services/orchestrator/driver/src/driver.rs
+++ b/services/orchestrator/driver/src/driver.rs
@@ -6,8 +6,8 @@
 
 use openprot_orchestrator_sm::{ComponentId, ComponentKind, Effect, EffectError, Event, Platform};
 
-use crate::board::{Board, BoardCapabilities, ImageSource, Verdict, Verifier};
-use orchestrator_capabilities::{BootControl, BootWatch, WalkVerdict};
+use crate::board::{Board, BoardCapabilities, ImageSource, SvnFloorBinding, Verdict, Verifier};
+use orchestrator_capabilities::{BootControl, BootWatch, Svn, SvnFloor, WalkVerdict};
 
 /// Why the driver could not carry out an effect.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -23,6 +23,11 @@ pub enum DriverError {
     VerifierFault,
     /// The component's boot control could not actuate the reset line.
     BootControlFault,
+    /// A floor commit was asked for a component with no verified image —
+    /// the SVN to advance to is unknown; fail closed.
+    NoVerifiedImage,
+    /// The component's SVN floor could not be advanced.
+    SvnFloorFault,
 }
 
 impl core::fmt::Display for DriverError {
@@ -33,6 +38,8 @@ impl core::fmt::Display for DriverError {
             DriverError::NotStaged => "no image staged for this component",
             DriverError::VerifierFault => "verifier could not perform the check",
             DriverError::BootControlFault => "boot control could not actuate the reset",
+            DriverError::NoVerifiedImage => "no verified image to commit the floor to",
+            DriverError::SvnFloorFault => "svn floor could not be advanced",
         })
     }
 }
@@ -50,6 +57,10 @@ pub struct PlatformDriver<B: BoardCapabilities, const N: usize> {
     /// terminal verdict. Only watched walks are polled, so a finished or
     /// quiesced walk emits no stale event.
     watching: [bool; N],
+    /// `verified_svn[i]` is the manifest SVN of `ComponentId(i)`'s last
+    /// authenticated image — the only value a floor commit may trust.
+    /// `None` until a verification passes; cleared again on rejection.
+    verified_svn: [Option<Svn>; N],
 }
 
 impl<B: BoardCapabilities, const N: usize> PlatformDriver<B, N> {
@@ -60,7 +71,17 @@ impl<B: BoardCapabilities, const N: usize> PlatformDriver<B, N> {
             board,
             staged: None,
             watching: [false; N],
+            verified_svn: [None; N],
         }
+    }
+
+    /// The board wiring, read-only, for the tests: they observe a
+    /// capability after it moved into the driver, instead of every mock
+    /// smuggling out a shared handle. Real consumers get targeted queries
+    /// when they exist — not this.
+    #[cfg(test)]
+    pub(crate) fn board(&self) -> &Board<B, N> {
+        &self.board
     }
 
     /// `id`'s image source. Takes the array rather than `&mut self` so the
@@ -95,10 +116,35 @@ impl<B: BoardCapabilities, const N: usize> PlatformDriver<B, N> {
             .verifier
             .verify(id, source)
             .map_err(|_| DriverError::VerifierFault)?;
+        let idx = id.get() as usize;
         Ok(match verdict {
-            Verdict::Authenticated => Event::VerificationPassed(id),
-            Verdict::Rejected => Event::VerificationFailed(id),
+            Verdict::Authenticated { svn } => {
+                self.verified_svn[idx] = Some(svn);
+                Event::VerificationPassed(id)
+            }
+            Verdict::Rejected => {
+                self.verified_svn[idx] = None;
+                Event::VerificationFailed(id)
+            }
         })
+    }
+
+    /// Advance `id`'s anti-rollback floor to its verified image's SVN.
+    /// A self-managed component keeps its own floor; the commit is a
+    /// no-op. A target at or below the current floor is the capability's
+    /// documented no-op, so a replayed commit is harmless.
+    pub fn commit_svn_floor(&mut self, id: ComponentId) -> Result<(), DriverError> {
+        let idx = id.get() as usize;
+        let SvnFloorBinding::Erot(floor) = self
+            .board
+            .svn_floors
+            .get_mut(idx)
+            .ok_or(DriverError::UnknownComponent)?
+        else {
+            return Ok(());
+        };
+        let svn = self.verified_svn[idx].ok_or(DriverError::NoVerifiedImage)?;
+        floor.advance(svn).map_err(|_| DriverError::SvnFloorFault)
     }
 
     /// `id`'s reset actuator.
@@ -212,21 +258,20 @@ impl<B: BoardCapabilities, const N: usize> Platform for PlatformDriver<B, N> {
             Effect::VerifyFirmware(id) => self.verify_firmware(id).map(Some),
             Effect::ReleaseReset(id) => self.release_reset(id).map(|_| None),
             Effect::AssertReset(id) => self.assert_reset(id).map(|_| None),
+            Effect::CommitSvnFloor(id) => self.commit_svn_floor(id).map(|_| None),
             // No board capability is composed for these seams yet, so they
             // fail closed here instead of behind stub methods. Each group
             // gains an executor when its capability joins
             // [`BoardCapabilities`], as BootControl did above: recovery
             // sourcing for RecoverComponent; update staging, authentication
-            // and trial activation for the update quartet; anti-rollback
-            // commit for CommitSvnFloor; evidence signing for
-            // SignAttestation; the management reporting path for the Report
-            // effects; the terminal latch for LatchLockdown.
+            // and trial activation for the update quartet; evidence signing
+            // for SignAttestation; the management reporting path for the
+            // Report effects; the terminal latch for LatchLockdown.
             Effect::RecoverComponent { .. }
             | Effect::AuthenticateUpdate
             | Effect::StageUpdate
             | Effect::ActivateUpdate
             | Effect::DiscardStaged
-            | Effect::CommitSvnFloor(_)
             | Effect::SignAttestation
             | Effect::ReportIsolated(_)
             | Effect::ReportRecoveryFailed(_)

--- a/services/orchestrator/driver/src/lib.rs
+++ b/services/orchestrator/driver/src/lib.rs
@@ -16,9 +16,10 @@
 //!
 //! Everything device-specific arrives through the seams in [`board`]:
 //! image access ([`ImageSource`]), image judgment ([`Verifier`]), reset
-//! actuation ([`orchestrator_capabilities::BootControl`]) and boot
-//! supervision ([`orchestrator_capabilities::BootWatch`]), bundled in one
-//! [`Board`] built by the board's composition crate.
+//! actuation ([`orchestrator_capabilities::BootControl`]), boot
+//! supervision ([`orchestrator_capabilities::BootWatch`]) and the
+//! anti-rollback floor ([`orchestrator_capabilities::SvnFloor`]), bundled
+//! in one [`Board`] built by the board's composition crate.
 //!
 //! Boot-walk verdicts are the one asynchronous read: the run loop calls
 //! [`PlatformDriver::poll_boot_walks`] and dispatches the returned events
@@ -34,5 +35,7 @@ mod driver;
 #[cfg(test)]
 mod tests;
 
-pub use board::{Board, BoardCapabilities, ImageSource, Report, ReportSink, Verdict, Verifier};
+pub use board::{
+    Board, BoardCapabilities, ImageSource, Report, ReportSink, SvnFloorBinding, Verdict, Verifier,
+};
 pub use driver::{BootWalkPoll, DriverError, PlatformDriver};

--- a/services/orchestrator/driver/src/tests.rs
+++ b/services/orchestrator/driver/src/tests.rs
@@ -5,9 +5,10 @@ extern crate std;
 
 use crate::*;
 use openprot_orchestrator_sm::{
-    ComponentAttrs, ComponentId, ComponentKind, Event, Orchestrator, PowerOnResult, State,
+    ComponentAttrs, ComponentId, ComponentKind, Effect, Event, Orchestrator, Platform,
+    PowerOnResult, State,
 };
-use orchestrator_capabilities::{BootWatch, FailureCause, WalkVerdict};
+use orchestrator_capabilities::{BootWatch, FailureCause, Svn, SvnFloor, WalkVerdict};
 
 const C0: ComponentId = ComponentId::new(0);
 
@@ -36,9 +37,14 @@ impl core::fmt::Display for MemFault {
 
 impl core::error::Error for MemFault {}
 
-/// RAM-backed image source — the seam satisfied without a HAL.
+/// RAM-backed image source — the seam satisfied without a HAL. A re-flash
+/// can be queued: it lands on the first re-open (a re-stage), the way real
+/// flash changes underneath a source between stagings — never on the
+/// initial staging.
 struct MemImage {
     data: std::vec::Vec<u8>,
+    reflash: Option<std::vec::Vec<u8>>,
+    opened: bool,
     fail_open: bool,
     fail_read: bool,
 }
@@ -47,9 +53,17 @@ impl MemImage {
     fn holding(data: std::vec::Vec<u8>) -> Self {
         Self {
             data,
+            reflash: None,
+            opened: false,
             fail_open: false,
             fail_read: false,
         }
+    }
+
+    /// Queue a re-flash: the first re-open stages `data` instead.
+    fn reflash_on_reopen(mut self, data: std::vec::Vec<u8>) -> Self {
+        self.reflash = Some(data);
+        self
     }
 }
 
@@ -60,6 +74,10 @@ impl ImageSource for MemImage {
         if self.fail_open {
             return Err(MemFault);
         }
+        if let Some(data) = self.reflash.take_if(|_| self.opened) {
+            self.data = data;
+        }
+        self.opened = true;
         Ok(())
     }
 
@@ -91,6 +109,10 @@ impl core::error::Error for VerifierError {}
 /// chunks.
 struct XorVerifier {
     fault: bool,
+    /// The manifest SVN this verifier reports for an authenticated image.
+    /// A real verifier reads it from the signed manifest of the image it
+    /// just checked; the test image format has no manifest, so tests pin it.
+    svn: u32,
 }
 
 impl Verifier for XorVerifier {
@@ -122,7 +144,7 @@ impl Verifier for XorVerifier {
         }
         let ok = len > IMAGE_MAGIC.len() && magic == IMAGE_MAGIC && xor == 0;
         Ok(if ok {
-            Verdict::Authenticated
+            Verdict::Authenticated { svn: Svn(self.svn) }
         } else {
             Verdict::Rejected
         })
@@ -224,6 +246,52 @@ impl BootWatch for MockWalk {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct FloorFaultInjected;
+
+impl core::fmt::Display for FloorFaultInjected {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("floor fault injected")
+    }
+}
+
+impl core::error::Error for FloorFaultInjected {}
+
+/// An SVN floor without storage; tests read it back through the
+/// capability's own `floor()` via `PlatformDriver::board`.
+struct MockFloor {
+    floor: u32,
+    fail: bool,
+}
+
+impl MockFloor {
+    fn new() -> Self {
+        Self {
+            floor: 0,
+            fail: false,
+        }
+    }
+}
+
+impl orchestrator_capabilities::SvnFloor for MockFloor {
+    type Error = FloorFaultInjected;
+
+    fn floor(&self) -> Result<Svn, FloorFaultInjected> {
+        if self.fail {
+            return Err(FloorFaultInjected);
+        }
+        Ok(Svn(self.floor))
+    }
+
+    fn advance(&mut self, to: Svn) -> Result<(), FloorFaultInjected> {
+        if self.fail {
+            return Err(FloorFaultInjected);
+        }
+        self.floor = self.floor.max(to.0);
+        Ok(())
+    }
+}
+
 /// The test board's type choices.
 struct MockBoard;
 
@@ -232,15 +300,20 @@ impl BoardCapabilities for MockBoard {
     type Verifier = XorVerifier;
     type BootControl = MockReset;
     type BootWatch = MockWalk;
+    type SvnFloor = MockFloor;
 }
 
 fn driver(images: [MemImage; 1]) -> PlatformDriver<MockBoard, 1> {
     PlatformDriver::new(Board {
         images,
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [MockReset::new()],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     })
 }
 
@@ -320,10 +393,14 @@ fn verifier_fault_fails_closed() {
     let mut orch = orchestrator();
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: true },
+        verifier: XorVerifier {
+            fault: true,
+            svn: 5,
+        },
         boot_controls: [MockReset::new()],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
 
     orch.dispatch(&mut driver, Event::PowerGood(PowerOnResult::Provisioned));
@@ -340,10 +417,17 @@ fn verify_for_a_different_component_is_refused() {
             MemImage::holding(valid_image()),
             MemImage::holding(valid_image()),
         ],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [MockReset::new(), MockReset::new()],
         boot_watches: [MockWalk::idle(), MockWalk::idle()],
         component_kinds: [ComponentKind::Passive, ComponentKind::Passive],
+        svn_floors: [
+            SvnFloorBinding::Erot(MockFloor::new()),
+            SvnFloorBinding::Erot(MockFloor::new()),
+        ],
     });
 
     driver.stage_firmware(C0).unwrap();
@@ -374,21 +458,23 @@ fn verify_of_unknown_component_is_refused() {
 
 #[test]
 fn reset_release_and_assert_reach_the_boot_control() {
-    let control = MockReset::new();
-    let held = control.held.clone();
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: false },
-        boot_controls: [control],
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
+        boot_controls: [MockReset::new()],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
 
     driver.release_reset(C0).unwrap();
-    assert!(!held.get());
+    assert!(!driver.board().boot_controls[0].held.get());
 
     driver.assert_reset(C0).unwrap();
-    assert!(held.get());
+    assert!(driver.board().boot_controls[0].held.get());
 }
 
 #[test]
@@ -411,10 +497,14 @@ fn reset_line_fault_is_reported() {
     control.fail = true;
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [control],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
 
     assert_eq!(driver.release_reset(C0), Err(DriverError::BootControlFault));
@@ -477,6 +567,7 @@ impl BoardCapabilities for WatchBoard {
     type Verifier = LineWatchingVerifier;
     type BootControl = MockReset;
     type BootWatch = MockWalk;
+    type SvnFloor = MockFloor;
 }
 
 // The at-rest guarantee end to end: the component is still held while its
@@ -489,13 +580,17 @@ fn release_follows_verification() {
     let mut driver = PlatformDriver::<WatchBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
         verifier: LineWatchingVerifier {
-            inner: XorVerifier { fault: false },
+            inner: XorVerifier {
+                fault: false,
+                svn: 5,
+            },
             line: held.clone(),
             held_during_verify: held_during_verify.clone(),
         },
         boot_controls: [control],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
     let mut orch = orchestrator();
 
@@ -518,10 +613,14 @@ fn failed_release_fails_closed() {
     let held = control.held.clone();
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [control],
         boot_watches: [MockWalk::idle()],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
     let mut orch = orchestrator();
 
@@ -546,10 +645,17 @@ fn walk_driver(
             MemImage::holding(valid_image()),
             MemImage::holding(valid_image()),
         ],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [MockReset::new(), MockReset::new()],
         boot_watches: walks,
         component_kinds,
+        svn_floors: [
+            SvnFloorBinding::Erot(MockFloor::new()),
+            SvnFloorBinding::Erot(MockFloor::new()),
+        ],
     })
 }
 
@@ -729,10 +835,14 @@ fn booted_walk_settles_in_ready() {
     let mut orch = orchestrator();
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [MockReset::new()],
         boot_watches: [MockWalk::scripted(std::vec![WalkVerdict::Complete])],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
 
     orch.dispatch(&mut driver, Event::PowerGood(PowerOnResult::Provisioned));
@@ -754,13 +864,17 @@ fn boot_timeout_fails_closed_without_recovery() {
     let mut orch = orchestrator();
     let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
         images: [MemImage::holding(valid_image())],
-        verifier: XorVerifier { fault: false },
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
         boot_controls: [MockReset::new()],
         boot_watches: [MockWalk::scripted(std::vec![WalkVerdict::Failed {
             checkpoint: "heartbeat",
             cause: FailureCause::TimedOut,
         }])],
         component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
     });
 
     orch.dispatch(&mut driver, Event::PowerGood(PowerOnResult::Provisioned));
@@ -822,4 +936,133 @@ fn every_report_reaches_a_sink() {
     assert_eq!(recording.seen, every_report());
 
     tell(&mut (), every_report());
+}
+
+// ---------------------------------------------------------------------------
+// Anti-rollback floor commits.
+// ---------------------------------------------------------------------------
+
+// The floor may only move to the SVN the verifier vouched for, and only
+// after a verification has passed — the two halves of the commit contract.
+#[test]
+fn commit_advances_the_floor_to_the_verified_svn() {
+    let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
+        images: [MemImage::holding(valid_image())],
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
+        boot_controls: [MockReset::new()],
+        boot_watches: [MockWalk::idle()],
+        component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
+    });
+
+    driver
+        .execute(Effect::ReadFirmware(C0))
+        .expect("stage failed");
+    driver
+        .execute(Effect::VerifyFirmware(C0))
+        .expect("verify failed");
+
+    assert_eq!(driver.execute(Effect::CommitSvnFloor(C0)), Ok(None));
+    // Read back through the capability's own seam.
+    let SvnFloorBinding::Erot(floor) = &driver.board().svn_floors[0] else {
+        panic!("C0 is wired with an eRoT floor");
+    };
+    assert_eq!(
+        floor.floor(),
+        Ok(Svn(5)),
+        "floor advanced to the verifier's SVN"
+    );
+}
+
+// A component wired without an eRoT floor tracks its own SVN. The commit
+// succeeds even with no verified image cached: there is no floor to
+// mis-advance.
+#[test]
+fn commit_without_an_erot_floor_is_a_no_op() {
+    let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
+        images: [MemImage::holding(valid_image())],
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
+        boot_controls: [MockReset::new()],
+        boot_watches: [MockWalk::idle()],
+        component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::SelfManaged],
+    });
+
+    assert_eq!(driver.execute(Effect::CommitSvnFloor(C0)), Ok(None));
+}
+
+#[test]
+fn commit_without_a_verified_image_fails_closed() {
+    let mut driver = driver([MemImage::holding(valid_image())]);
+
+    assert_eq!(
+        driver.commit_svn_floor(C0),
+        Err(DriverError::NoVerifiedImage)
+    );
+}
+
+// A rejection must clear the cached SVN, or the floor could commit against
+// an image that is no longer the authenticated one.
+#[test]
+fn rejected_image_clears_the_verified_svn() {
+    let mut corrupt = valid_image();
+    corrupt[7] ^= 0x01;
+    let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
+        images: [MemImage::holding(valid_image()).reflash_on_reopen(corrupt)],
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
+        boot_controls: [MockReset::new()],
+        boot_watches: [MockWalk::idle()],
+        component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(MockFloor::new())],
+    });
+
+    driver.stage_firmware(C0).expect("stage failed");
+    assert_eq!(
+        driver.verify_firmware(C0),
+        Ok(Event::VerificationPassed(C0))
+    );
+
+    // The queued re-flash lands on the re-stage; the rejection must take
+    // the cached SVN with it.
+    driver.stage_firmware(C0).expect("re-stage failed");
+    assert_eq!(
+        driver.verify_firmware(C0),
+        Ok(Event::VerificationFailed(C0))
+    );
+
+    assert_eq!(
+        driver.commit_svn_floor(C0),
+        Err(DriverError::NoVerifiedImage)
+    );
+}
+
+#[test]
+fn floor_fault_is_reported() {
+    let mut mock = MockFloor::new();
+    mock.fail = true;
+    let mut driver = PlatformDriver::<MockBoard, 1>::new(Board {
+        images: [MemImage::holding(valid_image())],
+        verifier: XorVerifier {
+            fault: false,
+            svn: 5,
+        },
+        boot_controls: [MockReset::new()],
+        boot_watches: [MockWalk::idle()],
+        component_kinds: [ComponentKind::Passive],
+        svn_floors: [SvnFloorBinding::Erot(mock)],
+    });
+
+    driver.stage_firmware(C0).expect("stage failed");
+    driver.verify_firmware(C0).expect("verify failed");
+
+    assert_eq!(driver.commit_svn_floor(C0), Err(DriverError::SvnFloorFault));
 }


### PR DESCRIPTION
SvnFloor joins BoardCapabilities, one floor per component slot. The SVN to advance to travels in `Verdict::Authenticated`: verification is the only authenticated read of the manifest, so nothing else may tell the floor where to go. The driver caches it per component, clears it on rejection, and fails closed when asked to commit without it. A `None` slot marks a component that tracks its own SVN (iRoT, or a PLDM device committing internally); the eRoT keeps no second floor for it and its commit is a no-op.

Part of 9elements/openprot#18