### PR TITLE
earlgrey/hwe: implement interactive CLI framework and peripheral hierarchies (sys, gpio, usb, flash)

### DIFF
--- a/protocol/usb/cdc_acm/lib.rs
+++ b/protocol/usb/cdc_acm/lib.rs
@@ -277,7 +277,7 @@ impl CdcAcmBuilder {
                 },
                 EpIn {
                     num: self.data_in_ep,
-                    buf_pool_size: 1,
+                    buf_pool_size: 4,
                 },
             ],
             [EpOut {

--- a/services/flash/opcode.rs
+++ b/services/flash/opcode.rs
@@ -49,3 +49,25 @@ pub struct ReadOp {
     /// The number of bytes to read.
     pub length: u32,
 }
+
+/// IPC opcode for reading JEDEC ID from flash.
+pub const IPC_OP_FLASH_READ_ID: Opcode = Opcode::new(*b"FLID");
+
+/// Arguments for the `IPC_OP_FLASH_READ_ID` request.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(C)]
+pub struct ReadIdOp {
+    /// Index of the SPI EEPROM (0 or 1).
+    pub eeprom_index: u8,
+}
+
+/// Response returned by `IPC_OP_FLASH_READ_ID`.
+#[derive(
+    FromBytes, IntoBytes, KnownLayout, Immutable, Default, Clone, Copy, Debug, PartialEq, Eq,
+)]
+#[repr(C)]
+pub struct JedecIdResp {
+    pub manufacturer: u8,
+    pub memory_type: u8,
+    pub capacity_code: u8,
+}

--- a/services/flash/server.rs
+++ b/services/flash/server.rs
@@ -26,6 +26,14 @@ impl<TFlash: Flash<Error = ErrorCode>> FlashIpcServer<TFlash> {
         Self { flash }
     }
 
+    pub fn flash(&self) -> &TFlash {
+        &self.flash
+    }
+
+    pub fn flash_mut(&mut self) -> &mut TFlash {
+        &mut self.flash
+    }
+
     /// Handles the `IPC_OP_FLASH_GET_INFO` request.
     ///
     /// Writes the flash geometry into the provided buffer and returns it.

--- a/target/earlgrey/drivers/BUILD.bazel
+++ b/target/earlgrey/drivers/BUILD.bazel
@@ -34,6 +34,15 @@ rust_library(
     ],
 )
 
+rust_test(
+    name = "pinmux_test",
+    crate = ":pinmux",
+    rustc_flags = [
+        "-C",
+        "debug-assertions",
+    ],
+)
+
 rust_library(
     name = "eflash_driver",
     srcs = ["eflash_driver.rs"],

--- a/target/earlgrey/drivers/pinmux.rs
+++ b/target/earlgrey/drivers/pinmux.rs
@@ -131,10 +131,79 @@ pub enum Pull {
     Down,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SlewRate {
+    #[default]
+    Slowest = 0,
+    Slow = 1,
+    Fast = 2,
+    Fastest = 3,
+}
+
+impl SlewRate {
+    pub const fn from_raw(val: u32) -> Self {
+        match val & 3 {
+            0 => Self::Slowest,
+            1 => Self::Slow,
+            2 => Self::Fast,
+            _ => Self::Fastest,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DriveStrength {
+    #[default]
+    Drive0 = 0,
+    Drive1 = 1,
+    Drive2 = 2,
+    Drive3 = 3,
+    Drive4 = 4,
+    Drive5 = 5,
+    Drive6 = 6,
+    Drive7 = 7,
+    Drive8 = 8,
+    Drive9 = 9,
+    Drive10 = 10,
+    Drive11 = 11,
+    Drive12 = 12,
+    Drive13 = 13,
+    Drive14 = 14,
+    Drive15 = 15,
+}
+
+impl DriveStrength {
+    pub const fn from_raw(val: u32) -> Self {
+        match val & 0xf {
+            0 => Self::Drive0,
+            1 => Self::Drive1,
+            2 => Self::Drive2,
+            3 => Self::Drive3,
+            4 => Self::Drive4,
+            5 => Self::Drive5,
+            6 => Self::Drive6,
+            7 => Self::Drive7,
+            8 => Self::Drive8,
+            9 => Self::Drive9,
+            10 => Self::Drive10,
+            11 => Self::Drive11,
+            12 => Self::Drive12,
+            13 => Self::Drive13,
+            14 => Self::Drive14,
+            _ => Self::Drive15,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PadConfig {
     pub pull: Pull,
     pub open_drain: bool,
     pub invert: bool,
+    pub slew_rate: SlewRate,
+    pub drive_strength: DriveStrength,
 }
 
 impl Default for PadConfig {
@@ -143,7 +212,36 @@ impl Default for PadConfig {
             pull: Pull::None,
             open_drain: false,
             invert: false,
+            slew_rate: SlewRate::Slowest,
+            drive_strength: DriveStrength::Drive0,
         }
+    }
+}
+
+impl PadConfig {
+    pub const fn with_pull(mut self, pull: Pull) -> Self {
+        self.pull = pull;
+        self
+    }
+
+    pub const fn with_open_drain(mut self, open_drain: bool) -> Self {
+        self.open_drain = open_drain;
+        self
+    }
+
+    pub const fn with_invert(mut self, invert: bool) -> Self {
+        self.invert = invert;
+        self
+    }
+
+    pub const fn with_slew_rate(mut self, slew_rate: SlewRate) -> Self {
+        self.slew_rate = slew_rate;
+        self
+    }
+
+    pub const fn with_drive_strength(mut self, drive_strength: DriveStrength) -> Self {
+        self.drive_strength = drive_strength;
+        self
     }
 }
 
@@ -202,6 +300,8 @@ impl EarlGreyPinmux {
                     })
                     .od_en(config.open_drain)
                     .invert(config.invert)
+                    .slew_rate(config.slew_rate as u32)
+                    .drive_strength(config.drive_strength as u32)
             });
             Ok(())
         } else if let Some(mio_idx) = pad.mio_index() {
@@ -216,6 +316,8 @@ impl EarlGreyPinmux {
                     })
                     .od_en(config.open_drain)
                     .invert(config.invert)
+                    .slew_rate(config.slew_rate as u32)
+                    .drive_strength(config.drive_strength as u32)
             });
             Ok(())
         } else if pad.as_insel().is_some() {
@@ -225,5 +327,90 @@ impl EarlGreyPinmux {
         } else {
             Err(EG_PINMUX_INVALID_PAD)
         }
+    }
+
+    pub fn get_pad_config(&self, pad: Pad) -> Result<PadConfig, ErrorCode> {
+        let (pull_en, pull_sel, od_en, invert, slew_rate, drive_strength) =
+            if let Some(dio_idx) = pad.dio_index() {
+                let reg = self.registers.dio_pad_attr().at(dio_idx).read();
+                (
+                    reg.pull_en(),
+                    reg.pull_select(),
+                    reg.od_en(),
+                    reg.invert(),
+                    reg.slew_rate(),
+                    reg.drive_strength(),
+                )
+            } else if let Some(mio_idx) = pad.mio_index() {
+                let reg = self.registers.mio_pad_attr().at(mio_idx).read();
+                (
+                    reg.pull_en(),
+                    reg.pull_select(),
+                    reg.od_en(),
+                    reg.invert(),
+                    reg.slew_rate(),
+                    reg.drive_strength(),
+                )
+            } else if pad.as_insel().is_some() {
+                // Constant pads (ConstantZero, ConstantOne) have valid input selectors
+                // but no physical pad attributes to configure.
+                return Ok(PadConfig::default());
+            } else {
+                return Err(EG_PINMUX_INVALID_PAD);
+            };
+
+        let pull = if !pull_en {
+            Pull::None
+        } else if pull_sel == pinmux::enums::PullSelect::PullUp {
+            Pull::Up
+        } else {
+            Pull::Down
+        };
+
+        Ok(PadConfig {
+            pull,
+            open_drain: od_en,
+            invert,
+            slew_rate: SlewRate::from_raw(slew_rate),
+            drive_strength: DriveStrength::from_raw(drive_strength),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slew_rate_from_raw() {
+        assert_eq!(SlewRate::from_raw(0), SlewRate::Slowest);
+        assert_eq!(SlewRate::from_raw(1), SlewRate::Slow);
+        assert_eq!(SlewRate::from_raw(2), SlewRate::Fast);
+        assert_eq!(SlewRate::from_raw(3), SlewRate::Fastest);
+        assert_eq!(SlewRate::from_raw(4), SlewRate::Slowest);
+    }
+
+    #[test]
+    fn test_drive_strength_from_raw() {
+        assert_eq!(DriveStrength::from_raw(0), DriveStrength::Drive0);
+        assert_eq!(DriveStrength::from_raw(5), DriveStrength::Drive5);
+        assert_eq!(DriveStrength::from_raw(15), DriveStrength::Drive15);
+        assert_eq!(DriveStrength::from_raw(16), DriveStrength::Drive0);
+    }
+
+    #[test]
+    fn test_pad_config_builder() {
+        let config = PadConfig::default()
+            .with_pull(Pull::Up)
+            .with_open_drain(true)
+            .with_invert(true)
+            .with_slew_rate(SlewRate::Fast)
+            .with_drive_strength(DriveStrength::Drive7);
+
+        assert_eq!(config.pull, Pull::Up);
+        assert!(config.open_drain);
+        assert!(config.invert);
+        assert_eq!(config.slew_rate, SlewRate::Fast);
+        assert_eq!(config.drive_strength, DriveStrength::Drive7);
     }
 }

--- a/target/earlgrey/firmware/hwe/BUILD.bazel
+++ b/target/earlgrey/firmware/hwe/BUILD.bazel
@@ -1,6 +1,7 @@
 # Licensed under the Apache-2.0 license
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@pigweed//pw_kernel/tooling:multi_process_app.bzl", "multi_process_app")
 load("@pigweed//pw_kernel/tooling:rust_process.bzl", "rust_process")
 load("@pigweed//pw_kernel/tooling:system_image.bzl", "system_image")
@@ -12,12 +13,28 @@ load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
 load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
 load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
 
+bool_flag(
+    name = "cli",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "cli_enabled",
+    flag_values = {
+        ":cli": "true",
+    },
+)
+
 rust_process(
     name = "logmgr",
     srcs = [
         "logmgr.rs",
     ],
     codegen_crate_name = "logmgr_codegen",
+    crate_features = select({
+        ":cli_enabled": ["cli"],
+        "//conditions:default": [],
+    }),
     edition = "2024",
     system_config = "@pigweed//pw_kernel/target:system_config_file",
     tags = ["kernel"],
@@ -43,6 +60,10 @@ rust_process(
         "usbmgr.rs",
     ],
     codegen_crate_name = "usbmgr_codegen",
+    crate_features = select({
+        ":cli_enabled": ["cli"],
+        "//conditions:default": [],
+    }),
     edition = "2024",
     system_config = "@pigweed//pw_kernel/target:system_config_file",
     tags = ["kernel"],

--- a/target/earlgrey/firmware/hwe/BUILD.bazel
+++ b/target/earlgrey/firmware/hwe/BUILD.bazel
@@ -81,10 +81,14 @@ rust_process(
     tags = ["kernel"],
     visibility = ["//visibility:public"],
     deps = [
+        "//drivers/flash:spi_flash",
         "//hal/blocking/flash",
+        "//hal/blocking/flash:driver",
         "//services/flash:server",
         "//target/earlgrey/drivers:eflash_driver",
+        "//target/earlgrey/drivers:spi_host",
         "//target/earlgrey/registers:flash_ctrl_core",
+        "//target/earlgrey/registers:spi_host",
         "//target/earlgrey/util",
         "//util/error",
         "//util/ipc",
@@ -92,6 +96,7 @@ rust_process(
         "//util/zfmt",
         "@pigweed//pw_kernel/userspace",
         "@pigweed//pw_status/rust:pw_status",
+        "@rust_crates//:embedded-hal",
         "@zfmt//zfmt",
     ],
 )

--- a/target/earlgrey/firmware/hwe/BUILD.bazel
+++ b/target/earlgrey/firmware/hwe/BUILD.bazel
@@ -12,6 +12,8 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//target/earlgrey:defs.bzl", "TARGET_COMPATIBLE_WITH")
 load("//target/earlgrey/signing/keys:defs.bzl", "FPGA_ECDSA_KEY", "SILICON_ECDSA_KEY")
 load("//target/earlgrey/tooling:opentitan_runner.bzl", "opentitan_test")
+load("//third_party/lowrisc_opentitan:defs.bzl", "opentitan_rust_binary")
+load(":cli_image.bzl", "cli_system_image")
 
 bool_flag(
     name = "cli",
@@ -149,6 +151,10 @@ rust_process(
         "platform.rs",
     ],
     codegen_crate_name = "platform_codegen",
+    crate_features = select({
+        ":cli_enabled": ["cli"],
+        "//conditions:default": [],
+    }),
     edition = "2024",
     system_config = "@pigweed//pw_kernel/target:system_config_file",
     tags = ["kernel"],
@@ -285,4 +291,56 @@ opentitan_test(
         "hardware",
     ],
     target = ":hwe_firmware",
+)
+
+opentitan_rust_binary(
+    name = "host_cli_check",
+    srcs = ["host_cli_check.rs"],
+    edition = "2024",
+    rustc_flags = [
+        "-C",
+        "link-arg=-Wl,--allow-shlib-undefined",
+    ],
+    deps = [
+        "//third_party/lowrisc_opentitan:opentitanlib",
+        "//third_party/lowrisc_opentitan:usb_test_helper",
+        "@ot_crate_index//:anyhow",
+        "@ot_crate_index//:clap",
+        "@ot_crate_index//:humantime",
+        "@ot_crate_index//:log",
+        "@ot_crate_index//:serialport",
+    ],
+)
+
+cli_system_image(
+    name = "hwe_cli_firmware",
+    target = ":hwe_firmware",
+)
+
+opentitan_test(
+    name = "hwe_cli_hyper310_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper310",
+    interface = "hyper310",
+    tags = [
+        "hardware",
+        "hyper310",
+    ],
+    target = ":hwe_cli_firmware",
+    test_cmd = "--logging=info",
+    test_harness = ":host_cli_check",
+)
+
+opentitan_test(
+    name = "hwe_cli_hyper340_test",
+    ecdsa_key = FPGA_ECDSA_KEY,
+    environment = "//target/earlgrey/env:hyper340",
+    interface = "hyper340",
+    tags = [
+        "hardware",
+        "hyper340",
+    ],
+    target = ":hwe_cli_firmware",
+    test_cmd = "--logging=info",
+    test_harness = ":host_cli_check",
 )

--- a/target/earlgrey/firmware/hwe/BUILD.bazel
+++ b/target/earlgrey/firmware/hwe/BUILD.bazel
@@ -107,6 +107,7 @@ rust_process(
         "//drivers/flash:spi_flash",
         "//hal/blocking/flash",
         "//hal/blocking/flash:driver",
+        "//services/flash:opcode",
         "//services/flash:server",
         "//target/earlgrey/drivers:eflash_driver",
         "//target/earlgrey/drivers:spi_host",
@@ -120,6 +121,7 @@ rust_process(
         "@pigweed//pw_kernel/userspace",
         "@pigweed//pw_status/rust:pw_status",
         "@rust_crates//:embedded-hal",
+        "@rust_crates//:zerocopy",
         "@zfmt//zfmt",
     ],
 )

--- a/target/earlgrey/firmware/hwe/README.md
+++ b/target/earlgrey/firmware/hwe/README.md
@@ -97,7 +97,7 @@ graph TD
     *   Flash: `0xA0010000` (Size: 64 KiB)
     *   RAM: `0x10000000` (Size: 32 KiB)
 *   **Application (`hwe`)**:
-    *   Flash Size: 48 KiB
+    *   Flash Size: 64 KiB
     *   Process RAM allocations:
         *   `logmgr`: 4 KiB (Stack: 2 KiB)
         *   `sysmgr`: 4 KiB (Stack: 2 KiB)

--- a/target/earlgrey/firmware/hwe/cli_image.bzl
+++ b/target/earlgrey/firmware/hwe/cli_image.bzl
@@ -1,0 +1,51 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+load("@pigweed//pw_kernel/tooling:system_image.bzl", "SystemImageInfo")
+
+def _cli_transition_impl(settings, attr):
+    return {
+        "//target/earlgrey/firmware/hwe:cli": True,
+    }
+
+_cli_transition = transition(
+    implementation = _cli_transition_impl,
+    inputs = [],
+    outputs = ["//target/earlgrey/firmware/hwe:cli"],
+)
+
+def _cli_system_image_impl(ctx):
+    actual = ctx.attr.target[0]
+    actual_info = actual[SystemImageInfo]
+
+    elf_symlink = ctx.actions.declare_file(ctx.label.name + ".elf")
+    ctx.actions.symlink(output = elf_symlink, target_file = actual_info.elf)
+
+    bin_symlink = ctx.actions.declare_file(ctx.label.name + ".bin")
+    ctx.actions.symlink(output = bin_symlink, target_file = actual_info.bin)
+
+    return [
+        DefaultInfo(
+            files = depset([elf_symlink, bin_symlink]),
+            runfiles = ctx.runfiles(files = [bin_symlink, elf_symlink]),
+        ),
+        SystemImageInfo(
+            bin = bin_symlink,
+            elf = elf_symlink,
+            apps = actual_info.apps,
+        ),
+    ]
+
+cli_system_image = rule(
+    implementation = _cli_system_image_impl,
+    attrs = {
+        "target": attr.label(
+            cfg = _cli_transition,
+            mandatory = True,
+            providers = [SystemImageInfo],
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/target/earlgrey/firmware/hwe/flash_server.rs
+++ b/target/earlgrey/firmware/hwe/flash_server.rs
@@ -10,13 +10,28 @@ use userspace::time::Instant;
 use userspace::{process_entry, syscall};
 use util_error::{AsStatus, ErrorCode};
 use util_zfmt::messages::{ProcessExit, ProcessStart};
+use zfmt::Zfmt;
 
 use earlgrey_util::EarlgreyFlashAddress;
 use eflash_driver::{EmbeddedFlash, Permission};
 use hal_flash::{BlockingFlash, FlashAddress};
 use services_flash_server::FlashIpcServer;
+use spi_flash::SpiFlash;
+use spi_host::SpiHost0;
 use util_ipc::IpcHandle;
 use util_types::Blocking;
+
+#[derive(Zfmt)]
+#[zfmt(format = "SPI Host init failed: {code:08x}")]
+struct SpiHostInitFailed {
+    code: u32,
+}
+
+#[derive(Zfmt)]
+#[zfmt(format = "SPI Flash init failed: {code:08x}")]
+struct SpiFlashInitFailed {
+    code: u32,
+}
 
 struct FlashCtrlInterrupt;
 
@@ -38,28 +53,92 @@ impl Blocking for FlashCtrlInterrupt {
 }
 
 fn flash_server() -> Result<(), ErrorCode> {
-    let mut driver =
+    let mut eflash_driver =
         EmbeddedFlash::new_with_interrupts(unsafe { flash_ctrl_core::FlashCtrl::new() });
-    driver.set_default_permission(Permission::FULL_ACCESS);
+    eflash_driver.set_default_permission(Permission::FULL_ACCESS);
     for i in 5..9 {
-        driver.set_info_permission(FlashAddress::info(0, i, 0), Permission::FULL_ACCESS)?;
-        driver.set_info_permission(FlashAddress::info(1, i, 0), Permission::FULL_ACCESS)?;
+        eflash_driver.set_info_permission(FlashAddress::info(0, i, 0), Permission::FULL_ACCESS)?;
+        eflash_driver.set_info_permission(FlashAddress::info(1, i, 0), Permission::FULL_ACCESS)?;
     }
-    let flash = BlockingFlash {
-        driver,
+    let eflash = BlockingFlash {
+        driver: eflash_driver,
         blocking: FlashCtrlInterrupt,
     };
-    let mut flash_server = FlashIpcServer::new(flash);
+    let mut eflash_server = FlashIpcServer::new(eflash);
+
+    let mut spi_host = unsafe {
+        // SAFETY: we have exclusive access to the spi_host0 peripheral.
+        earlgrey_spi_host::SpiHost::new(spi_host::RegisterBlock::new(SpiHost0::PTR))
+    };
+    if let Err(e) = spi_host.init(&earlgrey_spi_host::SpiConfig::DEFAULT_SPI0) {
+        let code = u32::from(ErrorCode::from(e));
+        util_zfmt::error!(SpiHostInitFailed { code });
+        return Err(ErrorCode::from(e));
+    }
+
+    let mut spi_flash = SpiFlash::new(spi_host);
+    if let Err(e) = spi_flash.init() {
+        util_zfmt::error!(SpiFlashInitFailed { code: u32::from(e) });
+        return Err(e);
+    }
+    let mut spi_flash_server = FlashIpcServer::new(spi_flash);
+
+    syscall::wait_group_add(
+        handle::FLASH_WAIT_GROUP,
+        handle::EFLASH_UPDATEMGR_SERVICE,
+        syscall::Signals::READABLE,
+        handle::EFLASH_UPDATEMGR_SERVICE as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
+    syscall::wait_group_add(
+        handle::FLASH_WAIT_GROUP,
+        handle::EFLASH_USB_SERVICE,
+        syscall::Signals::READABLE,
+        handle::EFLASH_USB_SERVICE as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
+    syscall::wait_group_add(
+        handle::FLASH_WAIT_GROUP,
+        handle::SPI_FLASH_UPDATEMGR_SERVICE,
+        syscall::Signals::READABLE,
+        handle::SPI_FLASH_UPDATEMGR_SERVICE as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
+    syscall::wait_group_add(
+        handle::FLASH_WAIT_GROUP,
+        handle::SPI_FLASH_USB_SERVICE,
+        syscall::Signals::READABLE,
+        handle::SPI_FLASH_USB_SERVICE as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
     let mut buf = [0u8; 2064];
-    let ipc = IpcHandle::new(handle::FLASH_SERVICE);
+    let eflash_updatemgr_ipc = IpcHandle::new(handle::EFLASH_UPDATEMGR_SERVICE);
+    let eflash_usb_ipc = IpcHandle::new(handle::EFLASH_USB_SERVICE);
+    let spi_flash_updatemgr_ipc = IpcHandle::new(handle::SPI_FLASH_UPDATEMGR_SERVICE);
+    let spi_flash_usb_ipc = IpcHandle::new(handle::SPI_FLASH_USB_SERVICE);
+
     loop {
-        syscall::object_wait(
-            handle::FLASH_SERVICE,
+        let wait_result = syscall::object_wait(
+            handle::FLASH_WAIT_GROUP,
             syscall::Signals::READABLE,
             Instant::MAX,
         )
         .map_err(ErrorCode::kernel_error)?;
-        flash_server.handle_one(&ipc, &mut buf)?;
+
+        let channel = wait_result.user_data as u32;
+        if channel == handle::EFLASH_UPDATEMGR_SERVICE {
+            eflash_server.handle_one(&eflash_updatemgr_ipc, &mut buf)?;
+        } else if channel == handle::EFLASH_USB_SERVICE {
+            eflash_server.handle_one(&eflash_usb_ipc, &mut buf)?;
+        } else if channel == handle::SPI_FLASH_UPDATEMGR_SERVICE {
+            spi_flash_server.handle_one(&spi_flash_updatemgr_ipc, &mut buf)?;
+        } else if channel == handle::SPI_FLASH_USB_SERVICE {
+            spi_flash_server.handle_one(&spi_flash_usb_ipc, &mut buf)?;
+        }
     }
 }
 

--- a/target/earlgrey/firmware/hwe/flash_server.rs
+++ b/target/earlgrey/firmware/hwe/flash_server.rs
@@ -14,12 +14,15 @@ use zfmt::Zfmt;
 
 use earlgrey_util::EarlgreyFlashAddress;
 use eflash_driver::{EmbeddedFlash, Permission};
+use embedded_hal::spi::SpiDevice;
 use hal_flash::{BlockingFlash, FlashAddress};
+use services_flash_opcode::{JedecIdResp, IPC_OP_FLASH_READ_ID};
 use services_flash_server::FlashIpcServer;
 use spi_flash::SpiFlash;
-use spi_host::SpiHost0;
-use util_ipc::IpcHandle;
-use util_types::Blocking;
+use spi_host::{SpiHost0, SpiHost1};
+use util_ipc::{IpcChannel, IpcHandle};
+use util_types::{Blocking, Opcode};
+use zerocopy::{FromBytes, IntoBytes};
 
 #[derive(Zfmt)]
 #[zfmt(format = "SPI Host init failed: {code:08x}")]
@@ -83,6 +86,14 @@ fn flash_server() -> Result<(), ErrorCode> {
     }
     let mut spi_flash_server = FlashIpcServer::new(spi_flash);
 
+    let mmio1 = unsafe { spi_host::RegisterBlock::new(SpiHost1::PTR) };
+    let mut spi_host1 = unsafe { earlgrey_spi_host::SpiHost::new(mmio1) };
+    if let Err(e) = spi_host1.init(&earlgrey_spi_host::SpiConfig::DEFAULT_SPI1) {
+        let code = u32::from(ErrorCode::from(e));
+        util_zfmt::error!(SpiHostInitFailed { code });
+        return Err(ErrorCode::from(e));
+    }
+
     syscall::wait_group_add(
         handle::FLASH_WAIT_GROUP,
         handle::EFLASH_UPDATEMGR_SERVICE,
@@ -115,11 +126,20 @@ fn flash_server() -> Result<(), ErrorCode> {
     )
     .map_err(ErrorCode::kernel_error)?;
 
+    syscall::wait_group_add(
+        handle::FLASH_WAIT_GROUP,
+        handle::FLASH_PLATFORM_SERVICE,
+        syscall::Signals::READABLE,
+        handle::FLASH_PLATFORM_SERVICE as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
     let mut buf = [0u8; 2064];
     let eflash_updatemgr_ipc = IpcHandle::new(handle::EFLASH_UPDATEMGR_SERVICE);
     let eflash_usb_ipc = IpcHandle::new(handle::EFLASH_USB_SERVICE);
     let spi_flash_updatemgr_ipc = IpcHandle::new(handle::SPI_FLASH_UPDATEMGR_SERVICE);
     let spi_flash_usb_ipc = IpcHandle::new(handle::SPI_FLASH_USB_SERVICE);
+    let flash_platform_ipc = IpcHandle::new(handle::FLASH_PLATFORM_SERVICE);
 
     loop {
         let wait_result = syscall::object_wait(
@@ -138,6 +158,42 @@ fn flash_server() -> Result<(), ErrorCode> {
             spi_flash_server.handle_one(&spi_flash_updatemgr_ipc, &mut buf)?;
         } else if channel == handle::SPI_FLASH_USB_SERVICE {
             spi_flash_server.handle_one(&spi_flash_usb_ipc, &mut buf)?;
+        } else if channel == handle::FLASH_PLATFORM_SERVICE {
+            let n = flash_platform_ipc
+                .read(0, &mut buf)
+                .map_err(ErrorCode::kernel_error)?;
+            if n >= core::mem::size_of::<Opcode>() {
+                let (op_bytes, req_data) = buf.split_at_mut(core::mem::size_of::<Opcode>());
+                let op = Opcode::read_from_bytes(op_bytes).unwrap_or(Opcode::new(*b"\0\0\0\0"));
+                if op == IPC_OP_FLASH_READ_ID {
+                    let eeprom_idx = req_data.first().copied().unwrap_or(0);
+                    let mut jedec = JedecIdResp::default();
+                    let mut raw = [0u8; 3];
+                    let res = if eeprom_idx == 0 {
+                        spi_flash_server.flash_mut().read_jedec_id(&mut raw)
+                    } else if eeprom_idx == 1 {
+                        let mut ops = [
+                            embedded_hal::spi::Operation::Write(&[0x9F]),
+                            embedded_hal::spi::Operation::Read(&mut raw),
+                        ];
+                        spi_host1
+                            .transaction(&mut ops)
+                            .map_err(|_| util_error::FLASH_GENERIC_BUSY)
+                    } else {
+                        Err(util_error::FLASH_GENERIC_INVALID_SIZE)
+                    };
+                    let status = match res {
+                        Ok(()) => {
+                            jedec.manufacturer = raw[0];
+                            jedec.memory_type = raw[1];
+                            jedec.capacity_code = raw[2];
+                            0u32
+                        }
+                        Err(e) => e.0.get(),
+                    };
+                    let _ = flash_platform_ipc.respond(&[status.as_bytes(), jedec.as_bytes()]);
+                }
+            }
         }
     }
 }

--- a/target/earlgrey/firmware/hwe/host_cli_check.rs
+++ b/target/earlgrey/firmware/hwe/host_cli_check.rs
@@ -1,0 +1,148 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Read, Write};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+use usb::UsbOpts;
+
+#[derive(Parser, Debug)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    #[command(flatten)]
+    usb: UsbOpts,
+
+    #[arg(long, default_value_t = 15)]
+    timeout_secs: u64,
+}
+
+fn wait_for_usb_serial(
+    usb_vid: u16,
+    usb_pid: u16,
+    timeout: Duration,
+) -> Result<serialport::SerialPortInfo> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(ports) = serialport::available_ports() {
+            for info in ports {
+                if let serialport::SerialPortType::UsbPort(usb_info) = &info.port_type {
+                    if usb_info.vid == usb_vid && usb_info.pid == usb_pid {
+                        return Ok(info);
+                    }
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    bail!("USB CDC-ACM serial port not found within timeout");
+}
+
+fn test_uart_cli(transport: &opentitanlib::app::TransportWrapper, timeout: Duration) -> Result<()> {
+    log::info!("Testing UART0 hardware console CLI...");
+    let uart = transport.uart("console")?;
+
+    log::info!("Sending 'help\\r' to UART0 console...");
+    uart.write(b"help\r")
+        .context("Failed to write 'help\\r' to UART0")?;
+
+    UartConsole::wait_for(&*uart, r"Platform CLI Commands:", timeout)
+        .context("Did not receive 'Platform CLI Commands:' on UART0")?;
+    UartConsole::wait_for(&*uart, r"help  - Display this help message", timeout)
+        .context("Did not receive help message description on UART0")?;
+
+    log::info!("UART0 CLI help command verified successfully!");
+    Ok(())
+}
+
+fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
+    log::info!("Testing USB CDC-ACM virtual serial CLI on {}...", port_name);
+    let mut port = serialport::new(port_name, 115_200)
+        .timeout(Duration::from_millis(500))
+        .open()
+        .context("Failed to open USB CDC-ACM serial port")?;
+
+    log::info!("Sending 'help\\r' to USB CDC-ACM port...");
+    port.write_all(b"help\r")
+        .context("Failed to write 'help\\r' to USB CDC-ACM")?;
+    port.flush().context("Failed to flush USB CDC-ACM port")?;
+
+    let start = Instant::now();
+    let mut output = String::new();
+    let mut buf = [0u8; 256];
+
+    while start.elapsed() < timeout {
+        match port.read(&mut buf) {
+            Ok(n) if n > 0 => {
+                output.push_str(&String::from_utf8_lossy(&buf[..n]));
+                if output.contains("Platform CLI Commands:")
+                    && output.contains("help  - Display this help message")
+                {
+                    log::info!("USB CDC-ACM CLI help command verified successfully!");
+                    return Ok(());
+                }
+            }
+            Ok(_) => std::thread::sleep(Duration::from_millis(50)),
+            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
+            Err(e) => return Err(e).context("Error reading from USB CDC-ACM port"),
+        }
+    }
+
+    bail!(
+        "Timed out waiting for help response on USB CDC-ACM. Received output:\n{}",
+        output
+    );
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+
+    log::info!("Resetting target...");
+    transport.reset(opentitanlib::app::UartRx::Clear)?;
+
+    let uart = transport.uart("console")?;
+    log::info!("Waiting for HWE boot and Running state on UART0 console...");
+    UartConsole::wait_for(
+        &*uart,
+        r"Platform State: Running",
+        Duration::from_secs(opts.timeout_secs),
+    )?;
+    log::info!("HWE boot confirmed in Running state!");
+
+    // 1. Verify UART0 console CLI
+    test_uart_cli(&transport, Duration::from_secs(opts.timeout_secs))?;
+
+    // 2. Setup USB and verify USB CDC-ACM CLI
+    opts.usb.apply_strappings(&transport, true)?;
+    if opts.usb.vbus_control_available() {
+        opts.usb.enable_vbus(&transport, true)?;
+    }
+    if opts.usb.vbus_sense_available() && !opts.usb.vbus_present(&transport)? {
+        bail!("OT USB does not appear to be connected to host (VBUS not detected)");
+    }
+
+    log::info!(
+        "Waiting for USB CDC-ACM port (VID: 0x{:04x}, PID: 0x{:04x})...",
+        opts.usb.vid,
+        opts.usb.pid
+    );
+    let port_info = wait_for_usb_serial(
+        opts.usb.vid,
+        opts.usb.pid,
+        Duration::from_secs(opts.timeout_secs),
+    )?;
+    log::info!("Found USB CDC-ACM port: {}", port_info.port_name);
+
+    test_usb_cli(&port_info.port_name, Duration::from_secs(opts.timeout_secs))?;
+
+    log::info!("All CLI tests passed on both UART0 and USB CDC-ACM!");
+    Ok(())
+}

--- a/target/earlgrey/firmware/hwe/host_cli_check.rs
+++ b/target/earlgrey/firmware/hwe/host_cli_check.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
@@ -130,8 +130,66 @@ fn test_uart_cli(transport: &opentitanlib::app::TransportWrapper, timeout: Durat
     )
     .context("Failed 'gpio write 0' on UART0")?;
 
+    log::info!("Sending 'sys help\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"sys help\r", "System Commands:", timeout)
+        .context("Failed 'sys help' on UART0")?;
+
+    log::info!("Sending 'sys info\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"sys info\r", "System Information:", timeout)
+        .context("Failed 'sys info' on UART0")?;
+
+    log::info!("Sending 'sys id\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"sys id\r", "Device ID:", timeout)
+        .context("Failed 'sys id' on UART0")?;
+
     log::info!("UART0 CLI commands verified successfully!");
     Ok(())
+}
+
+fn usb_send_and_wait(
+    port: &mut dyn serialport::SerialPort,
+    cmd: &[u8],
+    expected: &str,
+    timeout: Duration,
+) -> Result<String> {
+    if !cmd.is_empty() {
+        port.write_all(cmd)?;
+        port.flush()?;
+    }
+    let start = Instant::now();
+    let mut last_send = Instant::now();
+    let mut output = String::new();
+    let mut buf = [0u8; 256];
+
+    while start.elapsed() < timeout {
+        if !cmd.is_empty()
+            && last_send.elapsed() >= Duration::from_secs(2)
+            && (!output.contains(expected) || !output.contains("hwe>"))
+        {
+            let _ = port.write_all(cmd);
+            let _ = port.flush();
+            last_send = Instant::now();
+        }
+        match port.read(&mut buf) {
+            Ok(n) if n > 0 => {
+                let chunk = String::from_utf8_lossy(&buf[..n]);
+                print!("{}", chunk);
+                let _ = std::io::stdout().flush();
+                output.push_str(&chunk);
+                if output.contains(expected) && output.contains("hwe>") {
+                    return Ok(output);
+                }
+            }
+            Ok(_) => std::thread::sleep(Duration::from_millis(50)),
+            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
+            Err(e) => return Err(e).context("Error reading from USB CDC-ACM port"),
+        }
+    }
+    bail!(
+        "Timed out waiting for '{}' and prompt on USB CDC-ACM. Output received:\n{}",
+        expected,
+        output
+    );
 }
 
 fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
@@ -144,43 +202,15 @@ fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
     std::thread::sleep(Duration::from_millis(100));
 
     log::info!("Sending 'gpio help\\r' to USB CDC-ACM port...");
-    port.write_all(b"gpio help\r")
-        .context("Failed to write 'gpio help\\r' to USB CDC-ACM")?;
-    port.flush().context("Failed to flush USB CDC-ACM port")?;
+    usb_send_and_wait(&mut *port, b"gpio help\r", "GPIO Commands:", timeout)
+        .context("Failed 'gpio help' on USB CDC-ACM")?;
 
-    let start = Instant::now();
-    let mut last_send = Instant::now();
-    let mut output = String::new();
-    let mut buf = [0u8; 256];
+    log::info!("Sending 'sys info\\r' to USB CDC-ACM port...");
+    usb_send_and_wait(&mut *port, b"sys info\r", "System Information:", timeout)
+        .context("Failed 'sys info' on USB CDC-ACM")?;
 
-    while start.elapsed() < timeout {
-        if last_send.elapsed() >= Duration::from_secs(2) {
-            let _ = port.write_all(b"gpio help\r");
-            let _ = port.flush();
-            last_send = Instant::now();
-        }
-        match port.read(&mut buf) {
-            Ok(n) if n > 0 => {
-                output.push_str(&String::from_utf8_lossy(&buf[..n]));
-                if output.contains("GPIO Commands:")
-                    && output.contains("read <pin>")
-                    && output.contains("write <pin>")
-                    && output.contains("hwe> ")
-                {
-                    log::info!("USB CDC-ACM CLI gpio help and prompt verified successfully!");
-                    return Ok(());
-                }
-            }
-            Ok(_) => std::thread::sleep(Duration::from_millis(50)),
-            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
-            Err(e) => return Err(e).context("Error reading from USB CDC-ACM port"),
-        }
-    }
-
-    bail!(
-        "Timed out waiting for gpio help response on USB CDC-ACM. Received output:\n{}",
-        output
-    );
+    log::info!("USB CDC-ACM CLI commands verified successfully!");
+    Ok(())
 }
 
 fn main() -> Result<()> {

--- a/target/earlgrey/firmware/hwe/host_cli_check.rs
+++ b/target/earlgrey/firmware/hwe/host_cli_check.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
+use opentitanlib::io::console::ConsoleExt;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 use usb::UsbOpts;
@@ -43,20 +44,93 @@ fn wait_for_usb_serial(
     bail!("USB CDC-ACM serial port not found within timeout");
 }
 
+fn uart_send_and_wait(
+    uart: &dyn opentitanlib::io::uart::Uart,
+    cmd: &[u8],
+    expected: &str,
+    timeout: Duration,
+) -> Result<String> {
+    if !cmd.is_empty() {
+        uart.write(cmd)?;
+    }
+    let start = Instant::now();
+    let mut last_send = Instant::now();
+    let mut output = String::new();
+    let mut buf = [0u8; 256];
+
+    while start.elapsed() < timeout {
+        if !cmd.is_empty()
+            && last_send.elapsed() >= Duration::from_secs(2)
+            && (!output.contains(expected) || !output.contains("hwe>"))
+        {
+            let _ = uart.write(cmd);
+            last_send = Instant::now();
+        }
+        let n = uart.read_timeout(&mut buf, Duration::from_millis(50))?;
+        if n > 0 {
+            let chunk = String::from_utf8_lossy(&buf[..n]);
+            print!("{}", chunk);
+            let _ = std::io::stdout().flush();
+            output.push_str(&chunk);
+            if output.contains(expected) && output.contains("hwe>") {
+                return Ok(output);
+            }
+        }
+    }
+    bail!(
+        "Timed out waiting for '{}' and prompt on UART0. Output received:\n{}",
+        expected,
+        output
+    );
+}
+
 fn test_uart_cli(transport: &opentitanlib::app::TransportWrapper, timeout: Duration) -> Result<()> {
     log::info!("Testing UART0 hardware console CLI...");
     let uart = transport.uart("console")?;
 
+    log::info!("Testing empty Enter liveness probe on UART0 console...");
+    uart_send_and_wait(&*uart, b"\r", "hwe>", timeout).context("Failed liveness probe on UART0")?;
+
     log::info!("Sending 'help\\r' to UART0 console...");
-    uart.write(b"help\r")
-        .context("Failed to write 'help\\r' to UART0")?;
+    uart_send_and_wait(&*uart, b"help\r", "Platform CLI Commands:", timeout)
+        .context("Failed 'help' on UART0")?;
 
-    UartConsole::wait_for(&*uart, r"Platform CLI Commands:", timeout)
-        .context("Did not receive 'Platform CLI Commands:' on UART0")?;
-    UartConsole::wait_for(&*uart, r"help  - Display this help message", timeout)
-        .context("Did not receive help message description on UART0")?;
+    log::info!("Sending 'gpio help\\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"gpio help\r", "GPIO Commands:", timeout)
+        .context("Failed 'gpio help' on UART0")?;
 
-    log::info!("UART0 CLI help command verified successfully!");
+    log::info!("Sending 'gpio list\\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"gpio list\r", "GPIO Pin Status:", timeout)
+        .context("Failed 'gpio list' on UART0")?;
+
+    log::info!("Sending 'gpio read RST_CTRL0_N\\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"gpio read RST_CTRL0_N\r",
+        "GPIO RST_CTRL0_N: in=",
+        timeout,
+    )
+    .context("Failed 'gpio read' on UART0")?;
+
+    log::info!("Sending 'gpio write EXT_DEBUG_N 1\\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"gpio write EXT_DEBUG_N 1\r",
+        "GPIO EXT_DEBUG_N written 1 -> readback: out=1",
+        timeout,
+    )
+    .context("Failed 'gpio write 1' on UART0")?;
+
+    log::info!("Sending 'gpio write EXT_DEBUG_N 0\\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"gpio write EXT_DEBUG_N 0\r",
+        "GPIO EXT_DEBUG_N written 0 -> readback: out=0",
+        timeout,
+    )
+    .context("Failed 'gpio write 0' on UART0")?;
+
+    log::info!("UART0 CLI commands verified successfully!");
     Ok(())
 }
 
@@ -67,23 +141,33 @@ fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
         .open()
         .context("Failed to open USB CDC-ACM serial port")?;
 
-    log::info!("Sending 'help\\r' to USB CDC-ACM port...");
-    port.write_all(b"help\r")
-        .context("Failed to write 'help\\r' to USB CDC-ACM")?;
+    std::thread::sleep(Duration::from_millis(100));
+
+    log::info!("Sending 'gpio help\\r' to USB CDC-ACM port...");
+    port.write_all(b"gpio help\r")
+        .context("Failed to write 'gpio help\\r' to USB CDC-ACM")?;
     port.flush().context("Failed to flush USB CDC-ACM port")?;
 
     let start = Instant::now();
+    let mut last_send = Instant::now();
     let mut output = String::new();
     let mut buf = [0u8; 256];
 
     while start.elapsed() < timeout {
+        if last_send.elapsed() >= Duration::from_secs(2) {
+            let _ = port.write_all(b"gpio help\r");
+            let _ = port.flush();
+            last_send = Instant::now();
+        }
         match port.read(&mut buf) {
             Ok(n) if n > 0 => {
                 output.push_str(&String::from_utf8_lossy(&buf[..n]));
-                if output.contains("Platform CLI Commands:")
-                    && output.contains("help  - Display this help message")
+                if output.contains("GPIO Commands:")
+                    && output.contains("read <pin>")
+                    && output.contains("write <pin>")
+                    && output.contains("hwe> ")
                 {
-                    log::info!("USB CDC-ACM CLI help command verified successfully!");
+                    log::info!("USB CDC-ACM CLI gpio help and prompt verified successfully!");
                     return Ok(());
                 }
             }
@@ -94,7 +178,7 @@ fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
     }
 
     bail!(
-        "Timed out waiting for help response on USB CDC-ACM. Received output:\n{}",
+        "Timed out waiting for gpio help response on USB CDC-ACM. Received output:\n{}",
         output
     );
 }

--- a/target/earlgrey/firmware/hwe/host_cli_check.rs
+++ b/target/earlgrey/firmware/hwe/host_cli_check.rs
@@ -142,6 +142,23 @@ fn test_uart_cli(transport: &opentitanlib::app::TransportWrapper, timeout: Durat
     uart_send_and_wait(&*uart, b"sys id\r", "Device ID:", timeout)
         .context("Failed 'sys id' on UART0")?;
 
+    log::info!("Sending 'usb help\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"usb help\r", "USB Commands:", timeout)
+        .context("Failed 'usb help' on UART0")?;
+
+    log::info!("Sending 'usb info\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"usb info\r", "USB Status:", timeout)
+        .context("Failed 'usb info' on UART0")?;
+
+    log::info!("Sending 'usb mux device\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"usb mux device\r",
+        "USB multiplexer routed to device",
+        timeout,
+    )
+    .context("Failed 'usb mux device' on UART0")?;
+
     log::info!("UART0 CLI commands verified successfully!");
     Ok(())
 }
@@ -201,13 +218,17 @@ fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
 
     std::thread::sleep(Duration::from_millis(100));
 
-    log::info!("Sending 'gpio help\\r' to USB CDC-ACM port...");
+    log::info!("Sending 'gpio help\r' to USB CDC-ACM port...");
     usb_send_and_wait(&mut *port, b"gpio help\r", "GPIO Commands:", timeout)
         .context("Failed 'gpio help' on USB CDC-ACM")?;
 
-    log::info!("Sending 'sys info\\r' to USB CDC-ACM port...");
+    log::info!("Sending 'sys info\r' to USB CDC-ACM port...");
     usb_send_and_wait(&mut *port, b"sys info\r", "System Information:", timeout)
         .context("Failed 'sys info' on USB CDC-ACM")?;
+
+    log::info!("Sending 'usb info\r' to USB CDC-ACM port...");
+    usb_send_and_wait(&mut *port, b"usb info\r", "USB Status:", timeout)
+        .context("Failed 'usb info' on USB CDC-ACM")?;
 
     log::info!("USB CDC-ACM CLI commands verified successfully!");
     Ok(())

--- a/target/earlgrey/firmware/hwe/host_cli_check.rs
+++ b/target/earlgrey/firmware/hwe/host_cli_check.rs
@@ -159,6 +159,36 @@ fn test_uart_cli(transport: &opentitanlib::app::TransportWrapper, timeout: Durat
     )
     .context("Failed 'usb mux device' on UART0")?;
 
+    log::info!("Sending 'flash help\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"flash help\r", "Flash Commands:", timeout)
+        .context("Failed 'flash help' on UART0")?;
+
+    log::info!("Sending 'flash info\r' to UART0 console...");
+    uart_send_and_wait(&*uart, b"flash info\r", "SPI Flash Status:", timeout)
+        .context("Failed 'flash info' on UART0")?;
+
+    log::info!("Sending 'flash mux en\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"flash mux en\r",
+        "SPI multiplexer enabled",
+        timeout,
+    )
+    .context("Failed 'flash mux en' on UART0")?;
+
+    log::info!("Sending 'flash route host\r' to UART0 console...");
+    uart_send_and_wait(
+        &*uart,
+        b"flash route host\r",
+        "SPI multiplexer routed to host",
+        timeout,
+    )
+    .context("Failed 'flash route host' on UART0")?;
+
+    log::info!("Sending 'flash read-id\r' to UART0 console (auto EEPROM 0)...");
+    uart_send_and_wait(&*uart, b"flash read-id\r", "EEPROM 0 Status:", timeout)
+        .context("Failed 'flash read-id' on UART0")?;
+
     log::info!("UART0 CLI commands verified successfully!");
     Ok(())
 }
@@ -203,20 +233,32 @@ fn usb_send_and_wait(
         }
     }
     bail!(
-        "Timed out waiting for '{}' and prompt on USB CDC-ACM. Output received:\n{}",
+        "Timed out waiting for expected string '{}'. Received output:\n{}",
         expected,
         output
-    );
+    )
 }
 
 fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
     log::info!("Testing USB CDC-ACM virtual serial CLI on {}...", port_name);
-    let mut port = serialport::new(port_name, 115_200)
+    let mut port = serialport::new(port_name, 115200)
         .timeout(Duration::from_millis(500))
         .open()
         .context("Failed to open USB CDC-ACM serial port")?;
 
     std::thread::sleep(Duration::from_millis(100));
+
+    // Drain old backlog of logs generated during UART0 testing
+    port.set_timeout(Duration::from_millis(100))?;
+    let drain_start = Instant::now();
+    let mut drain_buf = [0u8; 256];
+    while drain_start.elapsed() < Duration::from_millis(800) {
+        match port.read(&mut drain_buf) {
+            Ok(n) if n > 0 => continue,
+            _ => break,
+        }
+    }
+    port.set_timeout(Duration::from_millis(500))?;
 
     log::info!("Sending 'gpio help\r' to USB CDC-ACM port...");
     usb_send_and_wait(&mut *port, b"gpio help\r", "GPIO Commands:", timeout)
@@ -229,6 +271,19 @@ fn test_usb_cli(port_name: &str, timeout: Duration) -> Result<()> {
     log::info!("Sending 'usb info\r' to USB CDC-ACM port...");
     usb_send_and_wait(&mut *port, b"usb info\r", "USB Status:", timeout)
         .context("Failed 'usb info' on USB CDC-ACM")?;
+
+    log::info!("Sending 'flash info\r' to USB CDC-ACM port...");
+    usb_send_and_wait(&mut *port, b"flash info\r", "SPI Flash Status:", timeout)
+        .context("Failed 'flash info' on USB CDC-ACM")?;
+
+    log::info!("Sending 'flash read-id 0\r' to USB CDC-ACM port...");
+    usb_send_and_wait(
+        &mut *port,
+        b"flash read-id 0\r",
+        "EEPROM 0 Status:",
+        timeout,
+    )
+    .context("Failed 'flash read-id 0' on USB CDC-ACM")?;
 
     log::info!("USB CDC-ACM CLI commands verified successfully!");
     Ok(())
@@ -245,12 +300,13 @@ fn main() -> Result<()> {
 
     let uart = transport.uart("console")?;
     log::info!("Waiting for HWE boot and Running state on UART0 console...");
-    UartConsole::wait_for(
-        &*uart,
-        r"Platform State: Running",
-        Duration::from_secs(opts.timeout_secs),
-    )?;
-    log::info!("HWE boot confirmed in Running state!");
+    if let Err(e) =
+        UartConsole::wait_for(&*uart, r"Platform State: Running", Duration::from_secs(5))
+    {
+        log::warn!("Waiting for Running state timed out (non-fatal): {e}");
+    } else {
+        log::info!("HWE boot confirmed in Running state!");
+    }
 
     // 1. Verify UART0 console CLI
     test_uart_cli(&transport, Duration::from_secs(opts.timeout_secs))?;

--- a/target/earlgrey/firmware/hwe/logmgr.rs
+++ b/target/earlgrey/firmware/hwe/logmgr.rs
@@ -11,7 +11,7 @@ use userspace::syscall::Signals;
 use userspace::time::Instant;
 use userspace::{process_entry, syscall};
 use util_ipc::{IpcChannel, IpcHandle};
-use util_zfmt::{render::render_event, FixedBuf, LogServer, StreamStart, Write, ZfmtU64};
+use util_zfmt::{render::render_event, FixedBuf, LogServer, StreamStart, ZfmtU64};
 use zerocopy::IntoBytes;
 
 use earlgrey_uart_driver::UartDriver;
@@ -25,7 +25,6 @@ use usart_api::backend::{BackendError, IrqMask, Parity, UsartBackend, UsartConfi
 enum TxState {
     Idle,
     Body,
-    Newline,
 }
 
 struct ActiveLog {
@@ -69,8 +68,8 @@ fn service_uart_tx<const N: usize>(
     uart_cursor: &mut u64,
 ) -> Result<(), Error> {
     loop {
-        // 1. Transmit current buffer (body or newline)
-        if active_log.state == TxState::Body || active_log.state == TxState::Newline {
+        // 1. Transmit current buffer
+        if active_log.state == TxState::Body {
             let data = active_log.buf.as_slice();
             // We maintain the invariant that active_log.sent <= data.len() and
             // should never get None. If we do, we halt transmission.
@@ -85,16 +84,7 @@ fn service_uart_tx<const N: usize>(
                 Ok(n) => {
                     active_log.sent += n;
                     if active_log.sent == data.len() {
-                        if active_log.state == TxState::Body {
-                            // Body sent, load newline into buffer
-                            active_log.buf.clear();
-                            let _ = active_log.buf.write_str("\r\n");
-                            active_log.sent = 0;
-                            active_log.state = TxState::Newline;
-                            continue; // Loop again to send newline
-                        } else {
-                            active_log.state = TxState::Idle;
-                        }
+                        active_log.state = TxState::Idle;
                     } else {
                         // Partial write, FIFO full. Enable interrupt and wait.
                         uart.enable_interrupts(IrqMask::TX_IDLE)
@@ -145,10 +135,153 @@ fn service_uart_tx<const N: usize>(
                     }
                 }
             }
-            // No more logs to load
             break;
         }
     }
+    Ok(())
+}
+
+#[cfg(feature = "cli")]
+pub const CMDLINE_MAX_LINE_LEN: usize = 128;
+
+#[cfg(feature = "cli")]
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommandLineBuffer<const N: usize> {
+    buf: [u8; N],
+    len: usize,
+    ready: bool,
+}
+
+#[cfg(feature = "cli")]
+impl<const N: usize> CommandLineBuffer<N> {
+    pub const fn new() -> Self {
+        Self {
+            buf: [0; N],
+            len: 0,
+            ready: false,
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready
+    }
+
+    pub fn push_char(&mut self, ch: u8) -> bool {
+        if self.ready || self.len >= N {
+            false
+        } else {
+            self.buf[self.len] = ch;
+            self.len += 1;
+            true
+        }
+    }
+
+    pub fn pop_char(&mut self) -> bool {
+        if self.ready || self.len == 0 {
+            false
+        } else {
+            self.len -= 1;
+            true
+        }
+    }
+
+    pub fn finish_line(&mut self) -> bool {
+        if self.ready {
+            false
+        } else {
+            self.ready = true;
+            true
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    pub fn is_blank(&self) -> bool {
+        self.len == 0
+            || self.buf[..self.len]
+                .iter()
+                .all(|&b| b == b' ' || b == b'\t')
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+        self.ready = false;
+    }
+}
+
+#[cfg(feature = "cli")]
+fn process_input_char<const N: usize, F>(
+    ch: u8,
+    cmd_buf: &mut CommandLineBuffer<N>,
+    cli_platform: &IpcHandle,
+    last_was_cr: &mut bool,
+    mut echo: F,
+) where
+    F: FnMut(&[u8]),
+{
+    if ch == b'\n' && *last_was_cr {
+        *last_was_cr = false;
+        return;
+    }
+    *last_was_cr = ch == b'\r';
+
+    if ch == b'\r' || ch == b'\n' {
+        if cmd_buf.is_blank() {
+            cmd_buf.clear();
+            echo(b"\r\nhwe> ");
+        } else {
+            echo(b"\r\n");
+            cmd_buf.finish_line();
+            let _ = cli_platform.set_peer_user_signal(true);
+        }
+    } else if ch == 0x08 || ch == 0x7f {
+        if cmd_buf.pop_char() {
+            echo(b"\x08 \x08");
+        }
+    } else if (0x20..0x7f).contains(&ch) {
+        if cmd_buf.push_char(ch) {
+            echo(&[ch]);
+        }
+    }
+}
+
+#[cfg(feature = "cli")]
+fn uart_write_all(uart: &mut UartDriver, mut data: &[u8]) {
+    while !data.is_empty() {
+        match uart.write(data) {
+            Ok(0) => continue,
+            Ok(n) => data = &data[n..],
+            Err(BackendError::WouldBlock) => continue,
+            Err(_) => break,
+        }
+    }
+}
+
+#[cfg(feature = "cli")]
+fn service_uart_rx(
+    uart: &mut UartDriver,
+    cmd_buf: &mut CommandLineBuffer<CMDLINE_MAX_LINE_LEN>,
+    cli_platform: &IpcHandle,
+    last_was_cr: &mut bool,
+    rx_buf: &mut [u8],
+) -> Result<(), Error> {
+    loop {
+        match uart.read(rx_buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                for &byte in &rx_buf[..n] {
+                    process_input_char(byte, cmd_buf, cli_platform, last_was_cr, |echo_slice| {
+                        uart_write_all(uart, echo_slice);
+                    });
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    uart.enable_interrupts(IrqMask::RX_DATA_AVAILABLE)
+        .map_err(|_| Error::Internal)?;
     Ok(())
 }
 
@@ -164,6 +297,10 @@ fn logmgr_server() -> Result<(), Error> {
         stop_bits: 1,
     })
     .map_err(|_| Error::Internal)?;
+
+    #[cfg(feature = "cli")]
+    uart.enable_interrupts(IrqMask::RX_DATA_AVAILABLE)
+        .map_err(|_| Error::Internal)?;
 
     syscall::wait_group_add(
         handle::LOGMGR_WAIT_GROUP,
@@ -183,23 +320,52 @@ fn logmgr_server() -> Result<(), Error> {
         Signals::READABLE,
         handle::LOGGER_FLASH as usize,
     )?;
-    // Add UART interrupt to wait group
-    syscall::wait_group_add(
-        handle::LOGMGR_WAIT_GROUP,
-        handle::UART0_INTERRUPTS,
-        signals::UART0_TX_DONE,
-        handle::UART0_INTERRUPTS as usize,
-    )?;
     syscall::wait_group_add(
         handle::LOGMGR_WAIT_GROUP,
         handle::LOGGER_SYSMGR,
         Signals::READABLE,
         handle::LOGGER_SYSMGR as usize,
     )?;
+    #[cfg(feature = "cli")]
+    syscall::wait_group_add(
+        handle::LOGMGR_WAIT_GROUP,
+        handle::CLI_PLATFORM,
+        Signals::READABLE,
+        handle::CLI_PLATFORM as usize,
+    )?;
+    #[cfg(feature = "cli")]
+    syscall::wait_group_add(
+        handle::LOGMGR_WAIT_GROUP,
+        handle::CLI_USB,
+        Signals::READABLE,
+        handle::CLI_USB as usize,
+    )?;
+    #[cfg(feature = "cli")]
+    let uart0_irq_signals =
+        signals::UART0_TX_DONE | signals::UART0_RX_WATERMARK | signals::UART0_RX_TIMEOUT;
+    #[cfg(not(feature = "cli"))]
+    let uart0_irq_signals = signals::UART0_TX_DONE;
+
+    syscall::wait_group_add(
+        handle::LOGMGR_WAIT_GROUP,
+        handle::UART0_INTERRUPTS,
+        uart0_irq_signals,
+        handle::UART0_INTERRUPTS as usize,
+    )?;
 
     let mut server = LogServer::<2048>::new();
     let mut active_log = ActiveLog::new();
     let mut uart_cursor = 0u64;
+    #[cfg(feature = "cli")]
+    let mut cmd_buf_uart = CommandLineBuffer::<CMDLINE_MAX_LINE_LEN>::new();
+    #[cfg(feature = "cli")]
+    let mut cmd_buf_usb = CommandLineBuffer::<CMDLINE_MAX_LINE_LEN>::new();
+    #[cfg(feature = "cli")]
+    let cli_platform_handle = IpcHandle::new(handle::CLI_PLATFORM);
+    #[cfg(feature = "cli")]
+    let mut last_was_cr_uart = false;
+    #[cfg(feature = "cli")]
+    let mut last_was_cr_usb = false;
 
     // Log StreamStart event to the buffer on startup.
     let ss = StreamStart {
@@ -227,29 +393,108 @@ fn logmgr_server() -> Result<(), Error> {
         let active_handle = wait_result.user_data as u32;
 
         if active_handle == handle::UART0_INTERRUPTS {
-            // Clear interrupt by re-enabling it (our implementation clears on enable)
-            uart.enable_interrupts(IrqMask::TX_IDLE)
-                .map_err(|_| Error::Internal)?;
-            service_uart_tx(&mut uart, &mut active_log, &server, &mut uart_cursor)?;
-            let _ = syscall::interrupt_ack(handle::UART0_INTERRUPTS, wait_result.pending_signals);
-        } else {
-            // IPC request
-            let channel = IpcHandle::new(active_handle);
-            let n = channel.read(0, &mut req)?;
-            let n = n.min(req.len());
-            let raise = match server.handle_request(&channel, &mut req[..n]) {
-                Ok(processed) => processed,
-                Err(e) => {
-                    channel.respond(e.as_bytes())?;
-                    false
-                }
-            };
-            if raise {
-                // Try to service TX (load new logs if idle)
-                service_uart_tx(&mut uart, &mut active_log, &server, &mut uart_cursor)?;
-                // Signal the USB task that there are logs available.
-                let _ = syscall::object_set_peer_user_signal(handle::LOGGER_USB, raise);
+            #[cfg(feature = "cli")]
+            if (wait_result.pending_signals
+                & (signals::UART0_RX_WATERMARK | signals::UART0_RX_TIMEOUT))
+                != Signals::empty()
+            {
+                service_uart_rx(
+                    &mut uart,
+                    &mut cmd_buf_uart,
+                    &cli_platform_handle,
+                    &mut last_was_cr_uart,
+                    &mut req[..32],
+                )?;
             }
+            if (wait_result.pending_signals & signals::UART0_TX_DONE) != Signals::empty() {
+                uart.enable_interrupts(IrqMask::TX_IDLE)
+                    .map_err(|_| Error::Internal)?;
+                service_uart_tx(&mut uart, &mut active_log, &server, &mut uart_cursor)?;
+            }
+            let _ = syscall::interrupt_ack(handle::UART0_INTERRUPTS, wait_result.pending_signals);
+            continue;
+        }
+
+        #[cfg(feature = "cli")]
+        if active_handle == handle::CLI_PLATFORM {
+            let channel = IpcHandle::new(handle::CLI_PLATFORM);
+            let n = channel.read(0, &mut req)?;
+            if n > 0 && &req[..n] == b"DONE" {
+                channel.respond(&[0u8; 0])?;
+                service_uart_tx(&mut uart, &mut active_log, &server, &mut uart_cursor)?;
+                continue;
+            }
+
+            if cmd_buf_uart.is_ready() {
+                let line = cmd_buf_uart.as_bytes();
+                channel.respond(line)?;
+                cmd_buf_uart.clear();
+            } else if cmd_buf_usb.is_ready() {
+                let line = cmd_buf_usb.as_bytes();
+                channel.respond(line)?;
+                cmd_buf_usb.clear();
+            } else {
+                channel.respond(&[0u8; 0])?;
+            }
+            if !cmd_buf_uart.is_ready() && !cmd_buf_usb.is_ready() {
+                let _ = cli_platform_handle.set_peer_user_signal(false);
+            }
+            continue;
+        }
+
+        #[cfg(feature = "cli")]
+        if active_handle == handle::CLI_USB {
+            let channel = IpcHandle::new(handle::CLI_USB);
+            // Split `req` [260 bytes] into:
+            // - `echo_buf` (196 bytes): Destination for cooked echo characters.
+            // - `input_buf` (64 bytes): Source for raw input characters (matches USB FS max packet size).
+            //
+            // Worst-case character expansion occurs on backspace ('\x08' or '\x7f' [1 byte] ->
+            // "\x08 \x08" [3 bytes]) to visually erase characters on standard VT100/ANSI terminals.
+            // With 64 bytes input, maximum echo is 64 * 3 = 192 bytes <= 196 bytes, guaranteeing
+            // that `echo_buf` will never overflow or drop echo characters.
+            const MAX_INPUT: usize = 64;
+            let mid = req.len() - MAX_INPUT;
+            let (echo_buf, input_buf) = req.split_at_mut(mid);
+            let n = channel.read(0, input_buf)?;
+            let input_slice = &input_buf[..n.min(input_buf.len())];
+
+            let mut echo_len = 0;
+            for &byte in input_slice {
+                process_input_char(
+                    byte,
+                    &mut cmd_buf_usb,
+                    &cli_platform_handle,
+                    &mut last_was_cr_usb,
+                    |echo_slice| {
+                        if echo_len + echo_slice.len() <= echo_buf.len() {
+                            echo_buf[echo_len..echo_len + echo_slice.len()]
+                                .copy_from_slice(echo_slice);
+                            echo_len += echo_slice.len();
+                        }
+                    },
+                );
+            }
+            let _ = channel.respond(&echo_buf[..echo_len]);
+            continue;
+        }
+
+        // IPC request from a logger client
+        let channel = IpcHandle::new(active_handle);
+        let n = channel.read(0, &mut req)?;
+        let n = n.min(req.len());
+        let raise = match server.handle_request(&channel, &mut req[..n]) {
+            Ok(processed) => processed,
+            Err(e) => {
+                channel.respond(e.as_bytes())?;
+                false
+            }
+        };
+        if raise {
+            // Try to service TX (load new logs if idle)
+            service_uart_tx(&mut uart, &mut active_log, &server, &mut uart_cursor)?;
+            // Signal the USB task that there are logs available.
+            let _ = syscall::object_set_peer_user_signal(handle::LOGGER_USB, raise);
         }
     }
 }

--- a/target/earlgrey/firmware/hwe/platform.rs
+++ b/target/earlgrey/firmware/hwe/platform.rs
@@ -99,7 +99,7 @@ fn platform_server() -> Result<(), ErrorCode> {
     };
 
     #[cfg(feature = "cli")]
-    use earlgrey_platform::cli::{CliContext, CliDispatcher};
+    use earlgrey_platform::cli::CliDispatcher;
 
     let mut server = PlatformServer::new(gpio, usb_mux, spi_mux, reset_policy);
     #[cfg(not(feature = "cli"))]
@@ -171,11 +171,7 @@ fn platform_server() -> Result<(), ErrorCode> {
                         .map_err(ErrorCode::kernel_error)?;
                     if let Ok(cmd_str) = core::str::from_utf8(&cmd_buf[..n]) {
                         util_zfmt::debug!("[cli] {cmd}", cmd = cmd_str);
-                        let mut context = CliContext {
-                            gpio: server.gpio_mut(),
-                            sysmgr: &sysmgr,
-                            straps,
-                        };
+                        let mut context = server.cli_context(&sysmgr, straps);
                         cli_dispatcher.dispatch(cmd_str, &mut context);
                         util_zfmt::raw!("hwe> ");
                         let _ = cli_platform.transact(b"DONE", &mut cmd_buf, Instant::MAX);

--- a/target/earlgrey/firmware/hwe/platform.rs
+++ b/target/earlgrey/firmware/hwe/platform.rs
@@ -171,7 +171,11 @@ fn platform_server() -> Result<(), ErrorCode> {
                         .map_err(ErrorCode::kernel_error)?;
                     if let Ok(cmd_str) = core::str::from_utf8(&cmd_buf[..n]) {
                         util_zfmt::debug!("[cli] {cmd}", cmd = cmd_str);
-                        let mut context = server.cli_context(&sysmgr, straps);
+                        let mut context = server.cli_context(
+                            &sysmgr,
+                            IpcHandle::new(handle::FLASH_PLATFORM),
+                            straps,
+                        );
                         cli_dispatcher.dispatch(cmd_str, &mut context);
                         util_zfmt::raw!("hwe> ");
                         let _ = cli_platform.transact(b"DONE", &mut cmd_buf, Instant::MAX);

--- a/target/earlgrey/firmware/hwe/platform.rs
+++ b/target/earlgrey/firmware/hwe/platform.rs
@@ -21,7 +21,12 @@ fn platform_server() -> Result<(), ErrorCode> {
     use earlgrey_sysmgr_client::{ResetInfo, SysmgrClient};
     use platform_codegen::{handle, signals};
     use userspace::syscall::Signals;
+    #[cfg(feature = "cli")]
+    use userspace::time::Instant;
+    #[cfg(not(feature = "cli"))]
     use userspace::time::{Clock, Duration, SystemClock};
+    #[cfg(feature = "cli")]
+    use util_ipc::IpcChannel;
     use util_ipc::IpcHandle;
 
     // SAFETY: the platform process has exclusive access to the GPIO & Pinmux peripherals.
@@ -93,37 +98,90 @@ fn platform_server() -> Result<(), ErrorCode> {
         }
     };
 
+    #[cfg(feature = "cli")]
+    use earlgrey_platform::cli::{CliContext, CliDispatcher};
+
     let mut server = PlatformServer::new(gpio, usb_mux, spi_mux, reset_policy);
+    #[cfg(not(feature = "cli"))]
     server.set_exit_deadline(SystemClock::now() + Duration::from_secs(10));
+    #[cfg(feature = "cli")]
+    server.set_exit_deadline(Instant::MAX);
     server.start(is_low_power)?;
+
+    #[cfg(feature = "cli")]
+    let mut cli_dispatcher = CliDispatcher::new();
+
+    #[cfg(feature = "cli")]
+    syscall::wait_group_add(
+        handle::PLATFORM_WAIT_GROUP,
+        handle::CLI_PLATFORM,
+        Signals::USER,
+        handle::CLI_PLATFORM as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
+    syscall::wait_group_add(
+        handle::PLATFORM_WAIT_GROUP,
+        handle::PLATFORM_INTERRUPTS,
+        usb_sig | rst0_sig | rst1_sig,
+        handle::PLATFORM_INTERRUPTS as usize,
+    )
+    .map_err(ErrorCode::kernel_error)?;
+
+    #[cfg(feature = "cli")]
+    let mut cmd_buf = [0u8; 128];
+
+    #[cfg(feature = "cli")]
+    util_zfmt::raw!("hwe> ");
 
     loop {
         if server.should_exit() {
             return Ok(());
         }
         let deadline = server.next_deadline();
-        let wait_res = syscall::object_wait(
-            handle::PLATFORM_INTERRUPTS,
-            usb_sig | rst0_sig | rst1_sig,
-            deadline,
-        );
+        let wait_res =
+            syscall::object_wait(handle::PLATFORM_WAIT_GROUP, Signals::READABLE, deadline);
 
         match wait_res {
             Ok(wait_return) => {
-                let signals = wait_return.pending_signals;
+                let active = wait_return.user_data as u32;
+                if active == handle::PLATFORM_INTERRUPTS {
+                    let signals = wait_return.pending_signals;
 
-                if (signals & usb_sig) != Signals::empty() {
-                    server.handle_usb_presence_interrupt()?;
-                }
-                if (signals & rst0_sig) != Signals::empty() {
-                    server.handle_rst_mon_interrupt(0)?;
-                }
-                if (signals & rst1_sig) != Signals::empty() {
-                    server.handle_rst_mon_interrupt(1)?;
+                    if (signals & usb_sig) != Signals::empty() {
+                        server.handle_usb_presence_interrupt()?;
+                    }
+                    if (signals & rst0_sig) != Signals::empty() {
+                        server.handle_rst_mon_interrupt(0)?;
+                    }
+                    if (signals & rst1_sig) != Signals::empty() {
+                        server.handle_rst_mon_interrupt(1)?;
+                    }
+
+                    syscall::interrupt_ack(handle::PLATFORM_INTERRUPTS, signals)
+                        .map_err(ErrorCode::kernel_error)?;
+                    continue;
                 }
 
-                syscall::interrupt_ack(handle::PLATFORM_INTERRUPTS, signals)
-                    .map_err(ErrorCode::kernel_error)?;
+                #[cfg(feature = "cli")]
+                if active == handle::CLI_PLATFORM {
+                    let cli_platform = IpcHandle::new(handle::CLI_PLATFORM);
+                    let n = cli_platform
+                        .transact(&[0u8; 0], &mut cmd_buf, Instant::MAX)
+                        .map_err(ErrorCode::kernel_error)?;
+                    if let Ok(cmd_str) = core::str::from_utf8(&cmd_buf[..n]) {
+                        util_zfmt::debug!("[cli] {cmd}", cmd = cmd_str);
+                        let mut context = CliContext {
+                            gpio: server.gpio_mut(),
+                            sysmgr: &sysmgr,
+                            straps,
+                        };
+                        cli_dispatcher.dispatch(cmd_str, &mut context);
+                        util_zfmt::raw!("hwe> ");
+                        let _ = cli_platform.transact(b"DONE", &mut cmd_buf, Instant::MAX);
+                    }
+                    continue;
+                }
             }
             Err(Error::DeadlineExceeded) => {
                 if server.should_exit() {

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -44,10 +44,20 @@
               type: "channel_handler"
             },
             {
+              name: "cli_platform",
+              type: "channel_handler"
+            },
+            {
+              name: "cli_usb",
+              type: "channel_handler"
+            },
+            {
               name: "uart0_interrupts",
               type: "interrupt",
               irqs: [
-                { name: "uart0_tx_done", number: 3 }
+                { name: "uart0_rx_watermark", number: 2 },
+                { name: "uart0_tx_done", number: 3 },
+                { name: "uart0_rx_timeout", number: 7 }
               ]
             },
             {
@@ -121,6 +131,12 @@
               type: "channel_initiator",
               handler_process: "logmgr",
               handler_object_name: "logger_platform"
+            },
+            {
+              name: "cli_platform",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "cli_platform"
             },
             {
               name: "sysmgr_platform",
@@ -265,6 +281,12 @@
               type: "channel_initiator",
               handler_process: "flash_server",
               handler_object_name: "eflash_usb_service"
+            },
+            {
+              name: "cli_usb",
+              type: "channel_initiator",
+              handler_process: "logmgr",
+              handler_object_name: "cli_usb"
             },
             {
               name: "sysmgr_usb",

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -154,6 +154,10 @@
               ]
             },
             {
+              name: "platform_wait_group",
+              type: "wait_group"
+            },
+            {
               name: "platform_thread",
               kernel_stack_size_bytes: 2048,
               type: "thread"

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -17,7 +17,7 @@
   apps: [
     {
       name: "hwe",
-      flash_size_bytes: 65536,
+      flash_size_bytes: 131072,
       processes: [
         {
           name: "logmgr",

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -17,7 +17,7 @@
   apps: [
     {
       name: "hwe",
-      flash_size_bytes: 49152,
+      flash_size_bytes: 65536,
       processes: [
         {
           name: "logmgr",
@@ -169,8 +169,24 @@
               handler_object_name: "logger_flash"
             },
             {
-              name: "flash_service",
+              name: "eflash_updatemgr_service",
               type: "channel_handler"
+            },
+            {
+              name: "eflash_usb_service",
+              type: "channel_handler"
+            },
+            {
+              name: "spi_flash_updatemgr_service",
+              type: "channel_handler"
+            },
+            {
+              name: "spi_flash_usb_service",
+              type: "channel_handler"
+            },
+            {
+              name: "flash_wait_group",
+              type: "wait_group"
             },
             {
               name: "flash_interrupts",
@@ -196,6 +212,12 @@
               type: "device",
               start_address: 0x41000000,
               size_bytes: 0x200
+            },
+            {
+              name: "spi_host0",
+              type: "device",
+              start_address: 0x40300000,
+              size_bytes: 0x1000
             }
           ]
         },
@@ -242,7 +264,7 @@
               name: "flash_usb",
               type: "channel_initiator",
               handler_process: "flash_server",
-              handler_object_name: "flash_service"
+              handler_object_name: "eflash_usb_service"
             },
             {
               name: "sysmgr_usb",

--- a/target/earlgrey/firmware/hwe/system.json5
+++ b/target/earlgrey/firmware/hwe/system.json5
@@ -145,6 +145,12 @@
               handler_object_name: "sysmgr_service"
             },
             {
+              name: "flash_platform",
+              type: "channel_initiator",
+              handler_process: "flash_server",
+              handler_object_name: "flash_platform_service"
+            },
+            {
               name: "platform_interrupts",
               type: "interrupt",
               irqs: [
@@ -205,6 +211,10 @@
               type: "channel_handler"
             },
             {
+              name: "flash_platform_service",
+              type: "channel_handler"
+            },
+            {
               name: "flash_wait_group",
               type: "wait_group"
             },
@@ -237,6 +247,12 @@
               name: "spi_host0",
               type: "device",
               start_address: 0x40300000,
+              size_bytes: 0x1000
+            },
+            {
+              name: "spi_host1",
+              type: "device",
+              start_address: 0x40310000,
               size_bytes: 0x1000
             }
           ]

--- a/target/earlgrey/firmware/hwe/usbmgr.rs
+++ b/target/earlgrey/firmware/hwe/usbmgr.rs
@@ -33,6 +33,8 @@ use earlgrey_sysmgr_client::SysmgrClient;
 use protocol_usb_cdc_acm::{CdcAcm, CdcAcmBuilder};
 use protocol_usb_dfu::{DfuBuilder, DfuClass};
 use services_flash_client::FlashIpcClient;
+#[cfg(feature = "cli")]
+use util_ipc::IpcChannel;
 use util_ipc::IpcHandle;
 
 use util_error::{AsStatus, ErrorCode};
@@ -285,35 +287,54 @@ fn handle_usb() -> Result<(), ErrorCode> {
                 action.run(&mut usb);
             }
             let _ = syscall::interrupt_ack(handle::USBDEV_INTERRUPTS, wait_return.pending_signals);
-        } else if wakeup == handle::LOGGER_USB {
+            continue;
+        }
+
+        if wakeup == handle::LOGGER_USB {
             // If we got a wakeup signal from the logger task, ack it and note that we have events
             // pending.
             util_zfmt::logger().clear_notifier()?;
             log_events_pending = true;
         }
 
-        // TODO: this just echos CDC-ACM input back into the output.
-        // Decide what to do with input.
+        #[cfg(feature = "cli")]
+        {
+            let slice = cdc_acm.rx_queue.as_slice();
+            if !slice.is_empty() {
+                // Reuse `event` [256 bytes] as a scratch buffer for receiving cooked echo bytes.
+                let cli_usb = IpcHandle::new(handle::CLI_USB);
+                if let Ok(echo_len) = cli_usb.transact(slice, &mut event, Instant::MAX) {
+                    cdc_acm.rx_queue.consume(slice.len());
+                    let echo = &event[..echo_len];
+                    let _ = cdc_acm.tx_queue.push_slice(echo);
+                }
+            }
+        }
+        #[cfg(not(feature = "cli"))]
         while let Some(byte) = cdc_acm.rx_queue.pop() {
             let _ = cdc_acm.tx_queue.push(byte);
         }
 
         // If the CDC-ACM queue is empty and if we have more log events,
         // process them.
-        if log_events_pending && cdc_acm.tx_queue.is_empty() {
+        while log_events_pending && cdc_acm.tx_queue.is_empty() {
             let (cursor, ev) = util_zfmt::logger().get_event(log_cursor, &mut event)?;
             log_cursor = cursor;
             if ev.is_empty() {
                 // No more events.
                 log_events_pending = false;
+                break;
+            }
+            // Render to text and advance the cursor.
+            let mut buf = FixedBuf::<254>::new();
+            if let Some(len) = render_event(ev, &mut buf) {
+                let _ = cdc_acm.tx_queue.push_slice(buf.as_slice());
+                log_cursor += len as u64;
+                break;
             } else {
-                // Render to text and advance the cursor.
-                let mut buf = FixedBuf::<254>::new();
-                if let Some(len) = render_event(ev, &mut buf) {
-                    let _ = cdc_acm.tx_queue.push_slice(buf.as_slice());
-                    let _ = cdc_acm.tx_queue.push_slice(b"\r\n");
-                    log_cursor += len as u64;
-                }
+                // Event cannot be rendered as text (e.g. structured zfmt event);
+                // advance log_cursor by raw event length to avoid stalling.
+                log_cursor += ev.len() as u64;
             }
         }
 

--- a/target/earlgrey/firmware/hwe/usbmgr.rs
+++ b/target/earlgrey/firmware/hwe/usbmgr.rs
@@ -235,7 +235,7 @@ fn handle_usb() -> Result<(), ErrorCode> {
 
     let mut usb = usb_driver::Usb::new(unsafe { usbdev::Usbdev::new() }, USB_CONFIG);
     let mut ep0 = usb_stack::SimpleEp0::new();
-    let mut cdc_acm = CdcAcm::<256, 256>::new(CDC_BUILDER);
+    let mut cdc_acm = CdcAcm::<256, 1024>::new(CDC_BUILDER);
 
     syscall::wait_group_add(
         handle::USB_WAIT_GROUP,
@@ -287,10 +287,7 @@ fn handle_usb() -> Result<(), ErrorCode> {
                 action.run(&mut usb);
             }
             let _ = syscall::interrupt_ack(handle::USBDEV_INTERRUPTS, wait_return.pending_signals);
-            continue;
-        }
-
-        if wakeup == handle::LOGGER_USB {
+        } else if wakeup == handle::LOGGER_USB {
             // If we got a wakeup signal from the logger task, ack it and note that we have events
             // pending.
             util_zfmt::logger().clear_notifier()?;

--- a/target/earlgrey/firmware/transport/logmgr.rs
+++ b/target/earlgrey/firmware/transport/logmgr.rs
@@ -11,7 +11,7 @@ use userspace::syscall::Signals;
 use userspace::time::Instant;
 use userspace::{process_entry, syscall};
 use util_ipc::{IpcChannel, IpcHandle};
-use util_zfmt::{render::render_event, FixedBuf, LogServer, StreamStart, Write, ZfmtU64};
+use util_zfmt::{render::render_event, FixedBuf, LogServer, StreamStart, ZfmtU64};
 use zerocopy::IntoBytes;
 
 use earlgrey_uart_driver::UartDriver;
@@ -25,7 +25,6 @@ use usart_api::backend::{BackendError, IrqMask, Parity, UsartBackend, UsartConfi
 enum TxState {
     Idle,
     Body,
-    Newline,
 }
 
 struct ActiveLog {
@@ -69,8 +68,8 @@ fn service_uart_tx<const N: usize>(
     uart_cursor: &mut u64,
 ) -> Result<(), Error> {
     loop {
-        // 1. Transmit current buffer (body or newline)
-        if active_log.state == TxState::Body || active_log.state == TxState::Newline {
+        // 1. Transmit current buffer
+        if active_log.state == TxState::Body {
             let data = active_log.buf.as_slice();
             // We maintain the invariant that active_log.sent <= data.len() and
             // should never get None. If we do, we halt transmission.
@@ -85,16 +84,7 @@ fn service_uart_tx<const N: usize>(
                 Ok(n) => {
                     active_log.sent += n;
                     if active_log.sent == data.len() {
-                        if active_log.state == TxState::Body {
-                            // Body sent, load newline into buffer
-                            active_log.buf.clear();
-                            let _ = active_log.buf.write_str("\r\n");
-                            active_log.sent = 0;
-                            active_log.state = TxState::Newline;
-                            continue; // Loop again to send newline
-                        } else {
-                            active_log.state = TxState::Idle;
-                        }
+                        active_log.state = TxState::Idle;
                     } else {
                         // Partial write, FIFO full. Enable interrupt and wait.
                         uart.enable_interrupts(IrqMask::TX_IDLE)

--- a/target/earlgrey/firmware/transport/usbmgr.rs
+++ b/target/earlgrey/firmware/transport/usbmgr.rs
@@ -323,7 +323,6 @@ fn handle_usb() -> Result<(), ErrorCode> {
                 let mut buf = FixedBuf::<254>::new();
                 if let Some(len) = render_event(ev, &mut buf) {
                     let _ = cdc_acm.tx_queue.push_slice(buf.as_slice());
-                    let _ = cdc_acm.tx_queue.push_slice(b"\r\n");
                     log_cursor += len as u64;
                 }
             }

--- a/target/earlgrey/pinout/config.rs
+++ b/target/earlgrey/pinout/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use earlgrey_gpio::GpioPin;
-use earlgrey_pinmux::{Pad, PadConfig, Pull};
+use earlgrey_pinmux::{DriveStrength, Pad, PadConfig, Pull, SlewRate};
 use top_earlgrey::{PinmuxOutsel as Outsel, PinmuxPeripheralIn as PeriphIn};
 
 pub enum Config {
@@ -141,29 +141,41 @@ pub const IN_PULL_NONE: PadConfig = PadConfig {
     pull: Pull::None,
     open_drain: false,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };
 pub const IN_PULL_UP: PadConfig = PadConfig {
     pull: Pull::Up,
     open_drain: false,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };
 pub const IN_PULL_DOWN: PadConfig = PadConfig {
     pull: Pull::Down,
     open_drain: false,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };
 pub const OUT_PUSH_PULL: PadConfig = PadConfig {
     pull: Pull::None,
     open_drain: false,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };
 pub const OUT_PULL_UP: PadConfig = PadConfig {
     pull: Pull::Up,
     open_drain: true,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };
 pub const OUT_PULL_DOWN: PadConfig = PadConfig {
     pull: Pull::Down,
     open_drain: true,
     invert: false,
+    slew_rate: SlewRate::Slowest,
+    drive_strength: DriveStrength::Drive0,
 };

--- a/target/earlgrey/services/platform/BUILD.bazel
+++ b/target/earlgrey/services/platform/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
     srcs = [
         "cli/gpio.rs",
         "cli/mod.rs",
+        "cli/sys.rs",
         "lib.rs",
         "reset.rs",
         "server.rs",

--- a/target/earlgrey/services/platform/BUILD.bazel
+++ b/target/earlgrey/services/platform/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
         "cli/gpio.rs",
         "cli/mod.rs",
         "cli/sys.rs",
+        "cli/usb.rs",
         "lib.rs",
         "reset.rs",
         "server.rs",

--- a/target/earlgrey/services/platform/BUILD.bazel
+++ b/target/earlgrey/services/platform/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "platform",
     srcs = [
+        "cli/flash.rs",
         "cli/gpio.rs",
         "cli/mod.rs",
         "cli/sys.rs",
@@ -22,6 +23,7 @@ rust_library(
     edition = "2024",
     deps = [
         "//hal/blocking",
+        "//services/flash:opcode",
         "//target/earlgrey/drivers:gpio",
         "//target/earlgrey/drivers:pinmux",
         "//target/earlgrey/registers:top_earlgrey",

--- a/target/earlgrey/services/platform/BUILD.bazel
+++ b/target/earlgrey/services/platform/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "platform",
     srcs = [
+        "cli/gpio.rs",
         "cli/mod.rs",
         "lib.rs",
         "reset.rs",
@@ -20,6 +21,7 @@ rust_library(
     deps = [
         "//hal/blocking",
         "//target/earlgrey/drivers:gpio",
+        "//target/earlgrey/drivers:pinmux",
         "//target/earlgrey/registers:top_earlgrey",
         "//target/earlgrey/services/sysmgr:client",
         "//target/earlgrey/util",

--- a/target/earlgrey/services/platform/BUILD.bazel
+++ b/target/earlgrey/services/platform/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "platform",
     srcs = [
+        "cli/mod.rs",
         "lib.rs",
         "reset.rs",
         "server.rs",
@@ -20,6 +21,7 @@ rust_library(
         "//hal/blocking",
         "//target/earlgrey/drivers:gpio",
         "//target/earlgrey/registers:top_earlgrey",
+        "//target/earlgrey/services/sysmgr:client",
         "//target/earlgrey/util",
         "//util/error",
         "//util/ipc",

--- a/target/earlgrey/services/platform/README.md
+++ b/target/earlgrey/services/platform/README.md
@@ -90,3 +90,10 @@ stateDiagram-v2
 *   **Running**: Main loop. Listens for interrupts:
     *   `RST_MON0_N` / `RST_MON1_N` falling edge: Transitions back to `LatchReset` to execute a reset.
     *   `USB_PRESENCE_N` edge: Updates the `USB_MUX_CTRL` output (High on unplug/rising edge, Low on plug-in/falling edge).
+
+## Command Line Interface (CLI)
+
+The Platform Service hosts an interactive hierarchical CLI dispatcher accessible over physical UART0 and USB CDC-ACM virtual serial when compiled with the `cli` feature.
+
+See [CLI Interface & Connection Guide](cli/README.md) for serial port identification, connection instructions (via `minicom` or `screen`), and command hierarchy details.
+

--- a/target/earlgrey/services/platform/cli/README.md
+++ b/target/earlgrey/services/platform/cli/README.md
@@ -87,3 +87,37 @@ screen /dev/serial/by-id/usb-Google_Inc._OpenPRoT_Earlgrey_*-if00 115200
 ```
 
 To disconnect and kill `screen`: press `Ctrl-A`, followed by `\` (or `Ctrl-A` then `k`).
+
+---
+
+## Supported CLI Commands
+
+### Root Commands
+- `help`: Displays root command hierarchy overview.
+
+### 1. `gpio` Hierarchy
+- `gpio help`: Displays GPIO command summary.
+- `gpio list`: Lists all configured GPIO pins with current direction, input level, and output level.
+- `gpio read <pin>`: Reads GPIO input, output, and OE levels (supports numeric index, signal name e.g. `RST_CTRL0_N`, or pad name e.g. `IOA0`).
+- `gpio write <pin> <0|1>`: Drives GPIO output level with immediate readback.
+- `gpio config <pin> <in|out|inout> [none|pullup|pulldown]`: Configures pin direction and internal pull resistor.
+- `gpio attr <pin> <od|pp>`: Configures pad open-drain or push-pull mode.
+
+### 2. `sys` Hierarchy
+- `sys help`: Displays system command summary.
+- `sys info`: Displays OpenTitan chip ID, ROM_EXT slot/version, active application slot, and reset reason.
+- `sys id`: Displays 256-bit OpenTitan hardware device ID.
+- `sys reset`: Triggers a software system reboot via `sysmgr`.
+
+### 3. `usb` Hierarchy
+- `usb help`: Displays USB command summary.
+- `usb info`: Displays USB cable presence state, multiplexer routing, and hardware pin mappings.
+- `usb mux <host|device>`: Manually switches the physical USB multiplexer (`USB_MUX_CTRL`).
+
+### 4. `flash` Hierarchy
+- `flash help`: Displays SPI flash command summary.
+- `flash info`: Displays external SPI flash multiplexer state, routing, and pin mappings.
+- `flash mux <en|dis>`: Enables or disables the external SPI multiplexer (`SPI_MUX_EN_N`).
+- `flash route <target|host>`: Switches SPI multiplexer route between target and host (`SPI_MUX_CTRL`).
+- `flash read-id [0|1]`: Reads the JEDEC ID, manufacturer name, device model, and density from the external SPI flash. When the argument is omitted, automatically reads the EEPROM not currently routed to the upstream device to avoid bus conflicts.
+

--- a/target/earlgrey/services/platform/cli/README.md
+++ b/target/earlgrey/services/platform/cli/README.md
@@ -1,0 +1,89 @@
+# Platform CLI Interface & Connection Guide
+
+This directory contains the Platform Command Line Interface (CLI) dispatcher framework and command hierarchies for Earlgrey Hardware Enablement (HWE) firmware.
+
+The CLI is accessible concurrently over both:
+1. **Physical UART0 Console**: Hardware UART exposed via HyperDebug.
+2. **USB CDC-ACM Virtual Serial**: Earlgrey native Full-Speed USB composite endpoint.
+
+---
+
+## Serial Port Identification
+
+The most reliable way to identify serial devices on Linux is via `/dev/serial/by-id/`, where `udev` creates persistent symlinks based on USB vendor/product IDs, serial numbers, and interface numbers:
+
+```bash
+ls -l /dev/serial/by-id/
+```
+
+### 1. Physical UART0 (Hardware Console)
+- **Symlink**: `/dev/serial/by-id/usb-Google_LLC_HyperDebug_CMSIS-DAP_*-if03-port0`
+- **Device Node**: Typically `/dev/ttyUSB5`
+- **Description**: HyperDebug exposes several USB interfaces. Interface 3 (`if03`) corresponds to `UART2` in HyperDebug firmware, which OpenTitan board configurations (`hyperdebug_chipwhisperer.json`) route to the Earlgrey physical `console` (UART0).
+
+### 2. USB CDC-ACM (Virtual Serial CLI)
+- **Symlink**: `/dev/serial/by-id/usb-Google_Inc._OpenPRoT_Earlgrey_*-if00`
+- **Device Node**: Typically `/dev/ttyACM2` (VID `0x18d1`, PID `0x503a`)
+- **Description**: Earlgrey's native USB Full-Speed device CDC-ACM class. Appears once firmware has booted and VBUS strapping is enabled.
+
+### 3. HyperDebug Control Shell (Reference)
+- **Symlink**: `/dev/serial/by-id/usb-Google_LLC_HyperDebug_CMSIS-DAP_*-if00-port0`
+- **Device Node**: Typically `/dev/ttyUSB4`
+- **Description**: The internal control shell for the HyperDebug MCU itself (used for manual hardware strap manipulation, power, and resets).
+
+---
+
+## Connecting with `minicom`
+
+### Port Settings
+- **Baud Rate**: `115200`
+- **Data Bits**: `8`
+- **Parity**: `None`
+- **Stop Bits**: `1`
+- **Hardware Flow Control (RTS/CTS)**: `No`
+- **Software Flow Control (XON/XOFF)**: `No`
+
+### Connecting to Physical UART0
+Using the persistent `/dev/serial/by-id/` symlink prevents connecting to the wrong port if enumeration indices change:
+
+```bash
+minicom -w -o -D /dev/serial/by-id/usb-Google_LLC_HyperDebug_CMSIS-DAP_*-if03-port0 -b 115200
+```
+Or directly with the device node:
+```bash
+minicom -w -o -D /dev/ttyUSB5 -b 115200
+```
+
+### Connecting to USB CDC-ACM
+```bash
+minicom -w -o -D /dev/serial/by-id/usb-Google_Inc._OpenPRoT_Earlgrey_*-if00 -b 115200
+```
+Or directly with the device node:
+```bash
+minicom -w -o -D /dev/ttyACM2 -b 115200
+```
+
+### Command Flags:
+- `-w`: Enable line-wrapping.
+- `-o`: Skip modem initialization strings.
+- `-D <path>`: Specify the device path.
+- `-b 115200`: Set the baud rate.
+
+### Minicom Navigation Tips:
+- **Interactive Prompt (`hwe> `)**: The console displays the `hwe> ` prompt once boot finishes, after each command finishes executing, and whenever you press **Enter** on an empty line as a liveness probe.
+- **Toggle Hardware Flow Control**: If typed characters are not echoing or appearing, press `Ctrl-A`, then `O`, navigate to `Serial port setup`, press `F` to toggle `Hardware Flow Control` to `No`, and press `Enter`.
+- **Exit Minicom**: Press `Ctrl-A`, then `Q` (exit without reset) or `Ctrl-A`, then `X`.
+
+---
+
+## Alternative: Connecting with `screen`
+
+```bash
+# Physical UART0
+screen /dev/serial/by-id/usb-Google_LLC_HyperDebug_CMSIS-DAP_*-if03-port0 115200
+
+# USB CDC-ACM
+screen /dev/serial/by-id/usb-Google_Inc._OpenPRoT_Earlgrey_*-if00 115200
+```
+
+To disconnect and kill `screen`: press `Ctrl-A`, followed by `\` (or `Ctrl-A` then `k`).

--- a/target/earlgrey/services/platform/cli/flash.rs
+++ b/target/earlgrey/services/platform/cli/flash.rs
@@ -1,0 +1,323 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::{CliContext, CliError, CommandHandler, TokenIter};
+use util_ipc::IpcChannel;
+use zerocopy::IntoBytes;
+
+pub struct FlashCommandHandler;
+
+impl FlashCommandHandler {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn print_help(&self) {
+        util_zfmt::debug!("Flash Commands:");
+        util_zfmt::debug!("  info                - Display SPI flash multiplexer and pin status");
+        util_zfmt::debug!("  mux <en|dis>        - Enable or disable SPI multiplexer");
+        util_zfmt::debug!("  route <target|host> - Configure SPI multiplexer route");
+        util_zfmt::debug!("  read-id [0|1]       - Read SPI flash JEDEC ID and chip information");
+        util_zfmt::debug!("  help                - Display this help message");
+    }
+
+    fn handle_info(&self, ctx: &mut CliContext<'_>) -> Result<(), CliError> {
+        let enabled = ctx
+            .spi_mux
+            .is_mux_enabled(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+        let host = ctx
+            .spi_mux
+            .is_route_host(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+        util_zfmt::debug!("SPI Flash Status:");
+        util_zfmt::debug!(
+            "  Mux:   {mux}",
+            mux = if enabled { "enabled" } else { "disabled" }
+        );
+        util_zfmt::debug!(
+            "  Route: {route}",
+            route = if host { "host" } else { "target" }
+        );
+        util_zfmt::debug!(
+            "  Pins:  en_n=GPIO {en}, ctrl=GPIO {ctrl}, rst_n=GPIO {rst}",
+            en = u32::from(ctx.spi_mux.spi_mux_en_n),
+            ctrl = u32::from(ctx.spi_mux.spi_mux_ctrl),
+            rst = u32::from(ctx.spi_mux.spi_reset_n),
+        );
+        util_zfmt::debug!(
+            "  WP:    host0_wp_n=GPIO {wp0}, host1_wp_n=GPIO {wp1}",
+            wp0 = u32::from(ctx.spi_mux.spi_host0_wp_n),
+            wp1 = u32::from(ctx.spi_mux.spi_host1_wp_n),
+        );
+        Ok(())
+    }
+
+    fn handle_mux(
+        &self,
+        tokens: &mut TokenIter<'_>,
+        ctx: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            Some("en") | Some("enable") => {
+                ctx.spi_mux
+                    .set_mux_enabled(ctx.gpio, true)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("SPI multiplexer enabled");
+                Ok(())
+            }
+            Some("dis") | Some("disable") => {
+                ctx.spi_mux
+                    .set_mux_enabled(ctx.gpio, false)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("SPI multiplexer disabled");
+                Ok(())
+            }
+            _ => {
+                util_zfmt::debug!("Usage: flash mux <en|dis>");
+                Err(CliError::InvalidArguments)
+            }
+        }
+    }
+
+    fn handle_route(
+        &self,
+        tokens: &mut TokenIter<'_>,
+        ctx: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            Some("target") => {
+                ctx.spi_mux
+                    .set_route_host(ctx.gpio, false)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("SPI multiplexer routed to target");
+                Ok(())
+            }
+            Some("host") => {
+                ctx.spi_mux
+                    .set_route_host(ctx.gpio, true)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("SPI multiplexer routed to host");
+                Ok(())
+            }
+            _ => {
+                util_zfmt::debug!("Usage: flash route <target|host>");
+                Err(CliError::InvalidArguments)
+            }
+        }
+    }
+
+    fn handle_read_id(
+        &self,
+        tokens: &mut TokenIter<'_>,
+        ctx: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        let mux_enabled = ctx
+            .spi_mux
+            .is_mux_enabled(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+        let route_host = ctx
+            .spi_mux
+            .is_route_host(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+
+        let eeprom_idx = match tokens.next_token() {
+            Some("0") => {
+                if mux_enabled && !route_host {
+                    util_zfmt::debug!("Error: EEPROM 0 is currently routed to upstream device. Change route with 'flash route' or disable mux first.");
+                    return Err(CliError::HardwareError);
+                }
+                0u8
+            }
+            Some("1") => {
+                if mux_enabled && route_host {
+                    util_zfmt::debug!("Error: EEPROM 1 is currently routed to upstream device. Change route with 'flash route' or disable mux first.");
+                    return Err(CliError::HardwareError);
+                }
+                1u8
+            }
+            Some(_) => {
+                util_zfmt::debug!("Usage: flash read-id [0|1]");
+                return Err(CliError::InvalidArguments);
+            }
+            None => {
+                if mux_enabled {
+                    if route_host {
+                        0u8
+                    } else {
+                        1u8
+                    }
+                } else {
+                    0u8
+                }
+            }
+        };
+
+        let op = services_flash_opcode::ReadIdOp {
+            eeprom_index: eeprom_idx,
+        };
+        let mut status = 0u32;
+        let mut jedec = services_flash_opcode::JedecIdResp::default();
+        let _ = ctx
+            .flash_ipc
+            .transact(
+                &[
+                    services_flash_opcode::IPC_OP_FLASH_READ_ID.as_bytes(),
+                    op.as_bytes(),
+                ],
+                &mut [status.as_mut_bytes(), jedec.as_mut_bytes()],
+                userspace::time::Instant::MAX,
+            )
+            .map_err(|_| CliError::HardwareError)?;
+
+        if status != 0 {
+            util_zfmt::debug!(
+                "Error: Failed to read JEDEC ID from EEPROM {idx} (error {status:08x}).",
+                idx = u32::from(eeprom_idx),
+                status = status
+            );
+            return Err(CliError::HardwareError);
+        }
+
+        let mfr = jedec.manufacturer;
+        let mem_type = jedec.memory_type;
+        let cap = jedec.capacity_code;
+
+        if (mfr == 0xFF && mem_type == 0xFF && cap == 0xFF)
+            || (mfr == 0 && mem_type == 0 && cap == 0)
+        {
+            util_zfmt::debug!(
+                "Error: No response from EEPROM {idx} (JEDEC ID: {mfr:02x} {mem:02x} {cap:02x}).",
+                idx = u32::from(eeprom_idx),
+                mfr = u32::from(mfr),
+                mem = u32::from(mem_type),
+                cap = u32::from(cap),
+            );
+            return Err(CliError::HardwareError);
+        }
+
+        let mfr_str = match mfr {
+            0xEF => "Winbond",
+            0xC2 => "Macronix",
+            0x20 => "Micron",
+            0x1F => "Adesto",
+            0x9D => "ISSI",
+            0x01 => "Spansion",
+            0xBF => "SST",
+            0xC8 => "GigaDevice",
+            _ => "Unknown",
+        };
+
+        let device_str = match (mfr, mem_type, cap) {
+            (0xEF, _, 0x15) => "W25Q16",
+            (0xEF, _, 0x16) => "W25Q32",
+            (0xEF, _, 0x17) => "W25Q64",
+            (0xEF, _, 0x18) => "W25Q128",
+            (0xEF, _, 0x19) => "W25Q256",
+            (0xEF, _, 0x20) => "W25Q512",
+            (0xC2, 0x20, 0x15) => "MX25L16",
+            (0xC2, 0x20, 0x16) => "MX25L32",
+            (0xC2, 0x20, 0x17) => "MX25L64",
+            (0xC2, 0x20, 0x18) => "MX25L128",
+            (0xC2, 0x20, 0x19) => "MX25L256",
+            (0xC2, 0x20, 0x1A) => "MX25L512",
+            (0xC2, 0x25, 0x38) => "MX25U128",
+            (0xC2, 0x25, 0x39) => "MX25U256",
+            (0xC2, 0x25, 0x3A) => "MX25U51245G / MX66U51235F",
+            (0xC2, _, 0x3A) => "MX25U512 / MX66U512",
+            (0xC2, _, 0x1A) => "MX25L512",
+            _ => "Generic NOR",
+        };
+
+        util_zfmt::debug!("EEPROM {idx} Status:", idx = u32::from(eeprom_idx));
+        util_zfmt::debug!(
+            "  JEDEC ID:     0x{mfr:02x} 0x{mem:02x} 0x{cap:02x}",
+            mfr = u32::from(mfr),
+            mem = u32::from(mem_type),
+            cap = u32::from(cap),
+        );
+        util_zfmt::debug!(
+            "  Manufacturer: {name} (0x{mfr:02x})",
+            name = mfr_str,
+            mfr = u32::from(mfr)
+        );
+        util_zfmt::debug!("  Device:       {dev}", dev = device_str);
+
+        let density_power = if (0x10..=0x24).contains(&cap) {
+            Some(cap)
+        } else if (0x30..=0x3C).contains(&cap) {
+            // Macronix 1.8V family uses 0x30 base (e.g. 0x3A -> 2^26 = 64 MiB / 512 Mbit)
+            Some(0x10 + (cap & 0x0F))
+        } else {
+            None
+        };
+
+        if let Some(power) = density_power {
+            let bytes = 1usize << power;
+            let mib = bytes / (1024 * 1024);
+            if mib > 0 {
+                util_zfmt::debug!(
+                    "  Density:      {mib} MiB ({bytes} bytes)",
+                    mib = mib as u32,
+                    bytes = bytes as u32
+                );
+            } else {
+                let kib = bytes / 1024;
+                util_zfmt::debug!(
+                    "  Density:      {kib} KiB ({bytes} bytes)",
+                    kib = kib as u32,
+                    bytes = bytes as u32
+                );
+            }
+        } else {
+            util_zfmt::debug!("  Density:      Unknown");
+        }
+
+        Ok(())
+    }
+}
+
+impl CommandHandler for FlashCommandHandler {
+    fn name(&self) -> &'static str {
+        "flash"
+    }
+
+    fn description(&self) -> &'static str {
+        "Flash status and memory info"
+    }
+
+    fn execute(
+        &mut self,
+        tokens: &mut TokenIter<'_>,
+        context: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            None | Some("help") => {
+                self.print_help();
+                Ok(())
+            }
+            Some("info") => self.handle_info(context),
+            Some("mux") => self.handle_mux(tokens, context),
+            Some("route") => self.handle_route(tokens, context),
+            Some("read-id") | Some("id") => self.handle_read_id(tokens, context),
+            Some(_) => {
+                util_zfmt::debug!(
+                    "Unknown flash subcommand. Type 'flash help' for available commands."
+                );
+                Err(CliError::UnknownCommand)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flash_command_metadata() {
+        let handler = FlashCommandHandler::new();
+        assert_eq!(handler.name(), "flash");
+        assert_eq!(handler.description(), "Flash status and memory info");
+    }
+}

--- a/target/earlgrey/services/platform/cli/gpio.rs
+++ b/target/earlgrey/services/platform/cli/gpio.rs
@@ -1,0 +1,550 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::{CliContext, CliError, CommandHandler, TokenIter};
+use earlgrey_gpio::{EarlGreyPinConfig, GpioMask};
+use earlgrey_pinmux::{Pad, Pull};
+use openprot_hal_blocking::gpio_port::GpioPort;
+
+pub struct GpioPinDesc {
+    pub index: u32,
+    pub name: &'static str,
+    pub pad: Option<Pad>,
+}
+
+pub const KNOWN_PINS: &[GpioPinDesc] = &[
+    GpioPinDesc {
+        index: 0,
+        name: "RST_CTRL0_N",
+        pad: Some(Pad::IOA0),
+    },
+    GpioPinDesc {
+        index: 1,
+        name: "RST_CTRL1_N",
+        pad: Some(Pad::IOA1),
+    },
+    GpioPinDesc {
+        index: 2,
+        name: "SPI_RESET_N",
+        pad: Some(Pad::IOA7),
+    },
+    GpioPinDesc {
+        index: 3,
+        name: "SPI_MUX_EN_N",
+        pad: Some(Pad::IOB7),
+    },
+    GpioPinDesc {
+        index: 4,
+        name: "SPI_MUX_CTRL",
+        pad: Some(Pad::IOB8),
+    },
+    GpioPinDesc {
+        index: 5,
+        name: "SPI_HOST0_WP_N",
+        pad: Some(Pad::IOA3),
+    },
+    GpioPinDesc {
+        index: 6,
+        name: "SPI_HOST1_WP_N",
+        pad: Some(Pad::IOA6),
+    },
+    GpioPinDesc {
+        index: 7,
+        name: "USB_MUX_CTRL",
+        pad: Some(Pad::IOC6),
+    },
+    GpioPinDesc {
+        index: 8,
+        name: "EXT_DEBUG_N",
+        pad: Some(Pad::IOC9),
+    },
+    GpioPinDesc {
+        index: 16,
+        name: "USB_PRESENCE_N",
+        pad: Some(Pad::IOR11),
+    },
+    GpioPinDesc {
+        index: 17,
+        name: "RST_MON0_N",
+        pad: Some(Pad::IOA2),
+    },
+    GpioPinDesc {
+        index: 18,
+        name: "RST_MON1_N",
+        pad: Some(Pad::IOA5),
+    },
+    GpioPinDesc {
+        index: 22,
+        name: "SW_STRAP0",
+        pad: Some(Pad::IOC0),
+    },
+    GpioPinDesc {
+        index: 23,
+        name: "SW_STRAP1",
+        pad: Some(Pad::IOC1),
+    },
+    GpioPinDesc {
+        index: 24,
+        name: "SW_STRAP2",
+        pad: Some(Pad::IOC2),
+    },
+];
+
+pub fn pad_name(pad: Pad) -> &'static str {
+    match pad {
+        Pad::IOA0 => "IOA0",
+        Pad::IOA1 => "IOA1",
+        Pad::IOA2 => "IOA2",
+        Pad::IOA3 => "IOA3",
+        Pad::IOA4 => "IOA4",
+        Pad::IOA5 => "IOA5",
+        Pad::IOA6 => "IOA6",
+        Pad::IOA7 => "IOA7",
+        Pad::IOA8 => "IOA8",
+        Pad::IOB0 => "IOB0",
+        Pad::IOB1 => "IOB1",
+        Pad::IOB2 => "IOB2",
+        Pad::IOB3 => "IOB3",
+        Pad::IOB4 => "IOB4",
+        Pad::IOB5 => "IOB5",
+        Pad::IOB6 => "IOB6",
+        Pad::IOB7 => "IOB7",
+        Pad::IOB8 => "IOB8",
+        Pad::IOB9 => "IOB9",
+        Pad::IOB10 => "IOB10",
+        Pad::IOB11 => "IOB11",
+        Pad::IOB12 => "IOB12",
+        Pad::IOC0 => "IOC0",
+        Pad::IOC1 => "IOC1",
+        Pad::IOC2 => "IOC2",
+        Pad::IOC3 => "IOC3",
+        Pad::IOC4 => "IOC4",
+        Pad::IOC5 => "IOC5",
+        Pad::IOC6 => "IOC6",
+        Pad::IOC7 => "IOC7",
+        Pad::IOC8 => "IOC8",
+        Pad::IOC9 => "IOC9",
+        Pad::IOC10 => "IOC10",
+        Pad::IOC11 => "IOC11",
+        Pad::IOC12 => "IOC12",
+        Pad::IOR0 => "IOR0",
+        Pad::IOR1 => "IOR1",
+        Pad::IOR2 => "IOR2",
+        Pad::IOR3 => "IOR3",
+        Pad::IOR4 => "IOR4",
+        Pad::IOR5 => "IOR5",
+        Pad::IOR6 => "IOR6",
+        Pad::IOR7 => "IOR7",
+        Pad::IOR10 => "IOR10",
+        Pad::IOR11 => "IOR11",
+        Pad::IOR12 => "IOR12",
+        Pad::IOR13 => "IOR13",
+        _ => "OTHER",
+    }
+}
+
+pub fn resolve_pin(token: &str) -> Option<(u32, Option<Pad>)> {
+    if let Ok(idx) = token.parse::<u32>() {
+        if idx < 32 {
+            let pad = KNOWN_PINS
+                .iter()
+                .find(|p| p.index == idx)
+                .and_then(|p| p.pad);
+            return Some((idx, pad));
+        }
+    }
+    if token.len() > 4 && token[..4].eq_ignore_ascii_case("gpio") {
+        if let Ok(idx) = token[4..].parse::<u32>() {
+            if idx < 32 {
+                let pad = KNOWN_PINS
+                    .iter()
+                    .find(|p| p.index == idx)
+                    .and_then(|p| p.pad);
+                return Some((idx, pad));
+            }
+        }
+    }
+    for p in KNOWN_PINS {
+        if p.name.eq_ignore_ascii_case(token) {
+            return Some((p.index, p.pad));
+        }
+        if let Some(pad) = p.pad {
+            if pad_name(pad).eq_ignore_ascii_case(token) {
+                return Some((p.index, p.pad));
+            }
+        }
+    }
+    None
+}
+
+pub struct GpioCommandHandler;
+
+impl GpioCommandHandler {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn print_help(&self) {
+        util_zfmt::debug!("GPIO Commands:");
+        util_zfmt::debug!(
+            "  list                              - List configured GPIO pins and status"
+        );
+        util_zfmt::debug!("  read <pin>                        - Read GPIO input/output state");
+        util_zfmt::debug!("  write <pin> <0|1>                 - Drive output level with readback");
+        util_zfmt::debug!(
+            "  config <pin> <in|out|inout> [pull] - Configure direction and pull (none/up/down)"
+        );
+        util_zfmt::debug!(
+            "  attr <pin> <od|pp>                - Configure pad open-drain or push-pull"
+        );
+        util_zfmt::debug!("  help                              - Display this help message");
+    }
+}
+
+impl CommandHandler for GpioCommandHandler {
+    fn name(&self) -> &'static str {
+        "gpio"
+    }
+
+    fn description(&self) -> &'static str {
+        "GPIO pin configuration and control"
+    }
+
+    fn execute(
+        &mut self,
+        tokens: &mut TokenIter<'_>,
+        context: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        let Some(subcmd) = tokens.next_token() else {
+            self.print_help();
+            return Ok(());
+        };
+
+        match subcmd {
+            "help" => {
+                self.print_help();
+                Ok(())
+            }
+            "list" => {
+                let in_mask = context
+                    .gpio
+                    .read_input()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0;
+                let out_mask = context
+                    .gpio
+                    .read_output()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0;
+                let oe_mask = context
+                    .gpio
+                    .read_oe()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0;
+
+                util_zfmt::debug!("GPIO Pin Status:");
+                for p in KNOWN_PINS {
+                    let in_val = ((in_mask >> p.index) & 1) as u32;
+                    let out_val = ((out_mask >> p.index) & 1) as u32;
+                    let oe_val = ((oe_mask >> p.index) & 1) as u32;
+                    let dir = if oe_val != 0 { "OUT" } else { "IN" };
+                    let pad_str = p.pad.map(pad_name).unwrap_or("none");
+                    util_zfmt::debug!(
+                        "  GPIO {idx:02} ({name}/{pad}): dir={dir}, in={in_val}, out={out_val}",
+                        idx = p.index,
+                        name = p.name,
+                        pad = pad_str,
+                        dir = dir,
+                        in_val = in_val,
+                        out_val = out_val,
+                    );
+                }
+                Ok(())
+            }
+            "read" => {
+                let Some(pin_token) = tokens.next_token() else {
+                    util_zfmt::debug!("Usage: gpio read <pin>");
+                    return Err(CliError::MissingArguments);
+                };
+                let Some((pin_idx, _)) = resolve_pin(pin_token) else {
+                    util_zfmt::debug!("Unknown pin: {pin}", pin = pin_token);
+                    return Err(CliError::InvalidArguments);
+                };
+                let in_val = ((context
+                    .gpio
+                    .read_input()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                let out_val = ((context
+                    .gpio
+                    .read_output()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                let oe_val = ((context
+                    .gpio
+                    .read_oe()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                util_zfmt::debug!(
+                    "GPIO {pin}: in={in_val} (oe={oe_val}, out={out_val})",
+                    pin = pin_token,
+                    in_val = in_val,
+                    oe_val = oe_val,
+                    out_val = out_val,
+                );
+                Ok(())
+            }
+            "write" => {
+                let Some(pin_token) = tokens.next_token() else {
+                    util_zfmt::debug!("Usage: gpio write <pin> <0|1>");
+                    return Err(CliError::MissingArguments);
+                };
+                let Some(val_token) = tokens.next_token() else {
+                    util_zfmt::debug!("Usage: gpio write <pin> <0|1>");
+                    return Err(CliError::MissingArguments);
+                };
+                let Some((pin_idx, _)) = resolve_pin(pin_token) else {
+                    util_zfmt::debug!("Unknown pin: {pin}", pin = pin_token);
+                    return Err(CliError::InvalidArguments);
+                };
+                let val = match val_token {
+                    "0" | "low" => 0u32,
+                    "1" | "high" => 1u32,
+                    _ => {
+                        util_zfmt::debug!("Invalid level: {val}. Expected 0 or 1", val = val_token);
+                        return Err(CliError::InvalidArguments);
+                    }
+                };
+
+                let mask = GpioMask(1 << pin_idx);
+                if val == 1 {
+                    context
+                        .gpio
+                        .set_reset(mask, GpioMask(0))
+                        .map_err(|_| CliError::HardwareError)?;
+                } else {
+                    context
+                        .gpio
+                        .set_reset(GpioMask(0), mask)
+                        .map_err(|_| CliError::HardwareError)?;
+                }
+
+                // Immediate readback
+                let out_val = ((context
+                    .gpio
+                    .read_output()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                let in_val = ((context
+                    .gpio
+                    .read_input()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                let oe_val = ((context
+                    .gpio
+                    .read_oe()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                util_zfmt::debug!(
+                    "GPIO {pin} written {val} -> readback: out={out_val}, in={in_val}, oe={oe_val}",
+                    pin = pin_token,
+                    val = val,
+                    out_val = out_val,
+                    in_val = in_val,
+                    oe_val = oe_val,
+                );
+                Ok(())
+            }
+            "config" => {
+                let Some(pin_token) = tokens.next_token() else {
+                    util_zfmt::debug!(
+                        "Usage: gpio config <pin> <in|out|inout> [none|pullup|pulldown]"
+                    );
+                    return Err(CliError::MissingArguments);
+                };
+                let Some(dir_token) = tokens.next_token() else {
+                    util_zfmt::debug!(
+                        "Usage: gpio config <pin> <in|out|inout> [none|pullup|pulldown]"
+                    );
+                    return Err(CliError::MissingArguments);
+                };
+                let Some((pin_idx, pad)) = resolve_pin(pin_token) else {
+                    util_zfmt::debug!("Unknown pin: {pin}", pin = pin_token);
+                    return Err(CliError::InvalidArguments);
+                };
+                let (is_input, is_output) = match dir_token {
+                    "in" | "input" => (true, false),
+                    "out" | "output" => (false, true),
+                    "inout" => (true, true),
+                    _ => {
+                        util_zfmt::debug!(
+                            "Invalid direction: {dir}. Expected in, out, or inout",
+                            dir = dir_token
+                        );
+                        return Err(CliError::InvalidArguments);
+                    }
+                };
+                let pull_token = tokens.next_token().unwrap_or("none");
+                let pull = match pull_token {
+                    "none" => Pull::None,
+                    "up" | "pullup" => Pull::Up,
+                    "down" | "pulldown" => Pull::Down,
+                    _ => {
+                        util_zfmt::debug!(
+                            "Invalid pull: {pull}. Expected none, up, or down",
+                            pull = pull_token
+                        );
+                        return Err(CliError::InvalidArguments);
+                    }
+                };
+
+                let mask = GpioMask(1 << pin_idx);
+                let cfg = EarlGreyPinConfig {
+                    is_input,
+                    is_output,
+                    input_filter: false,
+                    pad,
+                    pull,
+                };
+                context
+                    .gpio
+                    .configure(mask, cfg)
+                    .map_err(|_| CliError::HardwareError)?;
+
+                // Immediate readback
+                let oe_val = ((context
+                    .gpio
+                    .read_oe()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                let in_val = ((context
+                    .gpio
+                    .read_input()
+                    .map_err(|_| CliError::HardwareError)?
+                    .0
+                    >> pin_idx)
+                    & 1) as u32;
+                util_zfmt::debug!(
+                    "GPIO {pin} configured -> oe={oe_val}, in={in_val}",
+                    pin = pin_token,
+                    oe_val = oe_val,
+                    in_val = in_val,
+                );
+                Ok(())
+            }
+            "attr" => {
+                let Some(pin_token) = tokens.next_token() else {
+                    util_zfmt::debug!("Usage: gpio attr <pin> <od|pp>");
+                    return Err(CliError::MissingArguments);
+                };
+                let Some(mode_token) = tokens.next_token() else {
+                    util_zfmt::debug!("Usage: gpio attr <pin> <od|pp>");
+                    return Err(CliError::MissingArguments);
+                };
+                let Some((_pin_idx, pad)) = resolve_pin(pin_token) else {
+                    util_zfmt::debug!("Unknown pin: {pin}", pin = pin_token);
+                    return Err(CliError::InvalidArguments);
+                };
+                let open_drain = match mode_token {
+                    "od" | "opendrain" => true,
+                    "pp" | "pushpull" => false,
+                    _ => {
+                        util_zfmt::debug!(
+                            "Invalid attr mode: {mode}. Expected od or pp",
+                            mode = mode_token
+                        );
+                        return Err(CliError::InvalidArguments);
+                    }
+                };
+                let Some(pad) = pad else {
+                    util_zfmt::debug!("GPIO {pin} has no associated pad", pin = pin_token);
+                    return Err(CliError::InvalidArguments);
+                };
+
+                let mut pad_cfg = context
+                    .gpio
+                    .pinmux
+                    .get_pad_config(pad)
+                    .map_err(|_| CliError::HardwareError)?;
+                pad_cfg.open_drain = open_drain;
+                context
+                    .gpio
+                    .pinmux
+                    .configure_pad(pad, &pad_cfg)
+                    .map_err(|_| CliError::HardwareError)?;
+
+                // Immediate readback
+                let rb = context
+                    .gpio
+                    .pinmux
+                    .get_pad_config(pad)
+                    .map_err(|_| CliError::HardwareError)?;
+                let mode_str = if rb.open_drain {
+                    "open-drain"
+                } else {
+                    "push-pull"
+                };
+                util_zfmt::debug!(
+                    "GPIO {pin} ({pad}) pad attr -> {mode}",
+                    pin = pin_token,
+                    pad = pad_name(pad),
+                    mode = mode_str,
+                );
+                Ok(())
+            }
+            _ => {
+                util_zfmt::debug!("Unknown gpio subcommand. Type 'gpio help' for usage.");
+                Err(CliError::UnknownCommand)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_pin_numeric() {
+        assert_eq!(resolve_pin("0"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("1"), Some((1, Some(Pad::IOA1))));
+        assert_eq!(resolve_pin("16"), Some((16, Some(Pad::IOR11))));
+        assert_eq!(resolve_pin("31"), Some((31, None)));
+        assert_eq!(resolve_pin("32"), None);
+    }
+
+    #[test]
+    fn test_resolve_pin_gpio_prefix() {
+        assert_eq!(resolve_pin("gpio0"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("GPIO1"), Some((1, Some(Pad::IOA1))));
+        assert_eq!(resolve_pin("gpio16"), Some((16, Some(Pad::IOR11))));
+    }
+
+    #[test]
+    fn test_resolve_pin_name() {
+        assert_eq!(resolve_pin("RST_CTRL0_N"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("rst_ctrl0_n"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("EXT_DEBUG_N"), Some((8, Some(Pad::IOC9))));
+    }
+
+    #[test]
+    fn test_resolve_pin_pad() {
+        assert_eq!(resolve_pin("IOA0"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("ioa0"), Some((0, Some(Pad::IOA0))));
+        assert_eq!(resolve_pin("IOC9"), Some((8, Some(Pad::IOC9))));
+    }
+}

--- a/target/earlgrey/services/platform/cli/mod.rs
+++ b/target/earlgrey/services/platform/cli/mod.rs
@@ -1,0 +1,152 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use earlgrey_gpio::EarlGreyGpio;
+use earlgrey_sysmgr_client::SysmgrClient;
+use util_ipc::IpcHandle;
+
+/// Zero-allocation whitespace-separated token iterator for CLI parsing.
+pub struct TokenIter<'a> {
+    input: &'a str,
+}
+
+impl<'a> TokenIter<'a> {
+    pub const fn new(input: &'a str) -> Self {
+        Self { input }
+    }
+
+    pub fn next_token(&mut self) -> Option<&'a str> {
+        let bytes = self.input.as_bytes();
+        let mut start = 0;
+        while start < bytes.len() && (bytes[start] == b' ' || bytes[start] == b'\t') {
+            start += 1;
+        }
+        if start >= bytes.len() {
+            self.input = "";
+            return None;
+        }
+
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != b' ' && bytes[end] != b'\t' {
+            end += 1;
+        }
+
+        let token = &self.input[start..end];
+        self.input = &self.input[end..];
+        Some(token)
+    }
+
+    pub fn remaining(&self) -> &'a str {
+        self.input.trim_start()
+    }
+}
+
+/// Errors returned by CLI command handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliError {
+    UnknownCommand,
+    InvalidArguments,
+    MissingArguments,
+    HardwareError,
+    NotImplemented,
+}
+
+/// Execution context passed to CLI command handlers.
+pub struct CliContext<'a> {
+    pub gpio: &'a mut EarlGreyGpio,
+    pub sysmgr: &'a SysmgrClient<IpcHandle>,
+    pub straps: u32,
+}
+
+/// Trait implemented by CLI command hierarchy handlers.
+pub trait CommandHandler {
+    fn name(&self) -> &'static str;
+    fn description(&self) -> &'static str;
+    fn execute(
+        &mut self,
+        tokens: &mut TokenIter<'_>,
+        context: &mut CliContext<'_>,
+    ) -> Result<(), CliError>;
+}
+
+/// Root CLI dispatcher for the platform service.
+pub struct CliDispatcher;
+
+impl CliDispatcher {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn print_help(&self) {
+        util_zfmt::debug!("Platform CLI Commands:");
+        util_zfmt::debug!("  gpio  - GPIO pin configuration and control");
+        util_zfmt::debug!("  sys   - System information and reset control");
+        util_zfmt::debug!("  usb   - USB status and multiplexer control");
+        util_zfmt::debug!("  flash - Flash status and memory info");
+        util_zfmt::debug!("  help  - Display this help message");
+    }
+
+    pub fn dispatch(&mut self, line: &str, _context: &mut CliContext<'_>) {
+        let mut tokens = TokenIter::new(line);
+        let Some(cmd) = tokens.next_token() else {
+            return;
+        };
+
+        match cmd {
+            "help" => {
+                self.print_help();
+            }
+            "gpio" => {
+                util_zfmt::debug!("gpio: not implemented yet");
+            }
+            "sys" => {
+                util_zfmt::debug!("sys: not implemented yet");
+            }
+            "usb" => {
+                util_zfmt::debug!("usb: not implemented yet");
+            }
+            "flash" => {
+                util_zfmt::debug!("flash: not implemented yet");
+            }
+            _ => {
+                util_zfmt::debug!("Unknown command. Type 'help' for available commands.");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token_iter_empty() {
+        let mut iter = TokenIter::new("");
+        assert_eq!(iter.next_token(), None);
+
+        let mut iter2 = TokenIter::new("   ");
+        assert_eq!(iter2.next_token(), None);
+    }
+
+    #[test]
+    fn test_token_iter_single_token() {
+        let mut iter = TokenIter::new("help");
+        assert_eq!(iter.next_token(), Some("help"));
+        assert_eq!(iter.next_token(), None);
+
+        let mut iter2 = TokenIter::new("  help  ");
+        assert_eq!(iter2.next_token(), Some("help"));
+        assert_eq!(iter2.next_token(), None);
+    }
+
+    #[test]
+    fn test_token_iter_multiple_tokens() {
+        let mut iter = TokenIter::new("gpio   config  IOA2  in   none");
+        assert_eq!(iter.next_token(), Some("gpio"));
+        assert_eq!(iter.next_token(), Some("config"));
+        assert_eq!(iter.next_token(), Some("IOA2"));
+        assert_eq!(iter.next_token(), Some("in"));
+        assert_eq!(iter.next_token(), Some("none"));
+        assert_eq!(iter.next_token(), None);
+    }
+}

--- a/target/earlgrey/services/platform/cli/mod.rs
+++ b/target/earlgrey/services/platform/cli/mod.rs
@@ -1,13 +1,16 @@
 // Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod flash;
 pub mod gpio;
 pub mod sys;
 pub mod usb;
 
+use crate::spimux::SpiMuxHandler;
 use crate::usbmux::UsbMuxHandler;
 use earlgrey_gpio::EarlGreyGpio;
 use earlgrey_sysmgr_client::SysmgrClient;
+use flash::FlashCommandHandler;
 use gpio::GpioCommandHandler;
 use sys::SysCommandHandler;
 use usb::UsbCommandHandler;
@@ -64,6 +67,8 @@ pub struct CliContext<'a> {
     pub gpio: &'a mut EarlGreyGpio,
     pub sysmgr: &'a SysmgrClient<IpcHandle>,
     pub usb_mux: &'a mut UsbMuxHandler,
+    pub spi_mux: &'a mut SpiMuxHandler,
+    pub flash_ipc: IpcHandle,
     pub straps: u32,
 }
 
@@ -83,6 +88,7 @@ pub struct CliDispatcher {
     gpio_handler: GpioCommandHandler,
     sys_handler: SysCommandHandler,
     usb_handler: UsbCommandHandler,
+    flash_handler: FlashCommandHandler,
 }
 
 impl CliDispatcher {
@@ -91,6 +97,7 @@ impl CliDispatcher {
             gpio_handler: GpioCommandHandler::new(),
             sys_handler: SysCommandHandler::new(),
             usb_handler: UsbCommandHandler::new(),
+            flash_handler: FlashCommandHandler::new(),
         }
     }
 
@@ -123,7 +130,7 @@ impl CliDispatcher {
                 let _ = self.usb_handler.execute(&mut tokens, context);
             }
             "flash" => {
-                util_zfmt::debug!("flash: not implemented yet");
+                let _ = self.flash_handler.execute(&mut tokens, context);
             }
             _ => {
                 util_zfmt::debug!("Unknown command. Type 'help' for available commands.");

--- a/target/earlgrey/services/platform/cli/mod.rs
+++ b/target/earlgrey/services/platform/cli/mod.rs
@@ -3,11 +3,14 @@
 
 pub mod gpio;
 pub mod sys;
+pub mod usb;
 
+use crate::usbmux::UsbMuxHandler;
 use earlgrey_gpio::EarlGreyGpio;
 use earlgrey_sysmgr_client::SysmgrClient;
 use gpio::GpioCommandHandler;
 use sys::SysCommandHandler;
+use usb::UsbCommandHandler;
 use util_ipc::IpcHandle;
 
 /// Zero-allocation whitespace-separated token iterator for CLI parsing.
@@ -60,6 +63,7 @@ pub enum CliError {
 pub struct CliContext<'a> {
     pub gpio: &'a mut EarlGreyGpio,
     pub sysmgr: &'a SysmgrClient<IpcHandle>,
+    pub usb_mux: &'a mut UsbMuxHandler,
     pub straps: u32,
 }
 
@@ -78,6 +82,7 @@ pub trait CommandHandler {
 pub struct CliDispatcher {
     gpio_handler: GpioCommandHandler,
     sys_handler: SysCommandHandler,
+    usb_handler: UsbCommandHandler,
 }
 
 impl CliDispatcher {
@@ -85,6 +90,7 @@ impl CliDispatcher {
         Self {
             gpio_handler: GpioCommandHandler::new(),
             sys_handler: SysCommandHandler::new(),
+            usb_handler: UsbCommandHandler::new(),
         }
     }
 
@@ -114,7 +120,7 @@ impl CliDispatcher {
                 let _ = self.sys_handler.execute(&mut tokens, context);
             }
             "usb" => {
-                util_zfmt::debug!("usb: not implemented yet");
+                let _ = self.usb_handler.execute(&mut tokens, context);
             }
             "flash" => {
                 util_zfmt::debug!("flash: not implemented yet");

--- a/target/earlgrey/services/platform/cli/mod.rs
+++ b/target/earlgrey/services/platform/cli/mod.rs
@@ -1,8 +1,11 @@
 // Licensed under the Apache-2.0 license
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod gpio;
+
 use earlgrey_gpio::EarlGreyGpio;
 use earlgrey_sysmgr_client::SysmgrClient;
+use gpio::GpioCommandHandler;
 use util_ipc::IpcHandle;
 
 /// Zero-allocation whitespace-separated token iterator for CLI parsing.
@@ -70,11 +73,15 @@ pub trait CommandHandler {
 }
 
 /// Root CLI dispatcher for the platform service.
-pub struct CliDispatcher;
+pub struct CliDispatcher {
+    gpio_handler: GpioCommandHandler,
+}
 
 impl CliDispatcher {
     pub const fn new() -> Self {
-        Self
+        Self {
+            gpio_handler: GpioCommandHandler::new(),
+        }
     }
 
     pub fn print_help(&self) {
@@ -86,7 +93,7 @@ impl CliDispatcher {
         util_zfmt::debug!("  help  - Display this help message");
     }
 
-    pub fn dispatch(&mut self, line: &str, _context: &mut CliContext<'_>) {
+    pub fn dispatch(&mut self, line: &str, context: &mut CliContext<'_>) {
         let mut tokens = TokenIter::new(line);
         let Some(cmd) = tokens.next_token() else {
             return;
@@ -97,7 +104,7 @@ impl CliDispatcher {
                 self.print_help();
             }
             "gpio" => {
-                util_zfmt::debug!("gpio: not implemented yet");
+                let _ = self.gpio_handler.execute(&mut tokens, context);
             }
             "sys" => {
                 util_zfmt::debug!("sys: not implemented yet");

--- a/target/earlgrey/services/platform/cli/mod.rs
+++ b/target/earlgrey/services/platform/cli/mod.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod gpio;
+pub mod sys;
 
 use earlgrey_gpio::EarlGreyGpio;
 use earlgrey_sysmgr_client::SysmgrClient;
 use gpio::GpioCommandHandler;
+use sys::SysCommandHandler;
 use util_ipc::IpcHandle;
 
 /// Zero-allocation whitespace-separated token iterator for CLI parsing.
@@ -75,12 +77,14 @@ pub trait CommandHandler {
 /// Root CLI dispatcher for the platform service.
 pub struct CliDispatcher {
     gpio_handler: GpioCommandHandler,
+    sys_handler: SysCommandHandler,
 }
 
 impl CliDispatcher {
     pub const fn new() -> Self {
         Self {
             gpio_handler: GpioCommandHandler::new(),
+            sys_handler: SysCommandHandler::new(),
         }
     }
 
@@ -107,7 +111,7 @@ impl CliDispatcher {
                 let _ = self.gpio_handler.execute(&mut tokens, context);
             }
             "sys" => {
-                util_zfmt::debug!("sys: not implemented yet");
+                let _ = self.sys_handler.execute(&mut tokens, context);
             }
             "usb" => {
                 util_zfmt::debug!("usb: not implemented yet");

--- a/target/earlgrey/services/platform/cli/sys.rs
+++ b/target/earlgrey/services/platform/cli/sys.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::{CliContext, CliError, CommandHandler, TokenIter};
+
+pub struct SysCommandHandler;
+
+impl SysCommandHandler {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn print_help(&self) {
+        util_zfmt::debug!("System Commands:");
+        util_zfmt::debug!("  info  - Display system and chip boot information");
+        util_zfmt::debug!("  id    - Display OpenTitan 256-bit device ID");
+        util_zfmt::debug!("  reset - Trigger system software reboot");
+        util_zfmt::debug!("  help  - Display this help message");
+    }
+
+    fn handle_info(&self, ctx: &mut CliContext<'_>) -> Result<(), CliError> {
+        let boot_info = ctx
+            .sysmgr
+            .get_boot_info()
+            .map_err(|_| CliError::HardwareError)?;
+        util_zfmt::debug!("System Information:");
+        util_zfmt::debug!(
+            "  Chip: OpenTitan {creator:04x}-{product:04x}-{rev:02x}",
+            creator = boot_info.chip.creator_id,
+            product = boot_info.chip.product_id,
+            rev = boot_info.chip.revision
+        );
+        util_zfmt::debug!(
+            "  ROM_EXT: {major}.{minor} (slot={slot})",
+            major = boot_info.rom_ext.major,
+            minor = boot_info.rom_ext.minor,
+            slot = boot_info.rom_ext.boot_slot.as_str()
+        );
+        util_zfmt::debug!(
+            "  App: size={size} (slot={slot}/pref={pref})",
+            size = boot_info.app.size,
+            slot = boot_info.app.boot_slot.as_str(),
+            pref = boot_info.app.pref_slot.as_str()
+        );
+        util_zfmt::debug!(
+            "  Reset: reason=0x{reason:02x}, straps HW=0x{hw:02x}, SW=0x{sw:02x}",
+            reason = boot_info.reset.reason,
+            hw = boot_info.reset.hardware_straps,
+            sw = boot_info.reset.software_straps
+        );
+        Ok(())
+    }
+
+    fn handle_id(&self, ctx: &mut CliContext<'_>) -> Result<(), CliError> {
+        let boot_info = ctx
+            .sysmgr
+            .get_boot_info()
+            .map_err(|_| CliError::HardwareError)?;
+        let id = &boot_info.chip.device_id;
+        util_zfmt::debug!(
+            "Device ID: {d7:08x}{d6:08x}{d5:08x}{d4:08x}{d3:08x}{d2:08x}{d1:08x}{d0:08x}",
+            d7 = id[7],
+            d6 = id[6],
+            d5 = id[5],
+            d4 = id[4],
+            d3 = id[3],
+            d2 = id[2],
+            d1 = id[1],
+            d0 = id[0]
+        );
+        Ok(())
+    }
+
+    fn handle_reset(&self, ctx: &mut CliContext<'_>) -> Result<(), CliError> {
+        util_zfmt::debug!("Triggering system reset...");
+        ctx.sysmgr
+            .request_reboot()
+            .map_err(|_| CliError::HardwareError)?;
+        Ok(())
+    }
+}
+
+impl CommandHandler for SysCommandHandler {
+    fn name(&self) -> &'static str {
+        "sys"
+    }
+
+    fn description(&self) -> &'static str {
+        "System information and reset control"
+    }
+
+    fn execute(
+        &mut self,
+        tokens: &mut TokenIter<'_>,
+        context: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            None | Some("help") => {
+                self.print_help();
+                Ok(())
+            }
+            Some("info") => self.handle_info(context),
+            Some("id") => self.handle_id(context),
+            Some("reset") => self.handle_reset(context),
+            Some(_) => {
+                util_zfmt::debug!(
+                    "Unknown sys subcommand. Type 'sys help' for available commands."
+                );
+                Err(CliError::UnknownCommand)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sys_command_metadata() {
+        let handler = SysCommandHandler::new();
+        assert_eq!(handler.name(), "sys");
+        assert_eq!(
+            handler.description(),
+            "System information and reset control"
+        );
+    }
+}

--- a/target/earlgrey/services/platform/cli/usb.rs
+++ b/target/earlgrey/services/platform/cli/usb.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache-2.0 license
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::{CliContext, CliError, CommandHandler, TokenIter};
+
+pub struct UsbCommandHandler;
+
+impl UsbCommandHandler {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn print_help(&self) {
+        util_zfmt::debug!("USB Commands:");
+        util_zfmt::debug!("  info               - Display USB connection and multiplexer status");
+        util_zfmt::debug!("  mux <host|device>  - Manually configure USB multiplexer route");
+        util_zfmt::debug!("  help               - Display this help message");
+    }
+
+    fn handle_info(&self, ctx: &mut CliContext<'_>) -> Result<(), CliError> {
+        let present = ctx
+            .usb_mux
+            .is_present(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+        let host_routed = ctx
+            .usb_mux
+            .is_host_routed(ctx.gpio)
+            .map_err(|_| CliError::HardwareError)?;
+        util_zfmt::debug!("USB Status:");
+        util_zfmt::debug!(
+            "  Presence: {present}",
+            present = if present { "connected" } else { "disconnected" }
+        );
+        util_zfmt::debug!(
+            "  Route:    {route}",
+            route = if host_routed { "host" } else { "device" }
+        );
+        util_zfmt::debug!(
+            "  Pins:     presence=GPIO {pres}, mux_ctrl=GPIO {mux}",
+            pres = u32::from(ctx.usb_mux.usb_presence_n),
+            mux = u32::from(ctx.usb_mux.usb_mux_ctrl)
+        );
+        Ok(())
+    }
+
+    fn handle_mux(
+        &self,
+        tokens: &mut TokenIter<'_>,
+        ctx: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            Some("host") => {
+                ctx.usb_mux
+                    .set_host_route(ctx.gpio, true)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("USB multiplexer routed to host");
+                Ok(())
+            }
+            Some("device") => {
+                ctx.usb_mux
+                    .set_host_route(ctx.gpio, false)
+                    .map_err(|_| CliError::HardwareError)?;
+                util_zfmt::debug!("USB multiplexer routed to device");
+                Ok(())
+            }
+            _ => {
+                util_zfmt::debug!("Usage: usb mux <host|device>");
+                Err(CliError::InvalidArguments)
+            }
+        }
+    }
+}
+
+impl CommandHandler for UsbCommandHandler {
+    fn name(&self) -> &'static str {
+        "usb"
+    }
+
+    fn description(&self) -> &'static str {
+        "USB status and multiplexer control"
+    }
+
+    fn execute(
+        &mut self,
+        tokens: &mut TokenIter<'_>,
+        context: &mut CliContext<'_>,
+    ) -> Result<(), CliError> {
+        match tokens.next_token() {
+            None | Some("help") => {
+                self.print_help();
+                Ok(())
+            }
+            Some("info") => self.handle_info(context),
+            Some("mux") => self.handle_mux(tokens, context),
+            Some(_) => {
+                util_zfmt::debug!(
+                    "Unknown usb subcommand. Type 'usb help' for available commands."
+                );
+                Err(CliError::UnknownCommand)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_usb_command_metadata() {
+        let handler = UsbCommandHandler::new();
+        assert_eq!(handler.name(), "usb");
+        assert_eq!(handler.description(), "USB status and multiplexer control");
+    }
+}

--- a/target/earlgrey/services/platform/lib.rs
+++ b/target/earlgrey/services/platform/lib.rs
@@ -3,6 +3,7 @@
 
 #![no_std]
 
+pub mod cli;
 pub mod reset;
 pub mod server;
 pub mod spimux;

--- a/target/earlgrey/services/platform/server.rs
+++ b/target/earlgrey/services/platform/server.rs
@@ -38,6 +38,27 @@ impl PlatformServer {
         &mut self.gpio
     }
 
+    pub fn usb_mux(&self) -> &UsbMuxHandler {
+        &self.usb_mux
+    }
+
+    pub fn usb_mux_mut(&mut self) -> &mut UsbMuxHandler {
+        &mut self.usb_mux
+    }
+
+    pub fn cli_context<'a>(
+        &'a mut self,
+        sysmgr: &'a earlgrey_sysmgr_client::SysmgrClient<util_ipc::IpcHandle>,
+        straps: u32,
+    ) -> crate::cli::CliContext<'a> {
+        crate::cli::CliContext {
+            gpio: &mut self.gpio,
+            sysmgr,
+            usb_mux: &mut self.usb_mux,
+            straps,
+        }
+    }
+
     pub fn state(&self) -> TargetCpuState {
         self.reset_policy.state()
     }

--- a/target/earlgrey/services/platform/server.rs
+++ b/target/earlgrey/services/platform/server.rs
@@ -46,15 +46,26 @@ impl PlatformServer {
         &mut self.usb_mux
     }
 
+    pub fn spi_mux(&self) -> &SpiMuxHandler {
+        &self.spi_mux
+    }
+
+    pub fn spi_mux_mut(&mut self) -> &mut SpiMuxHandler {
+        &mut self.spi_mux
+    }
+
     pub fn cli_context<'a>(
         &'a mut self,
         sysmgr: &'a earlgrey_sysmgr_client::SysmgrClient<util_ipc::IpcHandle>,
+        flash_ipc: util_ipc::IpcHandle,
         straps: u32,
     ) -> crate::cli::CliContext<'a> {
         crate::cli::CliContext {
             gpio: &mut self.gpio,
             sysmgr,
             usb_mux: &mut self.usb_mux,
+            spi_mux: &mut self.spi_mux,
+            flash_ipc,
             straps,
         }
     }

--- a/target/earlgrey/services/platform/server.rs
+++ b/target/earlgrey/services/platform/server.rs
@@ -34,6 +34,10 @@ impl PlatformServer {
         }
     }
 
+    pub fn gpio_mut(&mut self) -> &mut EarlGreyGpio {
+        &mut self.gpio
+    }
+
     pub fn state(&self) -> TargetCpuState {
         self.reset_policy.state()
     }

--- a/target/earlgrey/services/platform/spimux.rs
+++ b/target/earlgrey/services/platform/spimux.rs
@@ -35,6 +35,48 @@ impl SpiMuxHandler {
         }
     }
 
+    pub fn is_mux_enabled(&self, gpio: &EarlGreyGpio) -> Result<bool, ErrorCode> {
+        let pin_mask = GpioMask::from(self.spi_mux_en_n);
+        let is_high = gpio
+            .read_output()
+            .map_err(ErrorCode::from)?
+            .contains(pin_mask);
+        Ok(!is_high)
+    }
+
+    pub fn is_route_host(&self, gpio: &EarlGreyGpio) -> Result<bool, ErrorCode> {
+        let pin_mask = GpioMask::from(self.spi_mux_ctrl);
+        let is_high = gpio
+            .read_output()
+            .map_err(ErrorCode::from)?
+            .contains(pin_mask);
+        Ok(is_high)
+    }
+
+    pub fn set_mux_enabled(&self, gpio: &mut EarlGreyGpio, enabled: bool) -> Result<(), ErrorCode> {
+        let pin_mask = GpioMask::from(self.spi_mux_en_n);
+        if enabled {
+            gpio.set_reset(GpioMask::empty(), pin_mask)
+                .map_err(ErrorCode::from)?;
+        } else {
+            gpio.set_reset(pin_mask, GpioMask::empty())
+                .map_err(ErrorCode::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn set_route_host(&self, gpio: &mut EarlGreyGpio, host: bool) -> Result<(), ErrorCode> {
+        let pin_mask = GpioMask::from(self.spi_mux_ctrl);
+        if host {
+            gpio.set_reset(pin_mask, GpioMask::empty())
+                .map_err(ErrorCode::from)?;
+        } else {
+            gpio.set_reset(GpioMask::empty(), pin_mask)
+                .map_err(ErrorCode::from)?;
+        }
+        Ok(())
+    }
+
     pub fn handle_event(
         &mut self,
         event: SpiMuxEvent,

--- a/target/earlgrey/services/platform/usbmux.rs
+++ b/target/earlgrey/services/platform/usbmux.rs
@@ -41,6 +41,36 @@ impl UsbMuxHandler {
         Ok(())
     }
 
+    pub fn is_present(&self, gpio: &EarlGreyGpio) -> Result<bool, ErrorCode> {
+        let pin_mask = GpioMask::from(self.usb_presence_n);
+        let is_high = gpio
+            .read_input()
+            .map_err(ErrorCode::from)?
+            .contains(pin_mask);
+        Ok(!is_high)
+    }
+
+    pub fn is_host_routed(&self, gpio: &EarlGreyGpio) -> Result<bool, ErrorCode> {
+        let pin_mask = GpioMask::from(self.usb_mux_ctrl);
+        let is_high = gpio
+            .read_output()
+            .map_err(ErrorCode::from)?
+            .contains(pin_mask);
+        Ok(is_high)
+    }
+
+    pub fn set_host_route(&self, gpio: &mut EarlGreyGpio, host: bool) -> Result<(), ErrorCode> {
+        let usb_mux = GpioMask::from(self.usb_mux_ctrl);
+        if host {
+            gpio.set_reset(usb_mux, GpioMask::empty())
+                .map_err(ErrorCode::from)?;
+        } else {
+            gpio.set_reset(GpioMask::empty(), usb_mux)
+                .map_err(ErrorCode::from)?;
+        }
+        Ok(())
+    }
+
     pub fn handle_event(
         &mut self,
         event: UsbMuxEvent,

--- a/util/zfmt/lib.rs
+++ b/util/zfmt/lib.rs
@@ -31,7 +31,7 @@ pub mod server;
 
 pub use buffer::LogBuffer;
 pub use server::LogServer;
-pub use zfmt::events::StreamStart;
+pub use zfmt::events::{DebugMessage, StreamStart};
 pub use zfmt::FixedBuf;
 pub use zfmt::Write;
 pub use zfmt::ZfmtU64;
@@ -170,4 +170,22 @@ macro_rules! error {
     ($event:expr) => {
         zfmt::log_error!(*$crate::logger(), $event);
     };
+}
+
+/// Log a bare unstructured text event without EventHeader (no timestamp or log level).
+#[cfg(not(test))]
+#[macro_export]
+macro_rules! raw {
+    ($msg:expr) => {{
+        let _msg = $crate::DebugMessage { message: $msg };
+        ::zfmt::output::send_bare_event($crate::logger(), &_msg);
+    }};
+}
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! raw {
+    ($msg:expr) => {{
+        let _ = &$msg;
+    }};
 }

--- a/util/zfmt/render.rs
+++ b/util/zfmt/render.rs
@@ -14,6 +14,7 @@ use zfmt::Write;
 pub fn render_event<const N: usize>(event: &[u8], buf: &mut FixedBuf<N>) -> Option<usize> {
     let mut i = 0usize;
     let mut rest = event;
+    let mut has_header = false;
     loop {
         let (tag, mut next) = u32::read_from_prefix(rest).ok()?;
         i += 4;
@@ -24,13 +25,14 @@ pub fn render_event<const N: usize>(event: &[u8], buf: &mut FixedBuf<N>) -> Opti
         i += len;
         match tag {
             StreamStart::ZFMT_TAG => {
-                let _ = buf.write_str("[StreamStart Event]");
+                let _ = buf.write_str("[StreamStart Event]\r\n");
                 return Some(i);
             }
             EventHeader::ZFMT_TAG => {
                 let eh = EventHeader::from_bytes(next.get(..len)?)?;
                 let _ = eh.format_into(buf);
                 let _ = buf.write_char(' ');
+                has_header = true;
             }
             DebugMessage::ZFMT_TAG => {
                 let (msg_len, n) = leb128::decode(next)?;
@@ -43,6 +45,9 @@ pub fn render_event<const N: usize>(event: &[u8], buf: &mut FixedBuf<N>) -> Opti
                     core::str::from_utf8_unchecked(msg_bytes)
                 };
                 let _ = buf.write_str(msg);
+                if has_header {
+                    let _ = buf.write_str("\r\n");
+                }
                 return Some(i);
             }
             _ => {
@@ -51,5 +56,60 @@ pub fn render_event<const N: usize>(event: &[u8], buf: &mut FixedBuf<N>) -> Opti
             }
         }
         rest = next.get(len..)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_bare_debug_message() {
+        let msg = DebugMessage { message: "hwe> " };
+        let mut frame = [0u8; 64];
+        let mut n = 0;
+        frame[n..n + 4].copy_from_slice(&msg.zfmt_tag().to_le_bytes());
+        n += 4;
+        let payload_size = msg.payload_size();
+        n += leb128::encode(payload_size as u32, &mut frame[n..]);
+        msg.serialize_into(&mut frame[n..]);
+        n += payload_size;
+
+        let mut buf = FixedBuf::<64>::new();
+        let consumed = render_event(&frame[..n], &mut buf);
+        assert_eq!(consumed, Some(n));
+        assert_eq!(buf.as_str(), "hwe> ");
+    }
+
+    #[test]
+    fn test_render_header_debug_message() {
+        let hdr = EventHeader::new(
+            zfmt::ZfmtU64::from_u64(100),
+            zfmt::events::Severity::Debug,
+            1,
+        );
+        let msg = DebugMessage {
+            message: "test log",
+        };
+        let mut frame = [0u8; 128];
+        let mut n = 0;
+        frame[n..n + 4].copy_from_slice(&hdr.zfmt_tag().to_le_bytes());
+        n += 4;
+        let hdr_size = hdr.payload_size();
+        n += leb128::encode(hdr_size as u32, &mut frame[n..]);
+        hdr.serialize_into(&mut frame[n..]);
+        n += hdr_size;
+
+        frame[n..n + 4].copy_from_slice(&msg.zfmt_tag().to_le_bytes());
+        n += 4;
+        let msg_size = msg.payload_size();
+        n += leb128::encode(msg_size as u32, &mut frame[n..]);
+        msg.serialize_into(&mut frame[n..]);
+        n += msg_size;
+
+        let mut buf = FixedBuf::<128>::new();
+        let consumed = render_event(&frame[..n], &mut buf);
+        assert_eq!(consumed, Some(n));
+        assert_eq!(buf.as_str(), "100 DEBUG test log\r\n");
     }
 }


### PR DESCRIPTION
This PR introduces an interactive command-line interface (CLI) to the OpenPRoT Earl Grey HWE firmware. The CLI is exposed simultaneously over physical UART0 and USB CDC-ACM virtual serial transports, allowing developers and automated test harnesses to inspect and manipulate chip state, GPIO pads, USB routing, and SPI flash memory.

### Command Hierarchies

1. **Root Dispatcher & Help (`help`)**
   - Hierarchical subcommand routing with command suggestions and formatted help listings.
   - Unadorned prompt (`hwe> `) preserved across transports.

2. **System Hierarchy (`sys`)**
   - `sys help`: Displays available system subcommands.
   - `sys info`: Queries `sysmgr` for chip version, active ROM_EXT/app slots, and reset reasons.
   - `sys id`: Retrieves and prints the 256-bit OpenTitan device ID formatted in hex.
   - `sys reset`: Requests a software reboot via `sysmgr` IPC.

3. **GPIO Hierarchy (`gpio`)**
   - `gpio list`: Enumerates all configured GPIO pins with active direction, pad name, and pin states.
   - `gpio read <pin>`: Reads digital input, output, and OE states.
   - `gpio write <pin> <0|1>`: Drives output level with immediate hardware readback confirmation.
   - `gpio config <pin> <in|out|inout> [none|pullup|pulldown]`: Configures pin direction and internal pull resistors.
   - `gpio attr <pin> <od|pp>`: Configures pad open-drain vs. push-pull drive mode.
   - Supports numeric pin indices (e.g. `0`..`31`), schematic signal names (e.g. `RST_CTRL0_N`, `EXT_DEBUG_N`), and package pad names (e.g. `IOA0`, `IOC6`).

4. **USB Hierarchy (`usb`)**
   - `usb help`: Displays available USB subcommands.
   - `usb info`: Reports VBUS cable presence state, active multiplexer route, and pin mapping.
   - `usb mux <host|device>`: Configures the physical USB multiplexer selection line (`USB_MUX_CTRL`).

5. **SPI Flash Hierarchy (`flash`)**
   - `flash help`: Displays available SPI flash subcommands.
   - `flash info`: Inspects SPI multiplexer status, active route (`target` vs `host`), pin assignments, and WP lines.
   - `flash mux <en|dis>`: Controls the external SPI flash multiplexer enable line (`SPI_MUX_EN_N`).
   - `flash route <target|host>`: Sets SPI routing between the DUT and upstream programmer (`SPI_MUX_CTRL`).
   - `flash read-id [0|1]`: Executes JEDEC Read ID (0x9F) via `flash_server` over SPI host, decoding manufacturer, device model, and density with upstream collision protection.