### PR TITLE
orchestrator/server: build for any pw_kernel target, not just ast10x0

### DIFF
--- a/services/orchestrator/server/BUILD.bazel
+++ b/services/orchestrator/server/BUILD.bazel
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_library")
-load("//target/ast10x0:defs.bzl", "TARGET_COMPATIBLE_WITH")
 
 rust_library(
     name = "orchestrator_server",
@@ -13,7 +12,8 @@ rust_library(
     crate_name = "openprot_orchestrator_server",
     edition = "2024",
     tags = ["kernel"],
-    target_compatible_with = TARGET_COMPATIBLE_WITH,
+    # Any pw_kernel userspace target (ast10x0, earlgrey, veer); not the host.
+    target_compatible_with = ["@platforms//os:none"],
     visibility = ["//visibility:public"],
     deps = [
         "//services/orchestrator/sm:orchestrator_sm",


### PR DESCRIPTION
orchestrator_server was pinned to the ast10x0 target, so it couldn't build for other pw_kernel targets (earlgrey, veer) or be reused portably.

