### PR TITLE
earlgrey: Update opentitan_devbundle to devbundle-2026-08-21-1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -133,10 +133,8 @@ override_repo(
 bazel_dep(name = "opentitan_devbundle")
 archive_override(
     module_name = "opentitan_devbundle",
-    integrity = "sha256-67i+jjvFg9Pd1CXudHpWZ6Gw5lRJvRg4EQm6rDfmang=",
-    # TODO(cfrantz): We should get this from github.com/lowRISC/opentitan/releases/...
-    # Update after creating the next official build upstream.
-    url = "https://storage.googleapis.com/artifacts.opentitan.org/dev_bundle/devbundle-20260714.tar.xz",
+    integrity = "sha256-7QQkw0JW8R0aYfkjg2IcVT6/mpLYSC0Ab2jEvPEGiq8=",
+    url = "https://github.com/lowRISC/opentitan/releases/download/devbundle-2026-08-21-1/devbundle.tar.xz",
 )
 
 bazel_dep(name = "lowrisc_opentitan")

--- a/target/earlgrey/env/environments.bzl
+++ b/target/earlgrey/env/environments.bzl
@@ -48,6 +48,12 @@ def _fpga_prepare(ctx, env, firmware_bin, tools):
             outputs = [boot_image_file],
             inputs = [env.rom_ext, firmware_bin],
             executable = tools.opentitantool,
+            # Workaround: When HOME is unset, opentitantool invokes getpwuid_r() to locate its
+            # default config directory, which dynamically dlopens host NSS libraries. In static glibc
+            # binaries, this causes a SIGSEGV if the static glibc version differs from the host glibc.
+            # Setting HOME prevents the NSS lookup.
+            # TODO(antchen): remove this workaround once upstream opentitantool handles missing HOME or fixes static NSS lookup.
+            env = {"HOME": "/tmp"},
             arguments = [
                 "image",
                 "assemble",


### PR DESCRIPTION
Updates the `opentitan_devbundle` dependency in `MODULE.bazel` to the upstream release `devbundle-2026-08-21-1` from GitHub, and adds a workaround in `target/earlgrey/env/environments.bzl` to avoid a segmentation fault in `opentitantool` during hermetic Bazel image assembly actions.


### Error Encountered
When building or running tests involving `OtpImageAssemble` without the workaround, `opentitantool` crashes with a segmentation fault in my local env:
```
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //target/earlgrey/firmware/transport/tests/updatemgr:updatemgr_eeprom_owner_transfer_slot_bb_hyper340_test (6 packages loaded, 48225 targets configured).
ERROR: /usr/local/google/home/antchen/workspace/openprot/target/earlgrey/firmware/transport/tests/updatemgr/BUILD.bazel:37:19: Assembling boot image: target/earlgrey/firmware/transport/tests/updatemgr/updatemgr_eeprom_owner_transfer_slot_bb_hyper340_test_boot.img failed: 
(Segmentation fault): opentitantool failed: error executing OtpImageAssemble command (from target //target/earlgrey/firmware/transport/tests/updatemgr:updatemgr_eeprom_owner_transfer_slot_bb_hyper340_test) external/opentitan_devbundle+/opentitantool/opentitantool image assemble '--mirror=false' ... (remaining 3 arguments skipped)
```
### What Happened

1. Hermetic Environment (`HOME` unset): In Bazel sandbox actions (`ctx.actions.run`), commands run in an isolated environment (`exec env -`) where `$HOME` and `$XDG_CONFIG_HOME` are not set.
2. Config Path Resolution in `opentitantool`: During CLI initialization in `opentitantool`, `clap` evaluates default arguments for `--rcfile` by calling `directories::ProjectDirs::from("org", "opentitan", "opentitantool")`.
3. NSS Fallback & dlopen(): Because `$HOME` is missing, the underlying `dirs-sys` crate falls back to glibc's `getpwuid_r(getuid())` to look up the user's home directory.
4. glibc Static/Dynamic Mismatch: `opentitantool` is built as a static-pie binary linked with glibc 2.35 (Ubuntu 22.04 LTS). Under glibc, `getpwuid_r` dynamically calls `dlopen()` on the host system's Name Service Switch (NSS) shared library (e.g. `/lib/x86_64-linux-gnu/libnss_files.so`).
5. SIGSEGV in `__libc_early_init`: When running on a host with a different glibc version (e.g., Debian / gLinux running glibc 2.42), the host NSS library's glibc runtime structures conflict with the static binary's glibc 2.35 runtime during `__libc_early_init` / `__GI___ctype_init`, immediately triggering a segmentation fault. 


### Applied Workaround
Setting `HOME` satisfies `dirs-sys` before it invokes `getpwuid_r()`, bypassing the host NSS `dlopen()` call.

### Upstream Potential Solutions (OpenTitan)
To permanently resolve this upstream in `lowRISC/opentitan`:

1. Rust Code: In `sw/host/opentitantool/src/main.rs`, avoid invoking `ProjectDirs::from()` if neither `HOME` nor `XDG_CONFIG_HOME` is set.
2. Toolchain: Build release binaries with `musl` (`x86_64-unknown-linux-musl`), which does not rely on dynamic NSS plugins.
3. Dynamic Linking: Alternatively, distribute dynamically linked binaries against an older glibc baseline, allowing clean forward-compatibility with newer host glibc runtimes.