### PR TITLE
orchestrator: Add the ReportSink seam for the Report effects

### DIFF
--- a/services/orchestrator/driver/src/board.rs
+++ b/services/orchestrator/driver/src/board.rs
@@ -89,6 +89,59 @@ pub enum Verdict {
     Rejected,
 }
 
+/// One fact about the platform running degraded, carried outward to
+/// management software. `#[non_exhaustive]`: a sink routes what it
+/// recognises and ignores the rest, so a new report is not a trait break.
+///
+/// Payloads stay `Copy` and lifetime-free, like the effects these mirror. A
+/// report names a component only where the effect it mirrors does.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Report {
+    /// Held in reset and out of the trust chain, so the platform runs
+    /// degraded. Reported once per component, as it is gated.
+    Isolated(ComponentId),
+    /// Recovery attempts exhausted and the platform halts. Reported before
+    /// the lockdown latch, while there is still a platform to report from.
+    RecoveryFailed(ComponentId),
+    /// An update request declined because the platform was busy. Nothing
+    /// staged, and the requester may ask again. Platform-wide, not
+    /// per-component: the machine supervises one update at a time and
+    /// `Event::UpdateRequest` names no component.
+    UpdateDeferred,
+    /// An update in flight superseded by recovery. Its staged image is
+    /// discarded and no verdict for that request follows. Platform-wide for
+    /// the same reason as [`Report::UpdateDeferred`].
+    UpdateAborted,
+}
+
+/// Where the driver hands its [`Report`]s. What a report becomes, a log
+/// entry, a management transport message, a fault line, is board wiring.
+///
+/// Infallible by design: a report names something that already happened, so
+/// an undeliverable one costs information, not containment. An error channel
+/// would put reports on the fail-closed path, letting the act of reporting a
+/// contained failure escalate it.
+pub trait ReportSink {
+    /// Receives one report. A sink that cannot deliver immediately queues on
+    /// its own side rather than stalling the effect batch.
+    fn report(&mut self, report: Report);
+}
+
+/// Drops every report, for a board with no management side to tell. Losing
+/// reports costs visibility only, so this is a wiring choice, not a stub.
+impl ReportSink for () {
+    #[inline(always)]
+    fn report(&mut self, _report: Report) {}
+}
+
+impl<S: ReportSink> ReportSink for &mut S {
+    #[inline(always)]
+    fn report(&mut self, report: Report) {
+        (**self).report(report)
+    }
+}
+
 /// The set of platform capabilities one board composes into the
 /// `PlatformDriver`, named by a marker type. A new seam adds an associated
 /// type here and a field on [`Board`] — never another parameter.

--- a/services/orchestrator/driver/src/lib.rs
+++ b/services/orchestrator/driver/src/lib.rs
@@ -34,5 +34,5 @@ mod driver;
 #[cfg(test)]
 mod tests;
 
-pub use board::{Board, BoardCapabilities, ImageSource, Verdict, Verifier};
+pub use board::{Board, BoardCapabilities, ImageSource, Report, ReportSink, Verdict, Verifier};
 pub use driver::{BootWalkPoll, DriverError, PlatformDriver};

--- a/services/orchestrator/driver/src/tests.rs
+++ b/services/orchestrator/driver/src/tests.rs
@@ -772,3 +772,54 @@ fn boot_timeout_fails_closed_without_recovery() {
 
     assert_eq!(orch.state(), State::Locked);
 }
+
+// ---------------------------------------------------------------------------
+// Report sink.
+// ---------------------------------------------------------------------------
+
+/// Records what it is handed: the seam satisfied without a management
+/// transport.
+struct RecordingSink {
+    seen: std::vec::Vec<Report>,
+}
+
+impl RecordingSink {
+    fn new() -> Self {
+        Self {
+            seen: std::vec::Vec::new(),
+        }
+    }
+}
+
+impl ReportSink for RecordingSink {
+    fn report(&mut self, report: Report) {
+        self.seen.push(report);
+    }
+}
+
+/// One of each report, so a test covers the whole enum.
+fn every_report() -> [Report; 4] {
+    [
+        Report::Isolated(C0),
+        Report::RecoveryFailed(C0),
+        Report::UpdateDeferred,
+        Report::UpdateAborted,
+    ]
+}
+
+// Every report is deliverable through the seam alone, in the order handed
+// over; the unit sink is a wiring choice and satisfies the same caller.
+#[test]
+fn every_report_reaches_a_sink() {
+    fn tell<S: ReportSink>(sink: &mut S, reports: [Report; 4]) {
+        for report in reports {
+            sink.report(report);
+        }
+    }
+
+    let mut recording = RecordingSink::new();
+    tell(&mut recording, every_report());
+    assert_eq!(recording.seen, every_report());
+
+    tell(&mut (), every_report());
+}


### PR DESCRIPTION
The four `Effect::Report*` variants have no consumer seam. This adds a `#[non_exhaustive]` `Report` enum and a single `ReportSink::report` instead of a method or a trait per variant, so a new report is one variant rather than a trait break and a sink routes only what it recognises.

`report` returns nothing: a report names something that already happened, so an undeliverable one costs information, not containment, and reporting stays off the driver's fail-closed path. Payloads stay `Copy` and lifetime-free, like the effects they mirror.

The seam lives in `driver/src/board.rs` rather than `orchestrator-capabilities`, because `Report` carries a `ComponentId` and that crate is a dependency-free leaf. Same split the driver already makes for `Verifier`.

Composing a sink into the board follows in the next PR.

References 9elements/openprot#3.
